### PR TITLE
Enable TypeScript's strict mode

### DIFF
--- a/packages/authenticator-core/src/authenticatedFetch/dPoP/DPoPAuthenticatedFetcher.ts
+++ b/packages/authenticator-core/src/authenticatedFetch/dPoP/DPoPAuthenticatedFetcher.ts
@@ -36,13 +36,17 @@ export default class DPoPAuthenticatedFetcher implements IAuthenticatedFetcher {
     }
     const dPoPRequestCredentials: IDPoPRequestCredentials =
       requestCredentials as IDPoPRequestCredentials
-    // TODO: this should clone requestInit before addint the authorization header
+    const requestInitiWithDefaults = {
+      headers: {},
+      method: 'GET',
+      ...requestInit
+    }
     return this.fetcher.fetch(url, {
       ...requestInit,
       headers: {
-        ...requestInit.headers,
+        ...requestInitiWithDefaults.headers,
         authorization: `DPOP ${dPoPRequestCredentials.authToken}`,
-        dpop: await this.dPoPHeaderCreator.createHeaderToken(url, requestInit.method || 'GET')
+        dpop: await this.dPoPHeaderCreator.createHeaderToken(url, requestInitiWithDefaults.method)
       }
     })
   }

--- a/packages/authenticator-core/src/authenticator/IStorage.ts
+++ b/packages/authenticator-core/src/authenticator/IStorage.ts
@@ -2,7 +2,7 @@
  * Interface that various platforms should implement for their own storage implementation
  */
 export default interface IStorage {
-  get: (key: string) => Promise<string>
+  get: (key: string) => Promise<string | undefined>
   set: (key: string, value: string) => Promise<void>
   delete: (key: string) => Promise<void>
 }

--- a/packages/authenticator-core/src/login/ILoginOptions.ts
+++ b/packages/authenticator-core/src/login/ILoginOptions.ts
@@ -4,6 +4,6 @@
 import URL from 'url-parse'
 
 export default interface ILoginOptions {
-  oidcIssuer?: URL
+  oidcIssuer: URL
   webId?: URL
 }

--- a/packages/authenticator-core/src/login/oidc/OIDCLoginHandler.ts
+++ b/packages/authenticator-core/src/login/oidc/OIDCLoginHandler.ts
@@ -34,7 +34,7 @@ export default class OIDCLoginHandler implements ILoginHandler {
 
   async handle (options: ILoginOptions): Promise<void> {
     // Check to ensure the login options are correct
-    const optionsError: Error = this.checkOptions(options)
+    const optionsError: Error | null = this.checkOptions(options)
     if (optionsError) {
       throw optionsError
     }

--- a/packages/authenticator-core/src/util/StorageRetriever.ts
+++ b/packages/authenticator-core/src/util/StorageRetriever.ts
@@ -17,7 +17,7 @@ export interface IStorageRetriever {
     key: string,
     schema?: Object,
     postProcess?: (retrievedObject: Object) => Object
-  ): Promise<Object>
+  ): Promise<Object | null>
 }
 
 @injectable()
@@ -32,7 +32,7 @@ export default class StorageRetriever implements IStorageRetriever {
     postProcess?: (retrievedObject: Object) => Object
   ): Promise<Object | null> {
     // Check if key is stored locally
-    const locallyStored: string | null =
+    const locallyStored: string | undefined =
       await this.storage.get(key)
 
     // If it is stored locally, check the validity of the value

--- a/packages/authenticator-core/src/util/dpop/DPoPHeaderCreator.ts
+++ b/packages/authenticator-core/src/util/dpop/DPoPHeaderCreator.ts
@@ -33,6 +33,11 @@ export default class DPoPHeaderCreator implements IDPoPHeaderCreator {
   ): Promise<string> {
     // TODO: update for multiple signing abilities
     const clientKey = await this.dPoPClientKeyManager.getClientKey()
+
+    if (clientKey === null) {
+      throw new Error('Could not obtain the key to sign the token with.')
+    }
+
     return this.joseUtility.signJWT(
       {
         htu: audience.toString(),

--- a/packages/authenticator-test-server/src/test-server.ts
+++ b/packages/authenticator-test-server/src/test-server.ts
@@ -46,7 +46,9 @@ app.get('/jwks', (req, res) => {
 })
 
 app.get('/authorize', (req, res) => {
-  req.session.authData = req.query
+  if (req.session) {
+    req.session.authData = req.query
+  }
 
   res.redirect(`${ISSUER}/login`)
 })
@@ -60,10 +62,10 @@ app.get('/login', (req, res) => {
 })
 
 app.post('/login', (req, res) => {
-  const user: IUser = USERS.find((user) => {
+  const user: IUser | undefined = USERS.find((user) => {
     return user.username === req.body.username && user.password === req.body.password
   })
-  if (user) {
+  if (user && req.session) {
     const dpopToken = JWT.decode(req.session.authData.dpop, {
       complete: true
     })

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "module": "commonjs",
+    "strict": true,
     "declaration": true,
     "noImplicitAny": true,
     "removeComments": true,


### PR DESCRIPTION
@jaxoncreed Was there a reason TypeScript's strict mode was off? This PR enables it, which required fairly modest changes that all look like they're for the better?

The most significant change is that `DPoPHeaderCreator` now throws an error when the key manager was unable to obtain a key to sign the JWT with, but I suppose that's what we'd want?