### PR TITLE
build-api-docs: --readme none

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -45,7 +45,7 @@
     "test-acceptance-ios": "echo \"Not Implemented\" && exit 1",
     "test-acceptance-android": "echo \"Not Implemented\" && exit 1",
     "bootstrap-examples": "./bootstrap-examples.bash",
-    "build-api-docs": "npx typedoc --out docs/api/source/api",
+    "build-api-docs": "npx typedoc --out docs/api/source/api --readme none",
     "build-docs-preview-site": "npm run build-api-docs; cd docs/prose; make html; cd ../api; make html; cd ../; rm -r dist || true; mkdir -p dist/prose dist/api; cp -r prose/build/html/. dist/prose/; cp -r api/build/html/. dist/api/; echo 'Draft documentation: <a href=\"./prose/\">Prose</a>, <a href=\"./api/\">API docs</a>.' >> dist/index.html"
   },
   "devDependencies": {


### PR DESCRIPTION
Update build-api-docs definition: Specify `--readme none` for so that typedoc generates a README.md for the API files instead of copying the packages/browser/README.md file.

- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

