### PR TITLE
Select the fetcher based on the environment only once

### DIFF
--- a/src/util/Fetcher.ts
+++ b/src/util/Fetcher.ts
@@ -30,11 +30,18 @@ export interface IFetcher {
 }
 
 export default class Fetcher implements IFetcher {
+  private fetcher: typeof _fetch;
+
+  constructor() {
+    if (typeof window !== "undefined" && typeof window.fetch === "function") {
+      this.fetcher = window.fetch;
+    } else {
+      this.fetcher = _fetch;
+    }
+  }
+
   async fetch(url: RequestInfo | URL, init?: RequestInit): Promise<Response> {
     const fetchUrl = url instanceof URL ? url.toString() : url;
-    if (typeof window !== "undefined" && typeof window.fetch !== "undefined") {
-      return window.fetch(fetchUrl, init);
-    }
-    return _fetch(fetchUrl, init);
+    return this.fetcher(fetchUrl, init);
   }
 }


### PR DESCRIPTION
The appropriate fetch method is selected when constructing the Fetcher object, instead of running the check at each query.

- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
