### PR TITLE
Clear local storage on login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### New features
 
+### Bugfixes
+
+- Browser
+  - Login now clears the local storage, so that you can log into a different server
+even if not logged out properly.
+
 ## [0.1.2] - 2020-09-07
 
 ### Internal refactor:

--- a/packages/browser/__tests__/login/oidc/OidcLoginHandler.spec.ts
+++ b/packages/browser/__tests__/login/oidc/OidcLoginHandler.spec.ts
@@ -113,10 +113,10 @@ describe("OidcLoginHandler", () => {
       clientId: "coolApp",
     });
     expect(nonEmptyStorage.getForUser("someUser", "someKey", { secure: true }))
-      .toBeUndefined;
+      .toBeUndefined();
     expect(nonEmptyStorage.getForUser("someUser", "someKey", { secure: false }))
-      .toBeUndefined;
+      .toBeUndefined();
     // This test is only necessary until the key is stored safely
-    expect(nonEmptyStorage.get("clientKey", { secure: false })).toBeUndefined;
+    expect(nonEmptyStorage.get("clientKey", { secure: false })).toBeUndefined();
   });
 });

--- a/packages/browser/__tests__/login/oidc/OidcLoginHandler.spec.ts
+++ b/packages/browser/__tests__/login/oidc/OidcLoginHandler.spec.ts
@@ -112,11 +112,15 @@ describe("OidcLoginHandler", () => {
       redirectUrl: new URL("https://app.com/redirect"),
       clientId: "coolApp",
     });
-    expect(nonEmptyStorage.getForUser("someUser", "someKey", { secure: true }))
-      .toBeUndefined();
-    expect(nonEmptyStorage.getForUser("someUser", "someKey", { secure: false }))
-      .toBeUndefined();
+    expect(
+      nonEmptyStorage.getForUser("someUser", "someKey", { secure: true })
+    ).resolves.toBeUndefined();
+    expect(
+      nonEmptyStorage.getForUser("someUser", "someKey", { secure: false })
+    ).resolves.toBeUndefined();
     // This test is only necessary until the key is stored safely
-    expect(nonEmptyStorage.get("clientKey", { secure: false })).toBeUndefined();
+    await expect(
+      nonEmptyStorage.get("clientKey", { secure: false })
+    ).resolves.toBeUndefined();
   });
 });

--- a/packages/browser/__tests__/login/oidc/OidcLoginHandler.spec.ts
+++ b/packages/browser/__tests__/login/oidc/OidcLoginHandler.spec.ts
@@ -25,10 +25,6 @@ import { OidcHandlerMock } from "../../../src/login/oidc/__mocks__/IOidcHandler"
 import { IssuerConfigFetcherMock } from "../../../src/login/oidc/__mocks__/IssuerConfigFetcher";
 import OidcLoginHandler from "../../../src/login/oidc/OidcLoginHandler";
 import URL from "url-parse";
-import {
-  StorageUtilityMock,
-  mockStorageUtility,
-} from "../../../src/storage/__mocks__/StorageUtility";
 import { DpopClientKeyManagerMock } from "../../../src/dpop/__mocks__/DpopClientKeyManager";
 import { ClientRegistrarMock } from "../../../src/login/oidc/__mocks__/ClientRegistrar";
 
@@ -37,7 +33,6 @@ describe("OidcLoginHandler", () => {
     oidcHandler: OidcHandlerMock,
     issuerConfigFetcher: IssuerConfigFetcherMock,
     dpopClientKeyManager: DpopClientKeyManagerMock,
-    storageUtility: StorageUtilityMock,
     clientRegistrar: ClientRegistrarMock,
   };
   function getInitialisedHandler(
@@ -47,8 +42,7 @@ describe("OidcLoginHandler", () => {
       mocks.oidcHandler ?? defaultMocks.oidcHandler,
       mocks.issuerConfigFetcher ?? defaultMocks.issuerConfigFetcher,
       mocks.dpopClientKeyManager ?? defaultMocks.dpopClientKeyManager,
-      mocks.clientRegistrar ?? defaultMocks.clientRegistrar,
-      mocks.storageUtility ?? defaultMocks.storageUtility
+      mocks.clientRegistrar ?? defaultMocks.clientRegistrar
     );
   }
 
@@ -92,35 +86,5 @@ describe("OidcLoginHandler", () => {
     const handler = getInitialisedHandler();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     await expect(handler.canHandle({} as any)).resolves.toBe(false);
-  });
-
-  it("should clear the local storage when logging in", async () => {
-    const nonEmptyStorage = mockStorageUtility({
-      someUser: { someKey: "someValue" },
-    });
-    nonEmptyStorage.setForUser(
-      "someUser",
-      { someKey: "someValue" },
-      { secure: true }
-    );
-    const handler = getInitialisedHandler({
-      storageUtility: nonEmptyStorage,
-    });
-    handler.handle({
-      sessionId: "someUser",
-      oidcIssuer: new URL("https://arbitrary.url"),
-      redirectUrl: new URL("https://app.com/redirect"),
-      clientId: "coolApp",
-    });
-    expect(
-      nonEmptyStorage.getForUser("someUser", "someKey", { secure: true })
-    ).resolves.toBeUndefined();
-    expect(
-      nonEmptyStorage.getForUser("someUser", "someKey", { secure: false })
-    ).resolves.toBeUndefined();
-    // This test is only necessary until the key is stored safely
-    await expect(
-      nonEmptyStorage.get("clientKey", { secure: false })
-    ).resolves.toBeUndefined();
   });
 });

--- a/packages/browser/__tests__/logout/GeneralLogoutHandler.spec.ts
+++ b/packages/browser/__tests__/logout/GeneralLogoutHandler.spec.ts
@@ -19,30 +19,26 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import {
-  StorageUtilityMock,
-  mockStorageUtility,
-} from "../../src/storage/__mocks__/StorageUtility";
+import { mockStorageUtility } from "../../src/storage/__mocks__/StorageUtility";
 import "reflect-metadata";
 import { default as LogoutHandler } from "../../src/logout/GeneralLogoutHandler";
+import { mockSessionInfoManager } from "../../src/sessionInfo/__mocks__/SessionInfoManager";
 
 describe("OidcLoginHandler", () => {
   const defaultMocks = {
-    storageUtility: StorageUtilityMock,
+    sessionManager: mockSessionInfoManager(mockStorageUtility({})),
   };
   function getInitialisedHandler(
     mocks: Partial<typeof defaultMocks> = defaultMocks
   ): LogoutHandler {
     return new LogoutHandler(
-      mocks.storageUtility ?? defaultMocks.storageUtility
+      mocks.sessionManager ?? defaultMocks.sessionManager
     );
   }
 
   describe("canHandle", () => {
     it("should always be able to handle logout", async () => {
-      const logoutHandler = getInitialisedHandler({
-        storageUtility: mockStorageUtility({}),
-      });
+      const logoutHandler = getInitialisedHandler();
       await expect(logoutHandler.canHandle()).resolves.toBe(true);
     });
   });
@@ -58,7 +54,7 @@ describe("OidcLoginHandler", () => {
         { secure: true }
       );
       const logoutHandler = getInitialisedHandler({
-        storageUtility: nonEmptyStorage,
+        sessionManager: mockSessionInfoManager(nonEmptyStorage),
       });
       logoutHandler.handle("someUser");
       await expect(

--- a/packages/browser/__tests__/logout/GeneralLogoutHandler.spec.ts
+++ b/packages/browser/__tests__/logout/GeneralLogoutHandler.spec.ts
@@ -64,11 +64,11 @@ describe("OidcLoginHandler", () => {
       await expect(
         nonEmptyStorage.getForUser("someUser", "someKey", { secure: true })
       ).resolves.toBeUndefined();
-      expect(
+      await expect(
         nonEmptyStorage.getForUser("someUser", "someKey", { secure: false })
       ).resolves.toBeUndefined();
       // This test is only necessary until the key is stored safely
-      expect(
+      await expect(
         nonEmptyStorage.get("clientKey", { secure: false })
       ).resolves.toBeUndefined();
     });

--- a/packages/browser/__tests__/logout/GeneralLogoutHandler.spec.ts
+++ b/packages/browser/__tests__/logout/GeneralLogoutHandler.spec.ts
@@ -61,14 +61,16 @@ describe("OidcLoginHandler", () => {
         storageUtility: nonEmptyStorage,
       });
       logoutHandler.handle("someUser");
-      expect(
+      await expect(
         nonEmptyStorage.getForUser("someUser", "someKey", { secure: true })
-      ).toBeUndefined;
+      ).resolves.toBeUndefined();
       expect(
         nonEmptyStorage.getForUser("someUser", "someKey", { secure: false })
-      ).toBeUndefined;
+      ).resolves.toBeUndefined();
       // This test is only necessary until the key is stored safely
-      expect(nonEmptyStorage.get("clientKey", { secure: false })).toBeUndefined;
+      expect(
+        nonEmptyStorage.get("clientKey", { secure: false })
+      ).resolves.toBeUndefined();
     });
   });
 });

--- a/packages/browser/src/ClientAuthentication.ts
+++ b/packages/browser/src/ClientAuthentication.ts
@@ -70,7 +70,7 @@ export default class ClientAuthentication {
     options: ILoginInputOptions
   ): Promise<void> => {
     // In order to get a clean start, make sure that the session is logged out on login.
-    await this.logout(sessionId);
+    await this.sessionInfoManager.clear(sessionId);
     return this.loginHandler.handle({
       sessionId,
       oidcIssuer: this.urlOptionToUrl(options.oidcIssuer),

--- a/packages/browser/src/ClientAuthentication.ts
+++ b/packages/browser/src/ClientAuthentication.ts
@@ -69,6 +69,8 @@ export default class ClientAuthentication {
     sessionId: string,
     options: ILoginInputOptions
   ): Promise<void> => {
+    // In order to get a clean start, make sure that the session is logged out on login.
+    await this.logout(sessionId);
     return this.loginHandler.handle({
       sessionId,
       oidcIssuer: this.urlOptionToUrl(options.oidcIssuer),

--- a/packages/browser/src/login/oidc/OidcLoginHandler.ts
+++ b/packages/browser/src/login/oidc/OidcLoginHandler.ts
@@ -39,7 +39,6 @@ import IIssuerConfig from "./IIssuerConfig";
 import { IDpopClientKeyManager } from "../../dpop/DpopClientKeyManager";
 import URL from "url-parse";
 import { IClientRegistrar } from "./ClientRegistrar";
-import { IStorageUtility } from "../../storage/StorageUtility";
 
 /**
  * @hidden

--- a/packages/browser/src/login/oidc/OidcLoginHandler.ts
+++ b/packages/browser/src/login/oidc/OidcLoginHandler.ts
@@ -52,8 +52,7 @@ export default class OidcLoginHandler implements ILoginHandler {
     private issuerConfigFetcher: IIssuerConfigFetcher,
     @inject("dpopClientKeyManager")
     private dpopClientKeyManager: IDpopClientKeyManager,
-    @inject("clientRegistrar") private clientRegistrar: IClientRegistrar,
-    @inject("storageUtility") private storageUtility: IStorageUtility
+    @inject("clientRegistrar") private clientRegistrar: IClientRegistrar
   ) {}
 
   checkOptions(options: ILoginOptions): Error | null {
@@ -73,18 +72,6 @@ export default class OidcLoginHandler implements ILoginHandler {
     if (optionsError) {
       throw optionsError;
     }
-
-    // Clears storage in case the session has not properly logged out.
-    await Promise.all([
-      this.storageUtility.deleteAllUserData(options.sessionId, {
-        secure: false,
-      }),
-      this.storageUtility.deleteAllUserData(options.sessionId, {
-        secure: true,
-      }),
-      // FIXME: This is needed until the DPoP key is stored safely
-      this.storageUtility.delete("clientKey", { secure: false }),
-    ]);
 
     // Fetch OpenId Config
     const issuerConfig: IIssuerConfig = await this.issuerConfigFetcher.fetchConfig(

--- a/packages/browser/src/logout/GeneralLogoutHandler.ts
+++ b/packages/browser/src/logout/GeneralLogoutHandler.ts
@@ -26,25 +26,7 @@
 
 import ILogoutHandler from "./ILogoutHandler";
 import { inject, injectable } from "tsyringe";
-import { IStorageUtility } from "../storage/StorageUtility";
-
-/**
- * This function removes all session-related information from storage.
- * @param userId the session identifier
- * @param storage the storage where session info is stored
- * @hidden
- */
-export async function clearSession(
-  userId: string,
-  storage: IStorageUtility
-): Promise<void> {
-  await Promise.all([
-    storage.deleteAllUserData(userId, { secure: false }),
-    storage.deleteAllUserData(userId, { secure: true }),
-    // FIXME: This is needed until the DPoP key is stored safely
-    storage.delete("clientKey", { secure: false }),
-  ]);
-}
+import { ISessionInfoManager } from "../sessionInfo/SessionInfoManager";
 
 /**
  * @hidden
@@ -52,7 +34,8 @@ export async function clearSession(
 @injectable()
 export default class LogoutHandler implements ILogoutHandler {
   constructor(
-    @inject("storageUtility") private storageUtility: IStorageUtility
+    @inject("sessionInfoManager")
+    private sessionInfoManager: ISessionInfoManager
   ) {}
 
   async canHandle(): Promise<boolean> {
@@ -60,6 +43,6 @@ export default class LogoutHandler implements ILogoutHandler {
   }
 
   async handle(userId: string): Promise<void> {
-    await clearSession(userId, this.storageUtility);
+    await this.sessionInfoManager.clear(userId);
   }
 }

--- a/packages/browser/src/logout/GeneralLogoutHandler.ts
+++ b/packages/browser/src/logout/GeneralLogoutHandler.ts
@@ -29,6 +29,24 @@ import { inject, injectable } from "tsyringe";
 import { IStorageUtility } from "../storage/StorageUtility";
 
 /**
+ * This function removes all session-related information from storage.
+ * @param userId the session identifier
+ * @param storage the storage where session info is stored
+ * @hidden
+ */
+export async function clearSession(
+  userId: string,
+  storage: IStorageUtility
+): Promise<void> {
+  await Promise.all([
+    storage.deleteAllUserData(userId, { secure: false }),
+    storage.deleteAllUserData(userId, { secure: true }),
+    // FIXME: This is needed until the DPoP key is stored safely
+    storage.delete("clientKey", { secure: false }),
+  ]);
+}
+
+/**
  * @hidden
  */
 @injectable()
@@ -42,11 +60,6 @@ export default class LogoutHandler implements ILogoutHandler {
   }
 
   async handle(userId: string): Promise<void> {
-    await Promise.all([
-      this.storageUtility.deleteAllUserData(userId, { secure: false }),
-      this.storageUtility.deleteAllUserData(userId, { secure: true }),
-      // FIXME: This is needed until the DPoP key is stored safely
-      this.storageUtility.delete("clientKey", { secure: false }),
-    ]);
+    await clearSession(userId, this.storageUtility);
   }
 }

--- a/packages/browser/src/logout/__mocks__/LogoutHandler.ts
+++ b/packages/browser/src/logout/__mocks__/LogoutHandler.ts
@@ -20,10 +20,24 @@
  */
 
 import ILogoutHandler from "../ILogoutHandler";
+import { IStorageUtility } from "../../storage/StorageUtility";
+import { clearSession } from "../GeneralLogoutHandler";
 
 export const LogoutHandlerMock: jest.Mocked<ILogoutHandler> = {
   canHandle: jest.fn(async (_localUserId: string) => true),
   handle: jest.fn(async (_localUserId: string) => {
     /* Do nothing */
   }),
+};
+
+export const mockLogoutHandler = (
+  storageUtility: IStorageUtility
+): jest.Mocked<ILogoutHandler> => {
+  console.log("coucou");
+  return {
+    canHandle: jest.fn(async (_localUserId: string) => true),
+    handle: jest.fn(async (localUserId: string) => {
+      await clearSession(localUserId, storageUtility);
+    }),
+  };
 };

--- a/packages/browser/src/logout/__mocks__/LogoutHandler.ts
+++ b/packages/browser/src/logout/__mocks__/LogoutHandler.ts
@@ -21,7 +21,7 @@
 
 import ILogoutHandler from "../ILogoutHandler";
 import { IStorageUtility } from "../../storage/StorageUtility";
-import { clearSession } from "../GeneralLogoutHandler";
+import { clear } from "../../sessionInfo/SessionInfoManager";
 
 export const LogoutHandlerMock: jest.Mocked<ILogoutHandler> = {
   canHandle: jest.fn(async (_localUserId: string) => true),
@@ -33,11 +33,10 @@ export const LogoutHandlerMock: jest.Mocked<ILogoutHandler> = {
 export const mockLogoutHandler = (
   storageUtility: IStorageUtility
 ): jest.Mocked<ILogoutHandler> => {
-  console.log("coucou");
   return {
     canHandle: jest.fn(async (_localUserId: string) => true),
     handle: jest.fn(async (localUserId: string) => {
-      await clearSession(localUserId, storageUtility);
+      return clear(localUserId, storageUtility);
     }),
   };
 };

--- a/packages/browser/src/sessionInfo/SessionInfoManager.ts
+++ b/packages/browser/src/sessionInfo/SessionInfoManager.ts
@@ -43,6 +43,24 @@ export interface ISessionInfoManager {
   update(sessionId: string, options: ISessionInfoManagerOptions): Promise<void>;
   get(sessionId: string): Promise<ISessionInfo | undefined>;
   getAll(): Promise<ISessionInfo[]>;
+  clear(sessionId: string): Promise<void>;
+}
+
+/**
+ * @param sessionId
+ * @param storage
+ * @hidden
+ */
+export async function clear(
+  sessionId: string,
+  storage: IStorageUtility
+): Promise<void> {
+  await Promise.all([
+    storage.deleteAllUserData(sessionId, { secure: false }),
+    storage.deleteAllUserData(sessionId, { secure: true }),
+    // FIXME: This is needed until the DPoP key is stored safely
+    storage.delete("clientKey", { secure: false }),
+  ]);
 }
 
 /**
@@ -117,5 +135,15 @@ export default class SessionInfoManager implements ISessionInfoManager {
 
   async getAll(): Promise<ISessionInfo[]> {
     throw new Error("Not implemented");
+  }
+
+  /**
+   * This function removes all session-related information from storage.
+   * @param sessionId the session identifier
+   * @param storage the storage where session info is stored
+   * @hidden
+   */
+  async clear(sessionId: string): Promise<void> {
+    return clear(sessionId, this.storageUtility);
   }
 }

--- a/packages/browser/src/sessionInfo/__mocks__/SessionInfoManager.ts
+++ b/packages/browser/src/sessionInfo/__mocks__/SessionInfoManager.ts
@@ -19,11 +19,12 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import {
+import SessionInfoManager, {
   ISessionInfoManager,
   ISessionInfoManagerOptions,
 } from "../SessionInfoManager";
 import ISessionInfo from "../ISessionInfo";
+import { IStorageUtility } from "../../storage/StorageUtility";
 
 export const SessionCreatorCreateResponse: ISessionInfo = {
   sessionId: "global",
@@ -42,4 +43,12 @@ export const SessionInfoManagerMock: jest.Mocked<ISessionInfoManager> = {
     Promise.resolve(SessionCreatorCreateResponse)
   ),
   getAll: jest.fn(async () => Promise.resolve([SessionCreatorCreateResponse])),
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  clear: jest.fn(async (sessionId: string) => Promise.resolve()),
 };
+
+export function mockSessionInfoManager(
+  storageUtility: IStorageUtility
+): ISessionInfoManager {
+  return new SessionInfoManager(storageUtility);
+}


### PR DESCRIPTION
If the user did not log out, and tries to login in a different tab, data stored in local storage prevents expected behaviour, and the login cannot happen. This fixes the issue byy clearing the storage on login as well as on logout.

- [X] All acceptance criteria are met.
- [X] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).