### PR TITLE
Run the CI on PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push]
+on: [push, pull_request]
 
 env:
   CI: true


### PR DESCRIPTION
In order to have the CI run for third-party contributions coming from a fork, they must run on PR, and not only on push, since technically a third-party contribution hasn't been pushed to a branch of the repo.

This should trigger the CI for https://github.com/inrupt/solid-client-authn-js/pull/277.