### PR TITLE
Align TypeDoc setups

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -16,7 +16,7 @@
     "moduleResolution": "node",
     "outDir": "./dist"
   },
-  "exclude": ["**/node_modules", "**/dist"],
+  "exclude": ["node_modules", "dist", "**/__mocks__/**"],
 
   // We don't provide an 'out' value here, each sub-package should provide its
   // own.


### PR DESCRIPTION
Since API documentation is generated per-package, they each need to
specify e.g. not to include non-exported files.

(Although TypeDoc allows you to specify its options in your
tsconfig, it does not appear to also follow its `extends`
statements in the way TypeScript does.)

Note: Creating as a draft so Vercel can deploy these API docs, so I can compare them to the current API docs.

- [ ] I've added a unit test to test for potential regressions of this bug. N/A
- [x] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
