### PR TITLE
Refactored crypto/DPoP to be available as standalone functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,6 @@ build/
 
 # Rollup-built code
 umd/
+
+# Ignore license checker output
+licenses.csv

--- a/packages/browser/__tests__/dpop/DpopHeaderCreator.spec.ts
+++ b/packages/browser/__tests__/dpop/DpopHeaderCreator.spec.ts
@@ -36,9 +36,9 @@ import { decodeJWT, generateJWK } from "../../src/jose/IsomorphicJoseUtility";
 describe("normalizeHtu", () => {
   [
     {
-      it: "should add a /  if missing at the end of the url",
+      it: "should not add a / if not present at the end of the url",
       url: new URL("https://audience.com"),
-      expected: "https://audience.com/",
+      expected: "https://audience.com",
     },
     {
       it: "should not change a URL with a slash at the end",
@@ -48,7 +48,7 @@ describe("normalizeHtu", () => {
     {
       it: "should not include queries",
       url: new URL("https://audience.com?cool=stuff&dope=things"),
-      expected: "https://audience.com/",
+      expected: "https://audience.com",
     },
     {
       it: "should not include queries but still include a slash",
@@ -58,7 +58,7 @@ describe("normalizeHtu", () => {
     {
       it: "should not include hash",
       url: new URL("https://audience.com#throwBackThursday"),
-      expected: "https://audience.com/",
+      expected: "https://audience.com",
     },
     {
       it: "should not include hash but include the slash",
@@ -68,17 +68,17 @@ describe("normalizeHtu", () => {
     {
       it: "should include the path",
       url: new URL("https://audience.com/path"),
-      expected: "https://audience.com/path/",
+      expected: "https://audience.com/path",
     },
     {
       it: "should not include the username and password",
       url: new URL("https://jackson:badpassword@audience.com"),
-      expected: "https://audience.com/",
+      expected: "https://audience.com",
     },
     {
       it: "should include ports",
       url: new URL("https://localhost:8080/path"),
-      expected: "https://localhost:8080/path/",
+      expected: "https://localhost:8080/path",
     },
   ].forEach((test) => {
     it(test.it, () => {

--- a/packages/browser/__tests__/dpop/DpopHeaderCreator.spec.ts
+++ b/packages/browser/__tests__/dpop/DpopHeaderCreator.spec.ts
@@ -38,7 +38,7 @@ describe("normalizeHtu", () => {
     {
       it: "should add a /  if missing at the end of the url",
       url: new URL("https://audience.com"),
-      expected: "https://audience.com",
+      expected: "https://audience.com/",
     },
     {
       it: "should not change a URL with a slash at the end",
@@ -48,7 +48,7 @@ describe("normalizeHtu", () => {
     {
       it: "should not include queries",
       url: new URL("https://audience.com?cool=stuff&dope=things"),
-      expected: "https://audience.com",
+      expected: "https://audience.com/",
     },
     {
       it: "should not include queries but still include a slash",
@@ -58,7 +58,7 @@ describe("normalizeHtu", () => {
     {
       it: "should not include hash",
       url: new URL("https://audience.com#throwBackThursday"),
-      expected: "https://audience.com",
+      expected: "https://audience.com/",
     },
     {
       it: "should not include hash but include the slash",
@@ -68,17 +68,17 @@ describe("normalizeHtu", () => {
     {
       it: "should include the path",
       url: new URL("https://audience.com/path"),
-      expected: "https://audience.com/path",
+      expected: "https://audience.com/path/",
     },
     {
       it: "should not include the username and password",
       url: new URL("https://jackson:badpassword@audience.com"),
-      expected: "https://audience.com",
+      expected: "https://audience.com/",
     },
     {
       it: "should include ports",
       url: new URL("https://localhost:8080/path"),
-      expected: "https://localhost:8080/path",
+      expected: "https://localhost:8080/path/",
     },
   ].forEach((test) => {
     it(test.it, () => {

--- a/packages/browser/__tests__/jose/IsomorphicJoseUtility.test.ts
+++ b/packages/browser/__tests__/jose/IsomorphicJoseUtility.test.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { describe, it } from "@jest/globals";
+import {
+  decodeJWT,
+  generateCodeVerifier,
+  generateJWK,
+  signJWT,
+} from "../../src/jose/IsomorphicJoseUtility";
+
+describe("generateJWK", () => {
+  it("can generate a RSA-based JWK", async () => {
+    const key = await generateJWK("RSA");
+    expect(key.kty).toEqual("RSA");
+  });
+
+  it("can generate an elliptic curve-based JWK", async () => {
+    const key = await generateJWK("EC", "P-256");
+    expect(key.kty).toEqual("EC");
+  });
+});
+
+describe("signJWT/decodeJWT", () => {
+  it("generates a JWT that can be decoded without signature verification", async () => {
+    const key = await generateJWK("RSA");
+    const payload = { testClaim: "testValue" };
+    const jwt = await signJWT(payload, key, { algorithm: "RS256" });
+    const decoded = await decodeJWT(jwt);
+    expect(decoded.testClaim).toEqual(payload.testClaim);
+  });
+
+  it("can verify the RSA signature of the generated JWT", async () => {
+    const key = await generateJWK("RSA");
+    const payload = { testClaim: "testValue" };
+    const jwt = await signJWT(payload, key, { algorithm: "RS256" });
+    const decoded = await decodeJWT(jwt, key, { algorithms: ["RS256"] });
+    expect(decoded.testClaim).toEqual(payload.testClaim);
+  });
+
+  it("can verify the ES256 signature of the generated JWT", async () => {
+    const key = await generateJWK("EC", "P-256", { alg: "ES256" });
+    const payload = { testClaim: "testValue" };
+    const jwt = await signJWT(payload, key, { algorithm: "ES256" });
+    const decoded = await decodeJWT(jwt, key, { algorithms: ["ES256"] });
+    expect(decoded.testClaim).toEqual(payload.testClaim);
+  });
+});
+
+describe("generateCodeVerifier", () => {
+  it("generates a different string on each call", async () => {
+    expect(await generateCodeVerifier()).not.toEqual(
+      await generateCodeVerifier()
+    );
+  });
+});

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -26,7 +26,7 @@
     "lint": "eslint \"src/**/*.ts\" && eslint \"__tests__/**/*.ts\"",
     "lint-fix": "eslint --fix \"src/**\" && eslint --fix \"__tests__/**/*.ts\"",
     "format": "prettier --write \"src/**\" \"__tests__/**\"",
-    "licenses": "license-checker --production --failOn \"AGPL-1.0-only; AGPL-1.0-or-later; AGPL-3.0-only; AGPL-3.0-or-later; Beerware; CC-BY-NC-1.0; CC-BY-NC-2.0; CC-BY-NC-2.5; CC-BY-NC-3.0; CC-BY-NC-4.0; CC-BY-NC-ND-1.0; CC-BY-NC-ND-2.0; CC-BY-NC-ND-2.5; CC-BY-NC-ND-3.0; CC-BY-NC-ND-4.0; CC-BY-NC-SA-1.0; CC-BY-NC-SA-2.0; CC-BY-NC-SA-2.5; CC-BY-NC-SA-3.0; CC-BY-NC-SA-4.0; CPAL-1.0; EUPL-1.0; EUPL-1.1; EUPL-1.1;  GPL-1.0-only; GPL-1.0-or-later; GPL-2.0-only;  GPL-2.0-or-later; GPL-3.0; GPL-3.0-only; GPL-3.0-or-later; SISSL;  SISSL-1.2; WTFPL\"",
+    "licenses": "license-checker --production --csv --out licenses.csv --failOn \"AGPL-1.0-only; AGPL-1.0-or-later; AGPL-3.0-only; AGPL-3.0-or-later; Beerware; CC-BY-NC-1.0; CC-BY-NC-2.0; CC-BY-NC-2.5; CC-BY-NC-3.0; CC-BY-NC-4.0; CC-BY-NC-ND-1.0; CC-BY-NC-ND-2.0; CC-BY-NC-ND-2.5; CC-BY-NC-ND-3.0; CC-BY-NC-ND-4.0; CC-BY-NC-SA-1.0; CC-BY-NC-SA-2.0; CC-BY-NC-SA-2.5; CC-BY-NC-SA-3.0; CC-BY-NC-SA-4.0; CPAL-1.0; EUPL-1.0; EUPL-1.1; EUPL-1.1;  GPL-1.0-only; GPL-1.0-or-later; GPL-2.0-only;  GPL-2.0-or-later; GPL-3.0; GPL-3.0-only; GPL-3.0-or-later; SISSL;  SISSL-1.2; WTFPL\"",
     "dev": "tsc-watch --preserveWatchOutput --noClear",
     "dev-server": "concurrently \"npm run dev\" \"npm run dev-test-helper\" \"cd examples/server && npm run dev\"",
     "dev-script": "concurrently \"npm run dev\" \"npm run dev-test-helper\" \"cd examples/script && npm run dev\"",

--- a/packages/browser/src/dpop/DpopHeaderCreator.ts
+++ b/packages/browser/src/dpop/DpopHeaderCreator.ts
@@ -52,9 +52,7 @@ export interface IDpopHeaderCreator {
  * @hidden
  */
 export function normalizeHtu(audience: URL): string {
-  return `${audience.origin}${audience.pathname}${
-    audience.pathname.endsWith("/") ? "" : "/"
-  }`;
+  return `${audience.origin}${audience.pathname}`;
 }
 
 /**

--- a/packages/browser/src/dpop/DpopHeaderCreator.ts
+++ b/packages/browser/src/dpop/DpopHeaderCreator.ts
@@ -32,6 +32,9 @@ import { inject, injectable } from "tsyringe";
 import IJoseUtility from "../jose/IJoseUtility";
 import { IDpopClientKeyManager } from "./DpopClientKeyManager";
 import { IUuidGenerator } from "../util/UuidGenerator";
+import { privateJWKToPublicJWK, signJWT } from "../jose/IsomorphicJoseUtility";
+import { v4 } from "uuid";
+import { JSONWebKey } from "jose";
 
 export interface IDpopHeaderCreator {
   /**
@@ -40,6 +43,49 @@ export interface IDpopHeaderCreator {
    * @param method The HTTP method that is being used
    */
   createHeaderToken(audience: URL, method: string): Promise<string>;
+}
+
+/**
+ * Normalizes a URL in order to generate the DPoP token based on a consistent scheme.
+ * @param audience The URL to normalize.
+ * @returns The normalized URL as a string.
+ * @hidden
+ */
+export function normalizeHtu(audience: URL): string {
+  return `${audience.origin}${audience.pathname}${
+    audience.pathname.endsWith("/") ? "" : "/"
+  }`;
+}
+
+/**
+ * Creates a DPoP header according to https://tools.ietf.org/html/draft-fett-oauth-dpop-04,
+ * based on the target URL and method, using the provided key.
+ * @param audience Target URL.
+ * @param method HTTP method allowed.
+ * @param key Key used to sign the token.
+ * @returns A JWT that can be used as a DPoP Authorization header.
+ */
+export async function createHeaderToken(
+  audience: URL,
+  method: string,
+  key: JSONWebKey
+): Promise<string> {
+  return signJWT(
+    {
+      htu: normalizeHtu(audience),
+      htm: method,
+      jti: v4(),
+    },
+    key,
+    {
+      header: {
+        jwk: privateJWKToPublicJWK(key),
+        typ: "dpop+jwt",
+      },
+      expiresIn: "1 hour",
+      algorithm: "ES256",
+    }
+  );
 }
 
 /**
@@ -54,9 +100,7 @@ export default class DpopHeaderCreator implements IDpopHeaderCreator {
     @inject("uuidGenerator") private uuidGenerator: IUuidGenerator
   ) {}
 
-  public normalizeHtu(audience: URL): string {
-    return `${audience.origin}${audience.pathname}`;
-  }
+  public normalizeHtu = normalizeHtu;
 
   async createHeaderToken(audience: URL, method: string): Promise<string> {
     // TODO: update for multiple signing abilities
@@ -65,23 +109,6 @@ export default class DpopHeaderCreator implements IDpopHeaderCreator {
     if (clientKey === undefined) {
       throw new Error("Could not obtain the key to sign the token with.");
     }
-
-    return this.joseUtility.signJWT(
-      {
-        // TODO: should add a slash at the end if none is present
-        htu: this.normalizeHtu(audience),
-        htm: method,
-        jti: this.uuidGenerator.v4(),
-      },
-      clientKey,
-      {
-        header: {
-          jwk: await this.joseUtility.privateJWKToPublicJWK(clientKey),
-          typ: "dpop+jwt",
-        },
-        expiresIn: "1 hour",
-        algorithm: "ES256",
-      }
-    );
+    return createHeaderToken(audience, method, clientKey);
   }
 }

--- a/packages/browser/src/dpop/__mocks__/DpopClientKeyManager.ts
+++ b/packages/browser/src/dpop/__mocks__/DpopClientKeyManager.ts
@@ -40,7 +40,7 @@ export const mockDpopClientKeyManager = (
 ): IDpopClientKeyManager => {
   return {
     // eslint-disable-next-line @typescript-eslint/no-empty-function
-    generateClientKeyIfNotAlready: async (): Promise<void> => {},
+    generateClientKeyIfNotAlready: () => Promise.resolve(),
     getClientKey: async (): Promise<JSONWebKey | undefined> => key,
   };
 };

--- a/packages/browser/src/dpop/__mocks__/DpopClientKeyManager.ts
+++ b/packages/browser/src/dpop/__mocks__/DpopClientKeyManager.ts
@@ -40,7 +40,7 @@ export const mockDpopClientKeyManager = (
 ): IDpopClientKeyManager => {
   return {
     // eslint-disable-next-line @typescript-eslint/no-empty-function
-    generateClientKeyIfNotAlready: () => Promise.resolve(),
+    generateClientKeyIfNotAlready: (): Promise<void> => Promise.resolve(),
     getClientKey: async (): Promise<JSONWebKey | undefined> => key,
   };
 };

--- a/packages/browser/src/dpop/__mocks__/DpopClientKeyManager.ts
+++ b/packages/browser/src/dpop/__mocks__/DpopClientKeyManager.ts
@@ -34,3 +34,13 @@ export const DpopClientKeyManagerMock: jest.Mocked<IDpopClientKeyManager> = {
     async () => DpopClientKeyManagerMockGetClientKeyResponse
   ),
 };
+
+export const mockDpopClientKeyManager = (
+  key: JSONWebKey | undefined
+): IDpopClientKeyManager => {
+  return {
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    generateClientKeyIfNotAlready: async (): Promise<void> => {},
+    getClientKey: async (): Promise<JSONWebKey | undefined> => key,
+  };
+};

--- a/packages/browser/src/jose/IsomorphicJoseUtility.ts
+++ b/packages/browser/src/jose/IsomorphicJoseUtility.ts
@@ -39,59 +39,121 @@ import {
   JSONWebKey,
 } from "jose";
 import { JWK } from "node-jose";
-import JWT from "jsonwebtoken";
+import JWT, { VerifyOptions } from "jsonwebtoken";
 import IJoseUtility from "./IJoseUtility";
 import randomString from "crypto-random-string";
 import crypto from "crypto";
 
 /**
+ * Generates a Json Web Key
+ * @param kty Key type
+ * @param crvBitlength Curve length (nly relevant for elliptic curve algorithms)
+ * @param parameters
+ */
+export async function generateJWK(
+  kty: "EC" | "OKP" | "RSA" | "oct",
+  crvBitlength?: ECCurve | OKPCurve | number,
+  parameters?: BasicParameters
+): Promise<JSONWebKey> {
+  const key = await JWK.createKey(kty, crvBitlength, parameters);
+  return key.toJSON(true) as JSONWebKey;
+}
+
+/**
+ * Generates a Json Web Token (https://tools.ietf.org/html/rfc7519) containing
+ * the provided payload and using the signature algorithm specified in the options.
+ * @param payload The body of the JWT.
+ * @param key The key used for the signature.
+ * @param options
+ * @returns a 3-parts base64-encoded string, split by dots.
+ * @hidden
+ */
+export async function signJWT(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  payload: Record<string, any>,
+  key: JWKECKey | JWKOKPKey | JWKRSAKey | JWKOctKey,
+  options?: JoseJWT.SignOptions
+): Promise<string> {
+  const parsedKey = await JWK.asKey(key);
+  const convertedKey: string = parsedKey.toPEM(true);
+  const signed = JWT.sign(payload, convertedKey, {
+    ...(options as JWT.SignOptions),
+  });
+  return signed;
+}
+
+/**
+ * Decodes the base64 Json Web Token into an object. If a key is specified, the
+ * JWT is also verified.
+ * @param token The base64-encoded token
+ * @param key The key used to sign the token
+ * @returns the payload of the JWT
+ * @hidden
+ */
+export async function decodeJWT(
+  token: string,
+  key?: JWKECKey | JWKOKPKey | JWKRSAKey | JWKOctKey,
+  options?: VerifyOptions
+): Promise<Record<string, unknown>> {
+  if (key) {
+    const parsedKey = await JWK.asKey(key);
+    const convertedKey: string = parsedKey.toPEM(true);
+    return JWT.verify(token, convertedKey, options) as Promise<
+      Record<string, unknown>
+    >;
+  }
+  return JWT.decode(token) as Promise<Record<string, unknown>>;
+}
+
+/**
+ * @param key
+ * @hidden
+ */
+export async function privateJWKToPublicJWK(
+  key: JSONWebKey
+): Promise<JSONWebKey> {
+  return (await JWK.asKey(key as JWK.RawKey, "public")) as JSONWebKey;
+}
+
+/**
+ * Generates a PKCE (https://tools.ietf.org/html/rfc7636) token.
+ * @returns A random string usable as a code verifier.
+ * @hidden
+ */
+export async function generateCodeVerifier(): Promise<string> {
+  return randomString({ length: 10, type: "base64" });
+}
+
+/**
+ * Hashes the code verifier to create a code challenge.
+ * @param verifier A PKCE token.
+ * @returns A SHA-256 hash of the input token.
+ * @hidden
+ */
+export async function generateCodeChallenge(verifier: string): Promise<string> {
+  const hash = crypto.createHash("sha256");
+  hash.update(verifier);
+  return hash
+    .digest()
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=/g, "");
+}
+
+/**
  * @hidden
  */
 export default class IsomorphicJoseUtility implements IJoseUtility {
-  async generateJWK(
-    kty: "EC" | "OKP" | "RSA" | "oct",
-    crvBitlength?: ECCurve | OKPCurve | number,
-    parameters?: BasicParameters
-  ): Promise<JSONWebKey> {
-    const key = await JWK.createKey(kty, crvBitlength, parameters);
-    return key.toJSON(true) as JSONWebKey;
-  }
+  generateJWK = generateJWK;
 
-  async signJWT(
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    payload: Record<string, any>,
-    key: JWKECKey | JWKOKPKey | JWKRSAKey | JWKOctKey,
-    options?: JoseJWT.SignOptions
-  ): Promise<string> {
-    const parsedKey = await JWK.asKey(key);
-    const convertedKey: string = parsedKey.toPEM(true);
-    const signed = JWT.sign(payload, convertedKey, {
-      ...(options as JWT.SignOptions),
-    });
-    return signed;
-  }
+  signJWT = signJWT;
 
-  // TODO: also should have functionality to validate the token
-  async decodeJWT(token: string): Promise<Record<string, unknown>> {
-    return JWT.decode(token) as Promise<Record<string, unknown>>;
-  }
+  decodeJWT = decodeJWT;
 
-  async privateJWKToPublicJWK(key: JSONWebKey): Promise<JSONWebKey> {
-    return (await JWK.asKey(key as JWK.RawKey, "public")) as JSONWebKey;
-  }
+  privateJWKToPublicJWK = privateJWKToPublicJWK;
 
-  async generateCodeVerifier(): Promise<string> {
-    return randomString({ length: 10, type: "base64" });
-  }
+  generateCodeVerifier = generateCodeVerifier;
 
-  async generateCodeChallenge(verifier: string): Promise<string> {
-    const hash = crypto.createHash("sha256");
-    hash.update(verifier);
-    return hash
-      .digest()
-      .toString("base64")
-      .replace(/\+/g, "-")
-      .replace(/\//g, "_")
-      .replace(/=/g, "");
-  }
+  generateCodeChallenge = generateCodeChallenge;
 }

--- a/packages/browser/src/jose/IsomorphicJoseUtility.ts
+++ b/packages/browser/src/jose/IsomorphicJoseUtility.ts
@@ -97,7 +97,7 @@ export async function decodeJWT(
 ): Promise<Record<string, unknown>> {
   if (key) {
     const parsedKey = await JWK.asKey(key);
-    const convertedKey: string = parsedKey.toPEM(true);
+    const convertedKey: string = parsedKey.toPEM(false);
     return JWT.verify(token, convertedKey, options) as Promise<
       Record<string, unknown>
     >;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,7 +16,7 @@
     "lint": "eslint \"src/**/*.ts\" && eslint \"__tests__/**/*.ts\"",
     "lint-fix": "eslint --fix \"src/**\" && eslint --fix \"__tests__/**/*.ts\"",
     "format": "prettier --write \"src/**\" \"__tests__/**\"",
-    "licenses": "license-checker --production --failOn \"AGPL-1.0-only; AGPL-1.0-or-later; AGPL-3.0-only; AGPL-3.0-or-later; Beerware; CC-BY-NC-1.0; CC-BY-NC-2.0; CC-BY-NC-2.5; CC-BY-NC-3.0; CC-BY-NC-4.0; CC-BY-NC-ND-1.0; CC-BY-NC-ND-2.0; CC-BY-NC-ND-2.5; CC-BY-NC-ND-3.0; CC-BY-NC-ND-4.0; CC-BY-NC-SA-1.0; CC-BY-NC-SA-2.0; CC-BY-NC-SA-2.5; CC-BY-NC-SA-3.0; CC-BY-NC-SA-4.0; CPAL-1.0; EUPL-1.0; EUPL-1.1; EUPL-1.1;  GPL-1.0-only; GPL-1.0-or-later; GPL-2.0-only;  GPL-2.0-or-later; GPL-3.0; GPL-3.0-only; GPL-3.0-or-later; SISSL;  SISSL-1.2; WTFPL\"",
+    "licenses": "license-checker --production --csv --out licenses.csv --failOn \"AGPL-1.0-only; AGPL-1.0-or-later; AGPL-3.0-only; AGPL-3.0-or-later; Beerware; CC-BY-NC-1.0; CC-BY-NC-2.0; CC-BY-NC-2.5; CC-BY-NC-3.0; CC-BY-NC-4.0; CC-BY-NC-ND-1.0; CC-BY-NC-ND-2.0; CC-BY-NC-ND-2.5; CC-BY-NC-ND-3.0; CC-BY-NC-ND-4.0; CC-BY-NC-SA-1.0; CC-BY-NC-SA-2.0; CC-BY-NC-SA-2.5; CC-BY-NC-SA-3.0; CC-BY-NC-SA-4.0; CPAL-1.0; EUPL-1.0; EUPL-1.1; EUPL-1.1;  GPL-1.0-only; GPL-1.0-or-later; GPL-2.0-only;  GPL-2.0-or-later; GPL-3.0; GPL-3.0-only; GPL-3.0-or-later; SISSL;  SISSL-1.2; WTFPL\"",
     "dev": "tsc-watch --preserveWatchOutput --noClear",
     "test": "npm run lint && npm run licenses && npm run test-unit",
     "test-unit": "jest --coverage --verbose",

--- a/packages/oidc-dpop-client-browser/package.json
+++ b/packages/oidc-dpop-client-browser/package.json
@@ -17,7 +17,7 @@
     "lint": "eslint \"src/**/*.ts\"",
     "lint-fix": "eslint --fix \"src/**\"",
     "format": "prettier --write \"src/**\" \"__tests__/**\"",
-    "licenses": "license-checker --production --failOn \"AGPL-1.0-only; AGPL-1.0-or-later; AGPL-3.0-only; AGPL-3.0-or-later; Beerware; CC-BY-NC-1.0; CC-BY-NC-2.0; CC-BY-NC-2.5; CC-BY-NC-3.0; CC-BY-NC-4.0; CC-BY-NC-ND-1.0; CC-BY-NC-ND-2.0; CC-BY-NC-ND-2.5; CC-BY-NC-ND-3.0; CC-BY-NC-ND-4.0; CC-BY-NC-SA-1.0; CC-BY-NC-SA-2.0; CC-BY-NC-SA-2.5; CC-BY-NC-SA-3.0; CC-BY-NC-SA-4.0; CPAL-1.0; EUPL-1.0; EUPL-1.1; EUPL-1.1;  GPL-1.0-only; GPL-1.0-or-later; GPL-2.0-only;  GPL-2.0-or-later; GPL-3.0; GPL-3.0-only; GPL-3.0-or-later; SISSL;  SISSL-1.2; WTFPL\"",
+    "licenses": "license-checker --csv --out licenses.csv --production --failOn \"AGPL-1.0-only; AGPL-1.0-or-later; AGPL-3.0-only; AGPL-3.0-or-later; Beerware; CC-BY-NC-1.0; CC-BY-NC-2.0; CC-BY-NC-2.5; CC-BY-NC-3.0; CC-BY-NC-4.0; CC-BY-NC-ND-1.0; CC-BY-NC-ND-2.0; CC-BY-NC-ND-2.5; CC-BY-NC-ND-3.0; CC-BY-NC-ND-4.0; CC-BY-NC-SA-1.0; CC-BY-NC-SA-2.0; CC-BY-NC-SA-2.5; CC-BY-NC-SA-3.0; CC-BY-NC-SA-4.0; CPAL-1.0; EUPL-1.0; EUPL-1.1; EUPL-1.1;  GPL-1.0-only; GPL-1.0-or-later; GPL-2.0-only;  GPL-2.0-or-later; GPL-3.0; GPL-3.0-only; GPL-3.0-or-later; SISSL;  SISSL-1.2; WTFPL\"",
     "test": "npm run lint && npm run licenses && npm run test-unit",
     "test-unit": "jest --coverage --verbose --passWithNoTests",
     "build-api-docs": "npx typedoc --out docs/api/source/api",


### PR DESCRIPTION
In order to build a fetch function with a token in its scope, it's easier not to depend on the DI framework to be able to generate the DPoP header, but to be able to simply call a function and to provide it the DPoP key.
This refactoring makes this possible, while remaining backward-compatible with the classes relying on DI to access crypto functions.

# Checklist

- [X] All acceptance criteria are met.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).