### PR TITLE
Detect the token type from the OIDC issuer

### DIFF
--- a/__tests__/login/oidc/oidcHandlers/LegacyImplicitFlowOIDCHandler.spec.ts
+++ b/__tests__/login/oidc/oidcHandlers/LegacyImplicitFlowOIDCHandler.spec.ts
@@ -105,27 +105,23 @@ describe("LegacyImplicitFlowOidcHandler", () => {
         dpop: false
       };
       await legacyImplicitFlowOidcHandler.handle(oidcOptions);
-      expect(defaultMocks.storageUtility.setForUser).toHaveBeenCalledWith(
+      expect(defaultMocks.storageUtility.setForUser.mock.calls[1]).toEqual([
         "mySession",
         {
-          isLoggedIn: "false",
-          sessionId: "mySession",
           dpopToken: "false"
         },
-        { secure: true }
-      );
+        { secure: false }
+      ]);
 
       oidcOptions["dpop"] = true;
       await legacyImplicitFlowOidcHandler.handle(oidcOptions);
-      expect(defaultMocks.storageUtility.setForUser).toHaveBeenCalledWith(
+      expect(defaultMocks.storageUtility.setForUser.mock.calls[3]).toEqual([
         "mySession",
         {
-          isLoggedIn: "false",
-          sessionId: "mySession",
           dpopToken: "true"
         },
-        { secure: true }
-      );
+        { secure: false }
+      ]);
     });
   });
 });

--- a/__tests__/login/oidc/oidcHandlers/LegacyImplicitFlowOIDCHandler.spec.ts
+++ b/__tests__/login/oidc/oidcHandlers/LegacyImplicitFlowOIDCHandler.spec.ts
@@ -97,5 +97,35 @@ describe("LegacyImplicitFlowOidcHandler", () => {
         { handleRedirect: standardOidcOptions.handleRedirect }
       );
     });
+
+    it("stores the token type", async () => {
+      const legacyImplicitFlowOidcHandler = getLegacyImplicitFlowOidcHandler();
+      const oidcOptions: IOidcOptions = {
+        ...standardOidcOptions,
+        dpop: false
+      };
+      await legacyImplicitFlowOidcHandler.handle(oidcOptions);
+      expect(defaultMocks.storageUtility.setForUser).toHaveBeenCalledWith(
+        "mySession",
+        {
+          isLoggedIn: "false",
+          sessionId: "mySession",
+          dpopToken: "false"
+        },
+        { secure: true }
+      );
+
+      oidcOptions["dpop"] = true;
+      await legacyImplicitFlowOidcHandler.handle(oidcOptions);
+      expect(defaultMocks.storageUtility.setForUser).toHaveBeenCalledWith(
+        "mySession",
+        {
+          isLoggedIn: "false",
+          sessionId: "mySession",
+          dpopToken: "true"
+        },
+        { secure: true }
+      );
+    });
   });
 });

--- a/__tests__/sessionInfo/SessionInfoManager.spec.ts
+++ b/__tests__/sessionInfo/SessionInfoManager.spec.ts
@@ -23,7 +23,10 @@ import "reflect-metadata";
 import { UuidGeneratorMock } from "../../src/util/__mocks__/UuidGenerator";
 import { AuthenticatedFetcherMock } from "../../src/authenticatedFetch/__mocks__/AuthenticatedFetcher";
 import { LogoutHandlerMock } from "../../src/logout/__mocks__/LogoutHandler";
-import { EmptyStorageUtilityMock } from "../../src/storage/__mocks__/StorageUtility";
+import {
+  EmptyStorageUtilityMock,
+  mockStorageUtility
+} from "../../src/storage/__mocks__/StorageUtility";
 import SessionInfoManager from "../../src/sessionInfo/SessionInfoManager";
 
 describe("SessionInfoManager", () => {
@@ -60,7 +63,7 @@ describe("SessionInfoManager", () => {
         .mockReturnValueOnce(
           Promise.resolve("https://zoomies.com/commanderCool#me")
         )
-        .mockReturnValueOnce(Promise.resolve("true"));
+        .mockReturnValue(Promise.resolve("true"));
       const sessionManager = getSessionInfoManager({ storageUtility });
       const session = await sessionManager.get("commanderCool");
       expect(session).toMatchObject({
@@ -70,11 +73,26 @@ describe("SessionInfoManager", () => {
     });
 
     it("returns undefined if the specified storage does not contain the user", async () => {
+      const storageUtility = mockStorageUtility({});
       const sessionManager = getSessionInfoManager({
-        storageUtility: EmptyStorageUtilityMock
+        storageUtility: storageUtility
       });
       const session = await sessionManager.get("commanderCool");
       expect(session).toBeUndefined();
+    });
+
+    it("retrieves the session token type from specified storage", async () => {
+      const storageUtility = mockStorageUtility({
+        commanderCool: {
+          dpopToken: "false",
+          webId: "https://zoomies.com/commanderCool#me",
+          sessionId: "commanderCool",
+          isLoggedIn: "false"
+        }
+      });
+      const sessionManager = getSessionInfoManager({ storageUtility });
+      const session = await sessionManager.get("commanderCool");
+      expect(session?.dpopToken).toBe(false);
     });
   });
 });

--- a/src/ClientAuthentication.ts
+++ b/src/ClientAuthentication.ts
@@ -82,14 +82,17 @@ export default class ClientAuthentication {
     let tokenType: string;
     if (!sessionInfo || sessionInfo.dpopToken === undefined) {
       // By default, use a dpop token
+      console.log("No token type found in storage");
       tokenType = "dpop";
     } else {
+      console.log(`Token type in storage is dpop: ${sessionInfo.dpopToken}`);
       tokenType = sessionInfo.dpopToken ? "dpop" : "bearer";
     }
     const credentials: IRequestCredentials = {
       localUserId: sessionId,
       type: tokenType
     };
+    console.log(`Issuing a request with ${credentials.type} token`);
     return this.authenticatedFetcher.handle(credentials, url, init);
   };
 

--- a/src/ClientAuthentication.ts
+++ b/src/ClientAuthentication.ts
@@ -78,10 +78,17 @@ export default class ClientAuthentication {
     url: RequestInfo,
     init?: RequestInit
   ): Promise<Response> => {
+    const sessionInfo = await this.getSessionInfo(sessionId);
+    let tokenType: string;
+    if (!sessionInfo || sessionInfo.dpopToken === undefined) {
+      // By default, use a dpop token
+      tokenType = "dpop";
+    } else {
+      tokenType = sessionInfo.dpopToken ? "dpop" : "bearer";
+    }
     const credentials: IRequestCredentials = {
       localUserId: sessionId,
-      // TODO: This should not be hard-coded
-      type: "dpop"
+      type: tokenType
     };
     return this.authenticatedFetcher.handle(credentials, url, init);
   };

--- a/src/authenticatedFetch/bearer/BearerAuthenticatedFetcher.ts
+++ b/src/authenticatedFetch/bearer/BearerAuthenticatedFetcher.ts
@@ -34,7 +34,6 @@ export default class BearerAuthenticatedFetcher
   implements IAuthenticatedFetcher {
   constructor(
     @inject("fetcher") private fetcher: IFetcher,
-    @inject("urlRepresentationConverter")
     @inject("storageUtility")
     private storageUtility: IStorageUtility
   ) {}

--- a/src/login/oidc/IIssuerConfig.ts
+++ b/src/login/oidc/IIssuerConfig.ts
@@ -48,6 +48,7 @@ export default interface IIssuerConfig {
   requestObjectEncryptionEncValuesSupported?: string[];
   tokenEndpointAuthMethodsSupported?: string[];
   tokenEndpointAuthSigningAlgValuesSupported?: string[];
+  tokenTypesSupported?: string[];
   displayValuesSupported?: string[];
   claimTypesSupported?: string[];
   claimsSupported: string[];

--- a/src/login/oidc/IssuerConfigFetcher.ts
+++ b/src/login/oidc/IssuerConfigFetcher.ts
@@ -106,6 +106,9 @@ const issuerConfigKeyMap: Record<
   token_endpoint_auth_signing_alg_values_supported: {
     toKey: "tokenEndpointAuthSigningAlgValuesSupported"
   },
+  token_types_supported: {
+    toKey: "tokenTypesSupported"
+  },
   display_values_supported: { toKey: "displayValuesSupported" },
   claim_types_supported: { toKey: "claimTypesSupported" },
   claims_supported: { toKey: "claimsSupported" },

--- a/src/login/oidc/OidcLoginHandler.ts
+++ b/src/login/oidc/OidcLoginHandler.ts
@@ -73,8 +73,10 @@ export default class OidcLoginHandler implements ILoginHandler {
     // Construct OIDC Options
     const OidcOptions: IOidcOptions = {
       issuer: options.oidcIssuer as URL,
-      // TODO: differentiate if DPoP should be true
-      dpop: true,
+      // FIXME: The logic of the test should be reversed, and test for the presence
+      // of "dpop" in the supportd token types, but a suspected bug on NSS requires
+      // that we look for the legacy bearer token instead.
+      dpop: !issuerConfig.tokenTypesSupported?.includes("legacyPop") ?? true,
       redirectUrl: options.redirectUrl as URL,
       issuerConfiguration: issuerConfig,
       client: await this.clientRegistrar.getClient(

--- a/src/login/oidc/TokenRequester.ts
+++ b/src/login/oidc/TokenRequester.ts
@@ -135,6 +135,9 @@ export default class TokenRequester {
     if (!decoded || !decoded.sub) {
       throw new Error("The idp returned a bad token without a sub.");
     }
+    console.log(
+      `Received the following access token: ${JSON.stringify(decoded)}`
+    );
 
     await this.storageUtility.setForUser(
       sessionId,

--- a/src/login/oidc/__mocks__/IssuerConfigFetcher.ts
+++ b/src/login/oidc/__mocks__/IssuerConfigFetcher.ts
@@ -39,3 +39,12 @@ export const IssuerConfigFetcherMock: jest.Mocked<IIssuerConfigFetcher> = {
     Promise.resolve(IssuerConfigFetcherFetchConfigResponse)
   )
 };
+
+export const mockIssuerConfigFetcher = (
+  config: IIssuerConfig
+): jest.Mocked<IIssuerConfigFetcher> => {
+  return {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    fetchConfig: jest.fn((_issuer: URL) => Promise.resolve(config))
+  };
+};

--- a/src/login/oidc/oidcHandlers/AuthorizationCodeWithPkceOidcHandler.ts
+++ b/src/login/oidc/oidcHandlers/AuthorizationCodeWithPkceOidcHandler.ts
@@ -70,6 +70,9 @@ export default class AuthorizationCodeWithPkceOidcHandler
     };
     /* eslint-enable @typescript-eslint/camelcase */
     requestUrl.set("query", query);
+    console.log(
+      `Storing code verifier ${codeVerifier} for session ${oidcLoginOptions.sessionId}`
+    );
     // TODO: This is inefficent, there should be a bulk
     await this.storageUtility.setForUser(oidcLoginOptions.sessionId, {
       codeVerifier,

--- a/src/login/oidc/oidcHandlers/LegacyImplicitFlowOidcHandler.ts
+++ b/src/login/oidc/oidcHandlers/LegacyImplicitFlowOidcHandler.ts
@@ -85,7 +85,8 @@ export default class LegacyImplicitFlowOidcHandler implements IOidcHandler {
         oidcLoginOptions.sessionId,
         {
           isLoggedIn: "false",
-          sessionId: oidcLoginOptions.sessionId
+          sessionId: oidcLoginOptions.sessionId,
+          dpopToken: `${oidcLoginOptions.dpop}`
         },
         { secure: true }
       )

--- a/src/login/oidc/oidcHandlers/LegacyImplicitFlowOidcHandler.ts
+++ b/src/login/oidc/oidcHandlers/LegacyImplicitFlowOidcHandler.ts
@@ -78,26 +78,35 @@ export default class LegacyImplicitFlowOidcHandler implements IOidcHandler {
       scope: "openid webid offline_access",
       state: oidcLoginOptions.sessionId
     };
-
+    console.log(`Storing token type is dpop ${oidcLoginOptions.dpop}`);
     await Promise.all([
       this.dpopClientKeyManager.generateClientKeyIfNotAlready(),
       this.storageUtility.setForUser(
         oidcLoginOptions.sessionId,
         {
           isLoggedIn: "false",
-          sessionId: oidcLoginOptions.sessionId,
-          dpopToken: `${oidcLoginOptions.dpop}`
+          sessionId: oidcLoginOptions.sessionId
         },
         { secure: true }
+      ),
+      this.storageUtility.setForUser(
+        oidcLoginOptions.sessionId,
+        {
+          dpopToken: `${oidcLoginOptions.dpop}`
+        },
+        { secure: false }
       )
     ]);
     /* eslint-enable @typescript-eslint/camelcase */
     // TODO: There is currently no secure storage of the DPoP key
     if (oidcLoginOptions.dpop) {
+      console.log("Requesting a DPoP token");
       query.dpop = await this.dpopHeaderCreator.createHeaderToken(
         oidcLoginOptions.issuer,
         "GET"
       );
+    } else {
+      console.log("Requesting a bearer token");
     }
     requestUrl.set("query", query);
     const sessionInfo = await this.sessionInfoManager.get(

--- a/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
+++ b/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
@@ -53,6 +53,7 @@ export default class AuthCodeRedirectHandler implements IRedirectHandler {
     const url = new URL(redirectUrl, true);
     const sessionId = url.query.state as string;
     const [codeVerifier, redirectUri] = await Promise.all([
+      // FIXME cleanup the await in the promise.all
       (await this.storageUtility.getForUser(sessionId, "codeVerifier", {
         errorIfNull: true
       })) as string,

--- a/src/sessionInfo/ISessionInfo.ts
+++ b/src/sessionInfo/ISessionInfo.ts
@@ -26,4 +26,6 @@ export default interface ISessionInfo {
   isLoggedIn: boolean;
   webId?: string;
   sessionId: string;
+  // Indicates of the session is associated to a DPoP or a Bearer token
+  dpopToken?: boolean;
 }

--- a/src/sessionInfo/SessionInfoManager.ts
+++ b/src/sessionInfo/SessionInfoManager.ts
@@ -86,12 +86,13 @@ export default class SessionInfoManager implements ISessionInfoManager {
         secure: true
       }),
       this.storageUtility.getForUser(sessionId, "dpopToken", {
-        secure: true
+        secure: false
       }),
       await this.storageUtility.getForUser(sessionId, "isLoggedIn", {
         secure: true
       })
     ]);
+    console.log(`dpop token is ${dpopToken}`);
     if (isLoggedIn !== undefined) {
       return {
         sessionId,

--- a/src/sessionInfo/SessionInfoManager.ts
+++ b/src/sessionInfo/SessionInfoManager.ts
@@ -81,21 +81,23 @@ export default class SessionInfoManager implements ISessionInfoManager {
   }
 
   async get(sessionId: string): Promise<ISessionInfo | undefined> {
-    const webId = await this.storageUtility.getForUser(sessionId, "webId", {
-      secure: true
-    });
-    const isLoggedIn = await this.storageUtility.getForUser(
-      sessionId,
-      "isLoggedIn",
-      {
+    const [webId, dpopToken, isLoggedIn] = await Promise.all([
+      this.storageUtility.getForUser(sessionId, "webId", {
         secure: true
-      }
-    );
+      }),
+      this.storageUtility.getForUser(sessionId, "dpopToken", {
+        secure: true
+      }),
+      await this.storageUtility.getForUser(sessionId, "isLoggedIn", {
+        secure: true
+      })
+    ]);
     if (isLoggedIn !== undefined) {
       return {
         sessionId,
         webId: webId,
-        isLoggedIn: isLoggedIn === "true"
+        isLoggedIn: isLoggedIn === "true",
+        dpopToken: dpopToken === undefined || dpopToken === "true"
       };
     }
     return undefined;

--- a/src/sessionInfo/__mocks__/SessionInfoManager.ts
+++ b/src/sessionInfo/__mocks__/SessionInfoManager.ts
@@ -43,3 +43,17 @@ export const SessionInfoManagerMock: jest.Mocked<ISessionInfoManager> = {
   ),
   getAll: jest.fn(async () => Promise.resolve([SessionCreatorCreateResponse]))
 };
+
+export const mockSessionManager = (
+  info: ISessionInfo
+): jest.Mocked<ISessionInfoManager> => {
+  return {
+    update: jest.fn(
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function
+      async (sessionId: string, options: ISessionInfoManagerOptions) => {}
+    ),
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    get: jest.fn(async (sessionId: string) => Promise.resolve(info)),
+    getAll: jest.fn(async () => Promise.resolve([info]))
+  };
+};

--- a/src/storage/__mocks__/StorageUtility.ts
+++ b/src/storage/__mocks__/StorageUtility.ts
@@ -116,3 +116,52 @@ export const EmptyStorageUtilityMock: jest.Mocked<IStorageUtility> = {
   )
   /* eslint-enable @typescript-eslint/no-unused-vars */
 };
+
+export const mockStorageUtility = (
+  store: Record<string, Record<string, string>>
+): jest.Mocked<IStorageUtility> => {
+  return {
+    /* eslint-disable @typescript-eslint/no-unused-vars */
+    get: jest.fn(
+      async (key: string, options: { errorIfNull?: boolean }) => undefined
+    ),
+    set: jest.fn(async (key: string, value: string) => {
+      /* do nothing */
+    }),
+    delete: jest.fn(async (key: string) => {
+      /* do nothing */
+    }),
+    getForUser: jest.fn(
+      async (userId: string, key: string, options: { errorIfNull?: true }) =>
+        store[userId] ? store[userId][key] : undefined
+    ),
+    setForUser: jest.fn(
+      async (
+        userId: string,
+        values: Record<string, string>,
+        options?: { secure?: boolean }
+      ) => {
+        store[userId] = values;
+      }
+    ),
+    deleteForUser: jest.fn(async (userId: string, key: string) => {
+      /* do nothing */
+    }),
+    deleteAllUserData: jest.fn(async (userId: string) => {
+      /* do nothing */
+    }),
+    safeGet: jest.fn(
+      async (
+        key: string,
+        options?: Partial<{
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          schema?: Record<string, any>;
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          postProcess?: (retrievedObject: any) => any;
+          userId?: string;
+        }>
+      ) => undefined
+    )
+    /* eslint-enable @typescript-eslint/no-unused-vars */
+  };
+};


### PR DESCRIPTION
Depending on the OIDC issuer config, this detects the token type, and adapts the behaviour of the OIDC handler and of subsequent fetches.

Combined to #255, this should add support for a complete bearer token interaction.

# Checklist

- [X] All acceptance criteria are met.
- [X] Relevant documentation, if any, has been written/updated.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
