### PR TITLE
Fix/apply travis fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### Bugfixes
 
 - Source files are now also published to npm, so source maps should work from now on.
+- Fixed typo in `detachSession` function name for the browser `SessionManager`.
 
 ## [0.1.4] - 2020-09-11
 

--- a/packages/browser/src/SessionManager.ts
+++ b/packages/browser/src/SessionManager.ts
@@ -181,7 +181,7 @@ export class SessionManager extends EventEmitter {
    *
    * @param sessionId A unique session identifier.
    */
-  detatchSession(sessionId: string): void {
+  detachSession(sessionId: string): void {
     const sessionRecord = this.sessionRecords[sessionId];
     if (sessionRecord) {
       sessionRecord.session.removeListener(


### PR DESCRIPTION
Replace `detatchSession` by `detachSession`.

This supersedes https://github.com/inrupt/solid-client-authn-js/pull/277, which has been pending for a while because of CI issues unrelated to the content of the contribution.

Again, thanks for the contribution @travis, and thanks for the patience :)

- [X] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).