### PR TITLE
Export public types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### Bugfixes
 
 - The Authorization header was not set properly, which made it impossible to access private resources.
+- The types consumed/returned by the API are now exported for convenience.
 
 ## [0.2.0]
 

--- a/packages/browser/__tests__/index.spec.ts
+++ b/packages/browser/__tests__/index.spec.ts
@@ -19,19 +19,16 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-export { Session, ISessionOptions } from "./Session";
+import { it } from "@jest/globals";
 
-export {
+import {
+  Session,
   SessionManager,
-  ISessionManager,
-  ISessionManagerOptions,
-} from "./SessionManager";
-export { getClientAuthenticationWithDependencies } from "./dependencies";
+  getClientAuthenticationWithDependencies,
+} from "../src/index";
 
-// Re-export of types defined in the core module and produced/consumed by our API
-
-export {
-  ILoginInputOptions,
-  ISessionInfo,
-  IStorage,
-} from "@inrupt/solid-client-authn-core";
+it("exports the public API from the entrypoint", () => {
+  expect(Session).toBeDefined();
+  expect(SessionManager).toBeDefined();
+  expect(getClientAuthenticationWithDependencies).toBeDefined();
+});


### PR DESCRIPTION
The types being consumed or produced by the public API are now exported from the entry point.

- [X] All acceptance criteria are met.
- [x] The changelog has been updated, if applicable.
- [X] New functions/types have been exported in `index.ts`, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).