### PR TITLE
Docs: Fix link to JS docs

### DIFF
--- a/packages/browser/docs/api/conf.py
+++ b/packages/browser/docs/api/conf.py
@@ -92,7 +92,7 @@ html_theme_options = {
     'github_repo': repo_name,
     'github_branch': 'master',
     'ess_docs': 'https://docs.inrupt.com/ess/',
-    'clientlibjs_docs': 'https://docs.inrupt.com/client-libraries/{0}/'.format(repo_name),
+    'clientlibjs_docs': 'https://docs.inrupt.com/developer-tools/javascript/client-libraries/',
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/packages/core/docs/api/conf.py
+++ b/packages/core/docs/api/conf.py
@@ -92,7 +92,7 @@ html_theme_options = {
     'github_repo': repo_name,
     'github_branch': 'master',
     'ess_docs': 'https://docs.inrupt.com/ess/',
-    'clientlibjs_docs': 'https://docs.inrupt.com/client-libraries/{0}/'.format(repo_name),
+    'clientlibjs_docs': 'https://docs.inrupt.com/developer-tools/javascript/client-libraries/',
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,


### PR DESCRIPTION
Update navbar to point to https://docs.inrupt.com/developer-tools/javascript/client-libraries/

<img width="398" alt="Screen Shot 2020-09-15 at 12 49 10 PM" src="https://user-images.githubusercontent.com/2126636/93240242-e2efcf00-f751-11ea-98d6-87cf90879462.png">