### PR TITLE
Redirect user to IdP logout page

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -6,6 +6,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### New features
 
+- Perform a [spec-compliant](https://openid.net/specs/openid-connect-rpinitiated-1_0.html#RPLogout) log out from the identity provider.
+
 ## [0.1.0] - 2020-08-10
 
 ### New features

--- a/__tests__/ClientAuthn.spec.ts
+++ b/__tests__/ClientAuthn.spec.ts
@@ -21,10 +21,7 @@
 
 // Required by TSyringe:
 import "reflect-metadata";
-import {
-  LoginHandlerMock,
-  LoginHandlerResponse
-} from "../src/login/__mocks__/LoginHandler";
+import { LoginHandlerMock } from "../src/login/__mocks__/LoginHandler";
 import {
   RedirectHandlerMock,
   RedirectHandlerResponse
@@ -108,9 +105,9 @@ describe("ClientAuthentication", () => {
     it("calls logout", async () => {
       const clientAuthn = getClientAuthentication();
       await clientAuthn.logout("mySession");
-      expect(defaultMocks.logoutHandler.handle).toHaveBeenCalledWith(
-        "mySession"
-      );
+      expect(defaultMocks.logoutHandler.handle).toHaveBeenCalledWith({
+        sessionId: "mySession"
+      });
     });
   });
 

--- a/__tests__/logout/GeneralLogoutHandler.spec.ts
+++ b/__tests__/logout/GeneralLogoutHandler.spec.ts
@@ -130,7 +130,53 @@ describe("OidcLoginHandler", () => {
       expect(nonEmptyStorage.get("clientKey", { secure: false })).toBeUndefined;
     });
 
-    it("should redirect the user to the logout endpoint", async () => {
+    it("should redirect the user to the logout endpoint on a hard logout", async () => {
+      const redirector = defaultMocks.redirector;
+      const logoutHandler = getInitialisedHandler({
+        storageUtility: mockStorageUtility({
+          someUser: {
+            issuer: "https://some.idp"
+          }
+        }),
+        issuerConfigFetcher: mockConfigFetcher({
+          ...IssuerConfigFetcherFetchConfigResponse,
+          endSessionEndpoint: new URL("https://https://some.idp/logout")
+        }),
+        redirector: redirector
+      });
+      await logoutHandler.handle({ sessionId: "someUser", soft: false });
+      expect(redirector.redirect).toHaveBeenCalledWith(
+        "https://https://some.idp/logout",
+        {
+          handleRedirect: undefined
+        }
+      );
+    });
+
+    it("should not redirect the user to the logout endpoint on a soft logout", async () => {
+      const redirector = defaultMocks.redirector;
+      const logoutHandler = getInitialisedHandler({
+        storageUtility: mockStorageUtility({
+          someUser: {
+            issuer: "https://some.idp"
+          }
+        }),
+        issuerConfigFetcher: mockConfigFetcher({
+          ...IssuerConfigFetcherFetchConfigResponse,
+          endSessionEndpoint: new URL("https://https://some.idp/logout")
+        }),
+        redirector: redirector
+      });
+      await logoutHandler.handle({ sessionId: "someUser", soft: true });
+      expect(redirector.redirect).not.toHaveBeenCalledWith(
+        "https://https://some.idp/logout",
+        {
+          handleRedirect: undefined
+        }
+      );
+    });
+
+    it("should not redirect the user to the logout endpoint by default", async () => {
       const redirector = defaultMocks.redirector;
       const logoutHandler = getInitialisedHandler({
         storageUtility: mockStorageUtility({
@@ -145,7 +191,7 @@ describe("OidcLoginHandler", () => {
         redirector: redirector
       });
       await logoutHandler.handle({ sessionId: "someUser" });
-      expect(redirector.redirect).toHaveBeenCalledWith(
+      expect(redirector.redirect).not.toHaveBeenCalledWith(
         "https://https://some.idp/logout",
         {
           handleRedirect: undefined

--- a/__tests__/sessionInfo/SessionInfoManager.spec.ts
+++ b/__tests__/sessionInfo/SessionInfoManager.spec.ts
@@ -55,12 +55,16 @@ describe("SessionInfoManager", () => {
 
   describe("get", () => {
     it("retrieves a session from specified storage", async () => {
-      const storageUtility = defaultMocks.storageUtility;
-      storageUtility.getForUser
-        .mockReturnValueOnce(
-          Promise.resolve("https://zoomies.com/commanderCool#me")
-        )
-        .mockReturnValueOnce(Promise.resolve("true"));
+      const storageUtility = mockStorageUtility(
+        {
+          commanderCool: {
+            sessionId: "commanderCool",
+            webId: "https://zoomies.com/commanderCool#me",
+            isLoggedIn: "true"
+          }
+        },
+        true
+      );
       const sessionManager = getSessionInfoManager({ storageUtility });
       const session = await sessionManager.get("commanderCool");
       expect(session).toMatchObject({

--- a/src/ClientAuthentication.ts
+++ b/src/ClientAuthentication.ts
@@ -22,7 +22,7 @@
 import { injectable, inject } from "tsyringe";
 import ILoginHandler from "./login/ILoginHandler";
 import IRedirectHandler from "./login/oidc/redirectHandler/IRedirectHandler";
-import ILogoutHandler from "./logout/ILogoutHandler";
+import ILogoutHandler, { ILogoutOptions } from "./logout/ILogoutHandler";
 import { ISessionInfoManager } from "./sessionInfo/SessionInfoManager";
 import IAuthenticatedFetcher from "./authenticatedFetch/IAuthenticatedFetcher";
 import { IEnvironmentDetector } from "./util/EnvironmentDetector";
@@ -86,8 +86,17 @@ export default class ClientAuthentication {
     return this.authenticatedFetcher.handle(credentials, url, init);
   };
 
-  logout = async (sessionId: string): Promise<void> => {
-    this.logoutHandler.handle(sessionId);
+  logout = async (
+    sessionId: string,
+    redirectUrl?: URL,
+    handleRedirect?: (redirectUrl: string) => unknown
+  ): Promise<void> => {
+    const logoutOptions: ILogoutOptions = {
+      sessionId: sessionId,
+      redirectUrl: redirectUrl,
+      handleRedirect: handleRedirect
+    };
+    this.logoutHandler.handle(logoutOptions);
   };
 
   getSessionInfo = async (

--- a/src/login/oidc/IIssuerConfig.ts
+++ b/src/login/oidc/IIssuerConfig.ts
@@ -29,6 +29,7 @@ export default interface IIssuerConfig {
   authorizationEndpoint: URL;
   tokenEndpoint: URL;
   userinfoEndpoint?: URL;
+  endSessionEndpoint?: URL;
   jwksUri: URL;
   registrationEndpoint?: URL;
   scopesSupported?: string[];

--- a/src/login/oidc/IssuerConfigFetcher.ts
+++ b/src/login/oidc/IssuerConfigFetcher.ts
@@ -59,6 +59,10 @@ const issuerConfigKeyMap: Record<
     toKey: "userinfoEndpoint",
     convertToUrl: true
   },
+  end_session_endpoint: {
+    toKey: "endSessionEndpoint",
+    convertToUrl: true
+  },
   jwks_uri: {
     toKey: "jwksUri",
     convertToUrl: true

--- a/src/login/oidc/TokenRequester.ts
+++ b/src/login/oidc/TokenRequester.ts
@@ -136,6 +136,8 @@ export default class TokenRequester {
       throw new Error("The idp returned a bad token without a sub.");
     }
 
+    console.log(`ID token: ${tokenResponse.id_token as string}`);
+
     await this.storageUtility.setForUser(
       sessionId,
       {

--- a/src/login/oidc/TokenRequester.ts
+++ b/src/login/oidc/TokenRequester.ts
@@ -136,8 +136,6 @@ export default class TokenRequester {
       throw new Error("The idp returned a bad token without a sub.");
     }
 
-    console.log(`ID token: ${tokenResponse.id_token as string}`);
-
     await this.storageUtility.setForUser(
       sessionId,
       {

--- a/src/login/oidc/__mocks__/IssuerConfigFetcher.ts
+++ b/src/login/oidc/__mocks__/IssuerConfigFetcher.ts
@@ -39,3 +39,12 @@ export const IssuerConfigFetcherMock: jest.Mocked<IIssuerConfigFetcher> = {
     Promise.resolve(IssuerConfigFetcherFetchConfigResponse)
   )
 };
+
+export const mockConfigFetcher = (
+  config: IIssuerConfig
+): jest.Mocked<IIssuerConfigFetcher> => {
+  return {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    fetchConfig: jest.fn((_issuer: URL) => Promise.resolve(config))
+  };
+};

--- a/src/logout/GeneralLogoutHandler.ts
+++ b/src/logout/GeneralLogoutHandler.ts
@@ -84,15 +84,13 @@ export default class LogoutHandler implements ILogoutHandler {
   async handleOidcLogout(
     logoutEndpoint: URL,
     logoutOptions: ILogoutOptions,
+    // See the FIXME inside the function
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     idToken?: string
   ): Promise<void> {
-    if (idToken) {
-      // See https://openid.net/specs/openid-connect-rpinitiated-1_0.html#RPLogout
-      // Disabling the camel case rule, because the key is mandated by the OIDC spec
-      // eslint-disable-next-line @typescript-eslint/camelcase
-      logoutEndpoint.set("query", { id_token_hint: idToken });
-      // FIXME: post_logout_redirect_uri not implemented yet
-    }
+    // FIXME: according to https://openid.net/specs/openid-connect-rpinitiated-1_0.html#RPLogout,
+    // id_token_hint should be sent as part of the logout request to the end_session_endpoint.
+    // However, some OP seem not to support this option, which is disabled for the time being.
     this.redirector.redirect(logoutEndpoint.toString(), {
       handleRedirect: logoutOptions.handleRedirect
     });

--- a/src/logout/GeneralLogoutHandler.ts
+++ b/src/logout/GeneralLogoutHandler.ts
@@ -60,9 +60,11 @@ export default class LogoutHandler implements ILogoutHandler {
       // FIXME: This is needed until the DPoP key is stored safely
       this.storageUtility.delete("clientKey", { secure: false })
     ]);
-    // The OIDC logout will redirect the user away from the current page,
-    // so it should be done after clearing the storage
-    await this.handleOidcLogout(logoutEndpoint, logoutOptions, idToken);
+    if (logoutOptions.soft !== undefined && !logoutOptions.soft) {
+      // The OIDC logout will redirect the user away from the current page,
+      // so it should be done after clearing the storage
+      await this.handleOidcLogout(logoutEndpoint, logoutOptions, idToken);
+    }
   }
 
   async retrieveSessionEndpoint(userId: string): Promise<URL> {

--- a/src/logout/GeneralLogoutHandler.ts
+++ b/src/logout/GeneralLogoutHandler.ts
@@ -69,7 +69,7 @@ export default class LogoutHandler implements ILogoutHandler {
     const issuer = await this.storageUtility.getForUser(userId, "issuer");
     if (!issuer) {
       throw new Error(
-        `Cannot find the Identity Provider [${issuer}] in storage, preventing logout to complete successfully.`
+        `Cannot find the Identity Provider for session [${userId}] in storage, preventing logout to complete successfully.`
       );
     }
     const issuerConfig = await this.issuerConfigFetcher.fetchConfig(

--- a/src/logout/ILogoutHandler.ts
+++ b/src/logout/ILogoutHandler.ts
@@ -20,6 +20,18 @@
  */
 
 import IHandleable from "../util/handlerPattern/IHandleable";
+import URL from "url-parse";
 
-type ILogoutHandler = IHandleable<[string], void>;
+export interface ILogoutOptions {
+  sessionId: string;
+  // The URL to which the user should be redirected after logout.
+  // Nothe: This "post_logout_url" must be specified at client registration
+  // FIXME: Not yet implemented at client registration
+  redirectUrl?: URL;
+  // Function to handle the redirection of the user to the identity provider.
+  // Optional in browser.
+  handleRedirect?: (redirectUrl: string) => unknown;
+}
+
+type ILogoutHandler = IHandleable<[ILogoutOptions], void>;
 export default ILogoutHandler;

--- a/src/logout/ILogoutHandler.ts
+++ b/src/logout/ILogoutHandler.ts
@@ -31,6 +31,10 @@ export interface ILogoutOptions {
   // Function to handle the redirection of the user to the identity provider.
   // Optional in browser.
   handleRedirect?: (redirectUrl: string) => unknown;
+  // A soft logout logs you out of the app. A hard logout logs you out of the
+  // identity provider as well. A soft logout should be the used unless you have
+  // a good reason not to.
+  soft?: boolean;
 }
 
 type ILogoutHandler = IHandleable<[ILogoutOptions], void>;

--- a/src/logout/__mocks__/LogoutHandler.ts
+++ b/src/logout/__mocks__/LogoutHandler.ts
@@ -19,11 +19,13 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import ILogoutHandler from "../ILogoutHandler";
+import ILogoutHandler, { ILogoutOptions } from "../ILogoutHandler";
 
 export const LogoutHandlerMock: jest.Mocked<ILogoutHandler> = {
-  canHandle: jest.fn(async (localUserId: string) => true),
-  handle: jest.fn(async (localUserId: string) => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  canHandle: jest.fn(async (options: ILogoutOptions) => true),
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  handle: jest.fn(async (options: ILogoutOptions) => {
     /* Do nothing */
   })
 };

--- a/src/sessionInfo/ISessionInfo.ts
+++ b/src/sessionInfo/ISessionInfo.ts
@@ -25,5 +25,6 @@
 export default interface ISessionInfo {
   isLoggedIn: boolean;
   webId?: string;
+  oidcIssuer?: string;
   sessionId: string;
 }

--- a/src/sessionInfo/SessionInfoManager.ts
+++ b/src/sessionInfo/SessionInfoManager.ts
@@ -84,6 +84,13 @@ export default class SessionInfoManager implements ISessionInfoManager {
     const webId = await this.storageUtility.getForUser(sessionId, "webId", {
       secure: true
     });
+    const oidcIssuer = await this.storageUtility.getForUser(
+      sessionId,
+      "oidcIssuer",
+      {
+        secure: true
+      }
+    );
     const isLoggedIn = await this.storageUtility.getForUser(
       sessionId,
       "isLoggedIn",
@@ -95,6 +102,7 @@ export default class SessionInfoManager implements ISessionInfoManager {
       return {
         sessionId,
         webId: webId,
+        oidcIssuer: oidcIssuer,
         isLoggedIn: isLoggedIn === "true"
       };
     }


### PR DESCRIPTION
This adds a new step to redirect the user when he/she is logging out, so that they can complete a proper OIDC session ending flow.

# Checklist

- [X] All acceptance criteria are met.
- [ ] ~Relevant documentation, if any, has been written/updated.~ Generating the API reference will be done later this sprint 
- [X] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).