### PR TITLE
Docs: Update to build

### DIFF
--- a/apidocs/Makefile
+++ b/apidocs/Makefile
@@ -32,7 +32,8 @@ migrate: clean
    # Copying to SOURCECOPYDIR instead of copying source dir to BUILDDIR
    # in case someone forgets to backslash after build/
 
-	cp -R $(SOURCEDIR)/* $(SOURCECOPYDIR)
+	cp -R $(SOURCEDIR)/index.rst $(SOURCECOPYDIR)
+	cp -R $(SOURCEDIR)/api/* $(SOURCECOPYDIR)
 
 html: Makefile migrate
 
@@ -41,9 +42,10 @@ html: Makefile migrate
 # Also, on macOS, need -i '' but not for Linux
 
 ifdef IS_MAC
-	find $(SOURCECOPYDIR)/api/modules/ -type f -name "*.md" -exec sed -i '' -e 's?\.md#?\.html#?g' {} \;
+	find $(SOURCECOPYDIR)/ -type f -name "*.md" -exec sed -i '' -e 's?\.md#?\.html#?g' {} \;
+	
 else
-	find $(SOURCECOPYDIR)/api/modules/ -type f -name "*.md" -exec sed -i  -e 's?\.md#?\.html#?g' {} \;
+	find $(SOURCECOPYDIR)/ -type f -name "*.md" -exec sed -i  -e 's?\.md#?\.html#?g' {} \;
 endif
 	@$(SPHINXBUILD) -M $@ "$(SOURCECOPYDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) -c .
 

--- a/apidocs/_templates/docs-sidebar.html
+++ b/apidocs/_templates/docs-sidebar.html
@@ -20,11 +20,6 @@
   #}
   <ul class="nav bd-sidenav">
      
-     <li class="nav-item toctree-top">
-        <a class="nav-link" href="{{url_root}}"> {{ theme_project_title }} </a>
-     </li>
-     
-     
       {% for main_nav_item in nav %}
          {% if main_nav_item.title %}
              <li class="nav-item {% if main_nav_item.active%}active{% endif %} toctree-l1"> <a class="nav-link" href="{{ main_nav_item.url }}">{{ main_nav_item.title }}</a>

--- a/apidocs/conf.py
+++ b/apidocs/conf.py
@@ -49,9 +49,7 @@ highlight_language = 'javascript'
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'sphinx_copybutton',
     'sphinx.ext.extlinks',
-    'sphinx_tabs.tabs',
     'sphinx.ext.todo',
     'myst_parser',
 ]
@@ -89,7 +87,7 @@ html_theme_options = {
     'banner': True,
     'banner_msg': 'This is a Beta (i.e. in progress) version of the manual. Content and features are subject to change.',
     'robots_index': True,
-    'github_editable': True,
+    'github_editable': False,
     'github_org': 'inrupt',
     'github_repo': repo_name,
     'github_branch': 'master',

--- a/apidocs/source/index.rst
+++ b/apidocs/source/index.rst
@@ -9,10 +9,7 @@ solid-client-authn API
    :titlesonly:
    :hidden:
 
-   /api/*
-
-.. toctree::
-   :glob:
-   :titlesonly:
-
-   /api/*/*
+   *
+   /classes/*
+   /interfaces/*
+   /modules/*

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -28,6 +28,7 @@ migrate: clean
 	cp -R $(SOURCEDIR)/* $(SOURCECOPYDIR)
 
 html: Makefile migrate
+	@$(SPHINXBUILD) -M $@ "$(SOURCECOPYDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,7 +24,7 @@ copyright = '2020-present, Inrupt Inc.'
 # -- product name -----
 # -- Separately update code samples and toc links and docs-navbar since not using substitutions--
 
-name = 'solid-client'
+name = 'solid-client-authn'
 repo_name = '{0}-js'.format(name)
 replacement_string = '.. |product|  replace:: ``{0}``'.format(name)
 
@@ -53,11 +53,10 @@ extensions = [
     'sphinx.ext.extlinks',
     'sphinx_tabs.tabs',
     'sphinx.ext.todo',
-    'myst_parser',
 ]
 
 extlinks = {
-    'apisolidclient': ('https://docs.inrupt.com/client-libraries/api/js/solid-client-authn-browser%s','')
+    'apisolidclient': ('https://docs.inrupt.com/client-libraries/api/javascript/solid-client-authn-browser%s','')
 }
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1,7 +1,0 @@
-=============
-API Reference
-=============
-
-.. toctree::
-
-   solid-client-authn-browser API <https://docs.inrupt.com/client-libraries/api/javascript/solid-client-authn-browser>

--- a/docs/source/includes/table-issues-help.rst
+++ b/docs/source/includes/table-issues-help.rst
@@ -1,0 +1,19 @@
+.. list-table::
+
+   * - Solid Community Forum
+           If you have questions about working with Solid or just
+           want to share what you're working on, visit the `Solid forum
+           <https://forum.solidproject.org>`_. The Solid forum is a
+           good place to meet the rest of the community.
+
+   * - Bugs and Feature Requests (Product)
+           For public feedback, bug reports, and feature requests please
+           file an issue via `Github
+           <https://github.com/inrupt/solid-client-js/issues/>`_.
+           For non-public feedback or support inquiries please use the
+           `Inrupt Service Desk <https://inrupt.atlassian.net/servicedesk>`_.
+
+   * - Bugs and Feature Requests (Documentation)
+           To report a documentation bug or make a documentation
+           request, please use the feedback
+           widget to create a ticket.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -2,9 +2,6 @@
 Inrupt |product| Documentation
 ==============================
 
-   * - :doc:`/api`
-
-     - Go to the API documentation.
 
 Issues & Help
 =============
@@ -15,7 +12,7 @@ Issues & Help
    :titlesonly:
    :hidden:
 
-   /api
+   API <https://docs.inrupt.com/client-libraries/api/javascript/solid-client-authn-js/>
    Source on GitHub <https://github.com/inrupt/solid-client-authn-js>
    /issues-help
 

--- a/docs/source/issues-help.rst
+++ b/docs/source/issues-help.rst
@@ -1,0 +1,5 @@
+=============
+Issues & Help
+=============
+
+.. include:: /includes/table-issues-help.rst


### PR DESCRIPTION
Minor fixes to configuration and makefile to build the docs:

- Update API docs conf.py - API docs don't need tabs/copy button extensions (and isn't part of the requirements.txt)
- Update API docs Makefile - when copying to  build directory, update the api docs structure
- Update API docs Makefile - clean .md files in all api directories, not just modules
- Update reference docs Makefile - missing the sphinx-builder line for the html target


