### PR TITLE
Annotate return types where ESLint wants us to

### DIFF
--- a/packages/core/src/storage/__mocks__/StorageUtility.ts
+++ b/packages/core/src/storage/__mocks__/StorageUtility.ts
@@ -113,7 +113,7 @@ export const mockStorageUtility = (
       userId: string,
       key: string,
       options?: { errorIfNull?: boolean; secure?: boolean }
-    ) => {
+    ): Promise<string | undefined> => {
       const store = options?.secure ? secureStore : nonSecureStore;
       return store[userId]
         ? (store[userId] as Record<string, string>)[key]
@@ -123,7 +123,7 @@ export const mockStorageUtility = (
       userId: string,
       values: Record<string, string>,
       options?: { secure?: boolean }
-    ) => {
+    ): Promise<void> => {
       const store = options?.secure ? secureStore : nonSecureStore;
       store[userId] = values;
     },
@@ -131,14 +131,14 @@ export const mockStorageUtility = (
       userId: string,
       key: string,
       options?: { secure?: boolean }
-    ) => {
+    ): Promise<void> => {
       const store = options?.secure ? secureStore : nonSecureStore;
       delete (store[userId] as Record<string, string>)[key];
     },
     deleteAllUserData: async (
       userId: string,
       options?: { secure?: boolean }
-    ) => {
+    ): Promise<void> => {
       const store = options?.secure ? secureStore : nonSecureStore;
       delete store[userId];
     },
@@ -151,7 +151,8 @@ export const mockStorageUtility = (
         postProcess?: (retrievedObject: any) => any;
         userId?: string;
       }>
-    ) => (nonSecureStore[key] ? (nonSecureStore[key] as string) : undefined),
+    ): Promise<string | undefined> =>
+      nonSecureStore[key] ? (nonSecureStore[key] as string) : undefined,
     /* eslint-enable @typescript-eslint/no-unused-vars */
   };
 };


### PR DESCRIPTION
There are a number of annotations listed in our CI: https://github.com/inrupt/solid-client-authn-js/actions/runs/253759683

They all come down to the same lint warning not being respected.

![image](https://user-images.githubusercontent.com/4251/93083154-7a8de880-f692-11ea-838b-92ed62408b02.png)

This PR fixes those lint warnings by making return types explicit.

- [ ] I've added a unit test to test for potential regressions of this bug. N/A
- [x] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
