### PR TITLE
Fix/authorization headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### New features
 
+### Bugfixes
+
+- The Authorization header was not set properly, which made it impossible to access private resources.
+
 ## [0.2.0]
 
 ### Breaking changes

--- a/packages/browser/__tests__/ClientAuthentication.spec.ts
+++ b/packages/browser/__tests__/ClientAuthentication.spec.ts
@@ -34,6 +34,8 @@ import URL from "url-parse";
 import { mockStorageUtility } from "@inrupt/solid-client-authn-core";
 import { mockFetcher } from "../src/util/__mocks__/Fetcher";
 
+jest.mock("cross-fetch");
+
 describe("ClientAuthentication", () => {
   const defaultMocks = {
     loginHandler: LoginHandlerMock,
@@ -152,6 +154,12 @@ describe("ClientAuthentication", () => {
 
   describe("handleIncomingRedirect", () => {
     it("calls handle redirect", async () => {
+      const fetch = jest.requireMock("cross-fetch") as {
+        fetch: jest.Mock<
+          ReturnType<typeof window.fetch>,
+          [RequestInfo, RequestInit?]
+        >;
+      };
       const clientAuthn = getClientAuthentication();
       const unauthFetch = clientAuthn.fetch;
       const url =

--- a/packages/browser/__tests__/authenticatedFetch/fetchFactory.spec.ts
+++ b/packages/browser/__tests__/authenticatedFetch/fetchFactory.spec.ts
@@ -45,7 +45,7 @@ describe("buildBearerFetch", () => {
 
     expect(
       // @ts-ignore
-      (fetch.fetch.mock.calls[0][1].headers as Headers).get("Authorization")
+      fetch.fetch.mock.calls[0][1].headers["Authorization"]
     ).toEqual("Bearer myToken");
   });
 
@@ -61,12 +61,12 @@ describe("buildBearerFetch", () => {
 
     expect(
       // @ts-ignore
-      (fetch.fetch.mock.calls[0][1].headers as Headers).get("Authorization")
+      fetch.fetch.mock.calls[0][1].headers["Authorization"]
     ).toEqual("Bearer myToken");
 
     expect(
       // @ts-ignore
-      (fetch.fetch.mock.calls[0][1].headers as Headers).get("someHeader")
+      fetch.fetch.mock.calls[0][1].headers["someHeader"]
     ).toEqual("SomeValue");
   });
 
@@ -82,7 +82,7 @@ describe("buildBearerFetch", () => {
 
     expect(
       // @ts-ignore
-      (fetch.fetch.mock.calls[0][1].headers as Headers).get("Authorization")
+      fetch.fetch.mock.calls[0][1].headers["Authorization"]
     ).toEqual("Bearer myToken");
   });
 });
@@ -101,12 +101,10 @@ describe("buildDpopFetch", () => {
 
     expect(
       // @ts-ignore
-      (fetch.fetch.mock.calls[0][1].headers as Headers).get("Authorization")
+      fetch.fetch.mock.calls[0][1].headers["Authorization"]
     ).toEqual("DPoP myToken");
     // @ts-ignore
-    const dpopHeader = (fetch.fetch.mock.calls[0][1].headers as Headers).get(
-      "DPoP"
-    ) as string;
+    const dpopHeader = fetch.fetch.mock.calls[0][1].headers["DPoP"] as string;
     const decodedHeader = await decodeJWT(dpopHeader, key);
     expect(decodedHeader["htu"]).toEqual("http://some.url");
     expect(decodedHeader["htm"]).toEqual("get");
@@ -125,19 +123,17 @@ describe("buildDpopFetch", () => {
 
     expect(
       // @ts-ignore
-      (fetch.fetch.mock.calls[0][1].headers as Headers).get("Authorization")
+      fetch.fetch.mock.calls[0][1].headers["Authorization"]
     ).toEqual("DPoP myToken");
     // @ts-ignore
-    const dpopHeader = (fetch.fetch.mock.calls[0][1].headers as Headers).get(
-      "DPoP"
-    ) as string;
+    const dpopHeader = fetch.fetch.mock.calls[0][1].headers["DPoP"] as string;
     const decodedHeader = await decodeJWT(dpopHeader, key);
     expect(decodedHeader["htu"]).toEqual("http://some.url");
     expect(decodedHeader["htm"]).toEqual("get");
 
     expect(
       // @ts-ignore
-      (fetch.fetch.mock.calls[0][1].headers as Headers).get("someHeader")
+      fetch.fetch.mock.calls[0][1].headers["someHeader"]
     ).toEqual("SomeValue");
   });
 
@@ -159,12 +155,10 @@ describe("buildDpopFetch", () => {
 
     expect(
       // @ts-ignore
-      (fetch.fetch.mock.calls[0][1].headers as Headers).get("Authorization")
+      fetch.fetch.mock.calls[0][1].headers["Authorization"]
     ).toEqual("DPoP myToken");
     // @ts-ignore
-    const dpopHeader = (fetch.fetch.mock.calls[0][1].headers as Headers).get(
-      "DPoP"
-    ) as string;
+    const dpopHeader = fetch.fetch.mock.calls[0][1].headers["DPoP"] as string;
     const decodedHeader = await decodeJWT(dpopHeader, key);
     expect(decodedHeader["htu"]).toEqual("http://some.url");
     expect(decodedHeader["htm"]).toEqual("get");

--- a/packages/browser/__tests__/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
+++ b/packages/browser/__tests__/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
@@ -159,9 +159,7 @@ describe("AuthCodeRedirectHandler", () => {
       );
       await redirectInfo.fetch("https://some.other.url");
       // @ts-ignore
-      const header = (fetch.fetch.mock.calls[0][1].headers as Headers).get(
-        "Authorization"
-      );
+      const header = fetch.fetch.mock.calls[0][1].headers["Authorization"];
       // We test that the Authorization header matches the structure of a JWT.
       expect(
         // @ts-ignore

--- a/packages/browser/__tests__/login/oidc/redirectHandler/GeneralRedirectHandler.spec.ts
+++ b/packages/browser/__tests__/login/oidc/redirectHandler/GeneralRedirectHandler.spec.ts
@@ -121,9 +121,7 @@ describe("GeneralRedirectHandler", () => {
       );
       await redirectInfo.fetch("https://some.other.url");
       // @ts-ignore
-      const header = (fetch.fetch.mock.calls[0][1].headers as Headers).get(
-        "Authorization"
-      );
+      const header = fetch.fetch.mock.calls[0][1].headers["Authorization"];
       // We test that the Authorization header matches the structure of a JWT.
       expect(
         // @ts-ignore

--- a/packages/browser/src/authenticatedFetch/fetchFactory.ts
+++ b/packages/browser/src/authenticatedFetch/fetchFactory.ts
@@ -22,7 +22,7 @@
 import URL from "url-parse";
 import { JSONWebKey } from "jose";
 import { createHeaderToken } from "../dpop/DpopHeaderCreator";
-import { fetch, Headers } from "cross-fetch";
+import { fetch } from "cross-fetch";
 
 /**
  * @param authToken A bearer token.
@@ -32,11 +32,12 @@ import { fetch, Headers } from "cross-fetch";
  */
 export function buildBearerFetch(authToken: string): typeof fetch {
   return (init, options): Promise<Response> => {
-    const headers = new Headers(options?.headers);
-    headers.set("Authorization", `Bearer ${authToken}`);
     return fetch(init, {
       ...options,
-      headers: headers,
+      headers: {
+        ...options?.headers,
+        Authorization: `Bearer ${authToken}`,
+      },
     });
   };
 }
@@ -52,19 +53,17 @@ export async function buildDpopFetch(
   dpopKey: JSONWebKey
 ): Promise<typeof fetch> {
   return async (init, options): Promise<Response> => {
-    const headers = new Headers(options?.headers);
-    headers.set("Authorization", `DPoP ${authToken}`);
-    headers.set(
-      "DPoP",
-      await createHeaderToken(
-        new URL(init.toString()),
-        options?.method ?? "get",
-        dpopKey
-      )
-    );
     return fetch(init, {
       ...options,
-      headers: headers,
+      headers: {
+        ...options?.headers,
+        Authorization: `DPoP ${authToken}`,
+        DPoP: await createHeaderToken(
+          new URL(init.toString()),
+          options?.method ?? "get",
+          dpopKey
+        ),
+      },
     });
   };
 }

--- a/packages/browser/src/authenticatedFetch/fetchFactory.ts
+++ b/packages/browser/src/authenticatedFetch/fetchFactory.ts
@@ -22,7 +22,7 @@
 import URL from "url-parse";
 import { JSONWebKey } from "jose";
 import { createHeaderToken } from "../dpop/DpopHeaderCreator";
-import { fetch } from "cross-fetch";
+import { fetch, Headers } from "cross-fetch";
 
 /**
  * @param authToken A bearer token.

--- a/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
+++ b/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
@@ -123,7 +123,6 @@ export default class AuthCodeRedirectHandler implements IRedirectHandler {
     if (!sessionInfo) {
       throw new Error(`Could not retrieve session: [${storedSessionId}].`);
     }
-
     return Object.assign(sessionInfo, {
       fetch: buildBearerFetch(signinResponse.access_token),
     });


### PR DESCRIPTION
This PR fixes a bug where the Authorization headers are added correctly  in the test environment, but not in the production one. Due to the nature of the bug, it's hard to test for non-regression. Not being quite sure of what's going on, I created a dedicated branch (https://github.com/inrupt/solid-client-authn-js/tree/debug/wtf-headers) so that we can take a closer look at the issue without blocking this PR.

- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).