### PR TITLE
Do not include copyright notice in API docs

### DIFF
--- a/packages/browser/__tests__/ClientAuthn.spec.ts
+++ b/packages/browser/__tests__/ClientAuthn.spec.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/__tests__/authenticatedFetch/AggregateAuthenticatedFetcher.spec.ts
+++ b/packages/browser/__tests__/authenticatedFetch/AggregateAuthenticatedFetcher.spec.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/__tests__/authenticatedFetch/bearer/BearerAuthenticatedFetcher.spec.ts
+++ b/packages/browser/__tests__/authenticatedFetch/bearer/BearerAuthenticatedFetcher.spec.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/__tests__/authenticatedFetch/dpop/DpopAuthenticatedFetcher.spec.ts
+++ b/packages/browser/__tests__/authenticatedFetch/dpop/DpopAuthenticatedFetcher.spec.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/__tests__/authenticatedFetch/headers/HeadersUtils.spec.ts
+++ b/packages/browser/__tests__/authenticatedFetch/headers/HeadersUtils.spec.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/__tests__/authenticatedFetch/unauthenticated/UnautenticatedFetcher.spec.ts
+++ b/packages/browser/__tests__/authenticatedFetch/unauthenticated/UnautenticatedFetcher.spec.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/__tests__/dependencies.node.spec.ts
+++ b/packages/browser/__tests__/dependencies.node.spec.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/__tests__/dependencies.spec.ts
+++ b/packages/browser/__tests__/dependencies.spec.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/__tests__/dpop/DpopClientKeyManager.spec.ts
+++ b/packages/browser/__tests__/dpop/DpopClientKeyManager.spec.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/__tests__/dpop/DpopHeaderCreator.spec.ts
+++ b/packages/browser/__tests__/dpop/DpopHeaderCreator.spec.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/__tests__/errors/errors.spec.ts
+++ b/packages/browser/__tests__/errors/errors.spec.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/__tests__/login/AggregateLoginHandler.spec.ts
+++ b/packages/browser/__tests__/login/AggregateLoginHandler.spec.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/__tests__/login/oidc/AggregateOidcHandler.spec.ts
+++ b/packages/browser/__tests__/login/oidc/AggregateOidcHandler.spec.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/__tests__/login/oidc/ClientRegistrar.spec.ts
+++ b/packages/browser/__tests__/login/oidc/ClientRegistrar.spec.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/__tests__/login/oidc/IssuerConfigFetcher.spec.ts
+++ b/packages/browser/__tests__/login/oidc/IssuerConfigFetcher.spec.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/__tests__/login/oidc/OidcLoginHandler.spec.ts
+++ b/packages/browser/__tests__/login/oidc/OidcLoginHandler.spec.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/__tests__/login/oidc/Redirector.spec.ts
+++ b/packages/browser/__tests__/login/oidc/Redirector.spec.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/__tests__/login/oidc/TokenRequester.spec.ts
+++ b/packages/browser/__tests__/login/oidc/TokenRequester.spec.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/__tests__/login/oidc/oidcHandlers/AuthorizationCodeWithPkceOidcHandler.spec.ts
+++ b/packages/browser/__tests__/login/oidc/oidcHandlers/AuthorizationCodeWithPkceOidcHandler.spec.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/__tests__/login/oidc/oidcHandlers/LegacyImplicitFlowOIDCHandler.spec.ts
+++ b/packages/browser/__tests__/login/oidc/oidcHandlers/LegacyImplicitFlowOIDCHandler.spec.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/__tests__/login/oidc/oidcHandlers/OidcHandlerCanHandleTests.ts
+++ b/packages/browser/__tests__/login/oidc/oidcHandlers/OidcHandlerCanHandleTests.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/__tests__/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
+++ b/packages/browser/__tests__/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/__tests__/login/oidc/redirectHandler/GeneralRedirectHandler.spec.ts
+++ b/packages/browser/__tests__/login/oidc/redirectHandler/GeneralRedirectHandler.spec.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/__tests__/login/oidc/redirectHandler/TokenSaver.spec.ts
+++ b/packages/browser/__tests__/login/oidc/redirectHandler/TokenSaver.spec.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/__tests__/login/oidc/refresh/TokenRefresher.spec.ts
+++ b/packages/browser/__tests__/login/oidc/refresh/TokenRefresher.spec.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/__tests__/login/popUp/PopUpLoginHandler.spec.ts
+++ b/packages/browser/__tests__/login/popUp/PopUpLoginHandler.spec.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/__tests__/logout/GeneralLogoutHandler.spec.ts
+++ b/packages/browser/__tests__/logout/GeneralLogoutHandler.spec.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/__tests__/sessionInfo/SessionInfoManager.spec.ts
+++ b/packages/browser/__tests__/sessionInfo/SessionInfoManager.spec.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/__tests__/storage/InMemoryStorage.spec.ts
+++ b/packages/browser/__tests__/storage/InMemoryStorage.spec.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/__tests__/util/Fetcher.spec.ts
+++ b/packages/browser/__tests__/util/Fetcher.spec.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/__tests__/util/UUIDGenerator.spec.ts
+++ b/packages/browser/__tests__/util/UUIDGenerator.spec.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/__tests__/util/UrlRepresentationConverter.spec.ts
+++ b/packages/browser/__tests__/util/UrlRepresentationConverter.spec.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/__tests__/util/handlerPattern/AggregateHandler.spec.ts
+++ b/packages/browser/__tests__/util/handlerPattern/AggregateHandler.spec.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/src/ClientAuthentication.ts
+++ b/packages/browser/src/ClientAuthentication.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/src/Session.ts
+++ b/packages/browser/src/Session.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/src/SessionManager.ts
+++ b/packages/browser/src/SessionManager.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/src/authenticatedFetch/AggregateAuthenticatedFetcher.ts
+++ b/packages/browser/src/authenticatedFetch/AggregateAuthenticatedFetcher.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/src/authenticatedFetch/AutomaticRefreshFetcher.ts
+++ b/packages/browser/src/authenticatedFetch/AutomaticRefreshFetcher.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/src/authenticatedFetch/__mocks__/AuthenticatedFetcher.ts
+++ b/packages/browser/src/authenticatedFetch/__mocks__/AuthenticatedFetcher.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/src/authenticatedFetch/bearer/BearerAuthenticatedFetcher.ts
+++ b/packages/browser/src/authenticatedFetch/bearer/BearerAuthenticatedFetcher.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/src/authenticatedFetch/dpop/DpopAuthenticatedFetcher.ts
+++ b/packages/browser/src/authenticatedFetch/dpop/DpopAuthenticatedFetcher.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/src/authenticatedFetch/headers/HeadersUtils.ts
+++ b/packages/browser/src/authenticatedFetch/headers/HeadersUtils.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/src/authenticatedFetch/unauthenticated/UnauthenticatedFetcher.ts
+++ b/packages/browser/src/authenticatedFetch/unauthenticated/UnauthenticatedFetcher.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/src/dependencies.ts
+++ b/packages/browser/src/dependencies.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/src/dpop/DpopClientKeyManager.ts
+++ b/packages/browser/src/dpop/DpopClientKeyManager.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/src/dpop/DpopHeaderCreator.ts
+++ b/packages/browser/src/dpop/DpopHeaderCreator.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/src/dpop/JwkSchema.ts
+++ b/packages/browser/src/dpop/JwkSchema.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/src/dpop/__mocks__/DpopClientKeyManager.ts
+++ b/packages/browser/src/dpop/__mocks__/DpopClientKeyManager.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/src/dpop/__mocks__/DpopHeaderCreator.ts
+++ b/packages/browser/src/dpop/__mocks__/DpopHeaderCreator.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/src/errors/ConfigurationError.ts
+++ b/packages/browser/src/errors/ConfigurationError.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/src/errors/HandlerNotFoundError.ts
+++ b/packages/browser/src/errors/HandlerNotFoundError.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/src/errors/NotImplementedError.ts
+++ b/packages/browser/src/errors/NotImplementedError.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/src/index.browser.ts
+++ b/packages/browser/src/index.browser.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/src/jose/IJoseUtility.ts
+++ b/packages/browser/src/jose/IJoseUtility.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/src/jose/IsomorphicJoseUtility.ts
+++ b/packages/browser/src/jose/IsomorphicJoseUtility.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/src/jose/__mocks__/JoseUtility.ts
+++ b/packages/browser/src/jose/__mocks__/JoseUtility.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/src/login/AggregateLoginHandler.ts
+++ b/packages/browser/src/login/AggregateLoginHandler.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/src/login/__mocks__/LoginHandler.ts
+++ b/packages/browser/src/login/__mocks__/LoginHandler.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/src/login/oidc/AggregateOidcHandler.ts
+++ b/packages/browser/src/login/oidc/AggregateOidcHandler.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/src/login/oidc/ClientRegistrar.ts
+++ b/packages/browser/src/login/oidc/ClientRegistrar.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/src/login/oidc/IssuerConfigFetcher.ts
+++ b/packages/browser/src/login/oidc/IssuerConfigFetcher.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/src/login/oidc/OidcLoginHandler.ts
+++ b/packages/browser/src/login/oidc/OidcLoginHandler.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/src/login/oidc/Redirector.ts
+++ b/packages/browser/src/login/oidc/Redirector.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/src/login/oidc/TokenRequester.ts
+++ b/packages/browser/src/login/oidc/TokenRequester.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/src/login/oidc/__mocks__/ClientRegistrar.ts
+++ b/packages/browser/src/login/oidc/__mocks__/ClientRegistrar.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/src/login/oidc/__mocks__/IOidcHandler.ts
+++ b/packages/browser/src/login/oidc/__mocks__/IOidcHandler.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/src/login/oidc/__mocks__/IOidcOptions.ts
+++ b/packages/browser/src/login/oidc/__mocks__/IOidcOptions.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/src/login/oidc/__mocks__/IssuerConfigFetcher.ts
+++ b/packages/browser/src/login/oidc/__mocks__/IssuerConfigFetcher.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/src/login/oidc/__mocks__/Redirector.ts
+++ b/packages/browser/src/login/oidc/__mocks__/Redirector.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/src/login/oidc/__mocks__/TokenRequester.ts
+++ b/packages/browser/src/login/oidc/__mocks__/TokenRequester.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/src/login/oidc/oidcHandlers/AuthorizationCodeOidcHandler.ts
+++ b/packages/browser/src/login/oidc/oidcHandlers/AuthorizationCodeOidcHandler.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/src/login/oidc/oidcHandlers/AuthorizationCodeWithPkceOidcHandler.ts
+++ b/packages/browser/src/login/oidc/oidcHandlers/AuthorizationCodeWithPkceOidcHandler.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.ts
+++ b/packages/browser/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/src/login/oidc/oidcHandlers/LegacyImplicitFlowOidcHandler.ts
+++ b/packages/browser/src/login/oidc/oidcHandlers/LegacyImplicitFlowOidcHandler.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/src/login/oidc/oidcHandlers/PrimaryDeviceOidcHandler.ts
+++ b/packages/browser/src/login/oidc/oidcHandlers/PrimaryDeviceOidcHandler.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/src/login/oidc/oidcHandlers/RefreshTokenOidcHandler.ts
+++ b/packages/browser/src/login/oidc/oidcHandlers/RefreshTokenOidcHandler.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/src/login/oidc/oidcHandlers/SecondaryDeviceOidcHandler.ts
+++ b/packages/browser/src/login/oidc/oidcHandlers/SecondaryDeviceOidcHandler.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/src/login/oidc/redirectHandler/AggregateRedirectHandler.ts
+++ b/packages/browser/src/login/oidc/redirectHandler/AggregateRedirectHandler.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
+++ b/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/src/login/oidc/redirectHandler/GeneralRedirectHandler.ts
+++ b/packages/browser/src/login/oidc/redirectHandler/GeneralRedirectHandler.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/src/login/oidc/redirectHandler/InactionRedirectHandler.ts
+++ b/packages/browser/src/login/oidc/redirectHandler/InactionRedirectHandler.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/src/login/oidc/redirectHandler/TokenSaver.ts
+++ b/packages/browser/src/login/oidc/redirectHandler/TokenSaver.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/src/login/oidc/redirectHandler/__mocks__/RedirectHandler.ts
+++ b/packages/browser/src/login/oidc/redirectHandler/__mocks__/RedirectHandler.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/src/login/oidc/redirectHandler/__mocks__/TokenSaver.ts
+++ b/packages/browser/src/login/oidc/redirectHandler/__mocks__/TokenSaver.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/src/login/oidc/refresh/TokenRefresher.ts
+++ b/packages/browser/src/login/oidc/refresh/TokenRefresher.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/src/login/popUp/AggregatePostPopUpLoginHandler.ts
+++ b/packages/browser/src/login/popUp/AggregatePostPopUpLoginHandler.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/src/login/popUp/PopUpLoginHandler.ts
+++ b/packages/browser/src/login/popUp/PopUpLoginHandler.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/src/login/webid/WebidLoginHandler.ts
+++ b/packages/browser/src/login/webid/WebidLoginHandler.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/src/logout/GeneralLogoutHandler.ts
+++ b/packages/browser/src/logout/GeneralLogoutHandler.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/src/logout/__mocks__/LogoutHandler.ts
+++ b/packages/browser/src/logout/__mocks__/LogoutHandler.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/src/sessionInfo/SessionInfoManager.ts
+++ b/packages/browser/src/sessionInfo/SessionInfoManager.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/src/sessionInfo/__mocks__/SessionInfoManager.ts
+++ b/packages/browser/src/sessionInfo/__mocks__/SessionInfoManager.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/src/storage/BrowserStorage.ts
+++ b/packages/browser/src/storage/BrowserStorage.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/src/storage/InMemoryStorage.ts
+++ b/packages/browser/src/storage/InMemoryStorage.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/src/storage/StorageUtility.ts
+++ b/packages/browser/src/storage/StorageUtility.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/src/util/EnvironmentDetector.ts
+++ b/packages/browser/src/util/EnvironmentDetector.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/src/util/Fetcher.ts
+++ b/packages/browser/src/util/Fetcher.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/src/util/UrlRepresenationConverter.ts
+++ b/packages/browser/src/util/UrlRepresenationConverter.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/src/util/UuidGenerator.ts
+++ b/packages/browser/src/util/UuidGenerator.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/src/util/__mocks__/EnvironmentDetector.ts
+++ b/packages/browser/src/util/__mocks__/EnvironmentDetector.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/src/util/__mocks__/Fetcher.ts
+++ b/packages/browser/src/util/__mocks__/Fetcher.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/src/util/__mocks__/UrlRepresentationConverter.ts
+++ b/packages/browser/src/util/__mocks__/UrlRepresentationConverter.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/src/util/__mocks__/UuidGenerator.ts
+++ b/packages/browser/src/util/__mocks__/UuidGenerator.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/browser/src/util/handlerPattern/AggregateHandler.ts
+++ b/packages/browser/src/util/handlerPattern/AggregateHandler.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/core/__tests__/util/StorageUtility.spec.ts
+++ b/packages/core/__tests__/util/StorageUtility.spec.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/core/__tests__/util/validateSchema.spec.ts
+++ b/packages/core/__tests__/util/validateSchema.spec.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/core/src/ILoginInputOptions.ts
+++ b/packages/core/src/ILoginInputOptions.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/core/src/authenticatedFetch/IAuthenticatedFetcher.ts
+++ b/packages/core/src/authenticatedFetch/IAuthenticatedFetcher.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/core/src/authenticatedFetch/IRequestCredentials.ts
+++ b/packages/core/src/authenticatedFetch/IRequestCredentials.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/core/src/dpop/IDpopRequestCredentials.ts
+++ b/packages/core/src/dpop/IDpopRequestCredentials.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/core/src/login/ILoginHandler.ts
+++ b/packages/core/src/login/ILoginHandler.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/core/src/login/ILoginOptions.ts
+++ b/packages/core/src/login/ILoginOptions.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/core/src/login/oidc/IClient.ts
+++ b/packages/core/src/login/oidc/IClient.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/core/src/login/oidc/IClientRegistrar.ts
+++ b/packages/core/src/login/oidc/IClientRegistrar.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/core/src/login/oidc/IIssuerConfig.ts
+++ b/packages/core/src/login/oidc/IIssuerConfig.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/core/src/login/oidc/IIssuerConfigFetcher.ts
+++ b/packages/core/src/login/oidc/IIssuerConfigFetcher.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/core/src/login/oidc/IOidcHandler.ts
+++ b/packages/core/src/login/oidc/IOidcHandler.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/core/src/login/oidc/IOidcOptions.ts
+++ b/packages/core/src/login/oidc/IOidcOptions.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/core/src/login/oidc/IRedirector.ts
+++ b/packages/core/src/login/oidc/IRedirector.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/core/src/login/oidc/issuerConfigSchema.ts
+++ b/packages/core/src/login/oidc/issuerConfigSchema.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/core/src/login/oidc/redirectHandler/IRedirectHandler.ts
+++ b/packages/core/src/login/oidc/redirectHandler/IRedirectHandler.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/core/src/logout/ILogoutHandler.ts
+++ b/packages/core/src/logout/ILogoutHandler.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/core/src/sessionInfo/ISessionInfo.ts
+++ b/packages/core/src/sessionInfo/ISessionInfo.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/core/src/sessionInfo/ISessionInfoManager.ts
+++ b/packages/core/src/sessionInfo/ISessionInfoManager.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/core/src/storage/IStorage.ts
+++ b/packages/core/src/storage/IStorage.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/core/src/storage/IStorageUtility.ts
+++ b/packages/core/src/storage/IStorageUtility.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/core/src/storage/StorageUtility.ts
+++ b/packages/core/src/storage/StorageUtility.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/core/src/storage/__mocks__/StorageUtility.ts
+++ b/packages/core/src/storage/__mocks__/StorageUtility.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/core/src/util/handlerPattern/IHandleable.ts
+++ b/packages/core/src/util/handlerPattern/IHandleable.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/core/src/util/validateSchema.ts
+++ b/packages/core/src/util/validateSchema.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/packages/oidc-dpop-client-browser/src/index.ts
+++ b/packages/oidc-dpop-client-browser/src/index.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/resources/license-header.js
+++ b/resources/license-header.js
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
~~Since we only really want people to import from the top-level,
the modules don't provide any relevant additional information.

This is a draft PR to trigger a preview deployment. After I've verified that it looks as expected, I will mark it as ready to review.~~

This PR makes sure that the Inrupt copyright notice isn't includes in the API docs.

(Initially I wanted to just remove the modules pages altogether, but it seems that that also removes the non-module pages, and it doesn't seem worth the effort at this time to investigate why that is the case.)

# Checklist

- [ ] All acceptance criteria are met. N/A
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
