### PR TITLE
Feat/export types

### DIFF
--- a/packages/example/.eslintrc.js
+++ b/packages/example/.eslintrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+  extends: ["../../.eslintrc.js"],
+  // rules: {
+  //   "license-header/header": ["error", "../../../resources/license-header.js"],
+  // },
+};

--- a/packages/example/.eslintrc.js
+++ b/packages/example/.eslintrc.js
@@ -1,6 +1,6 @@
 module.exports = {
   extends: ["../../.eslintrc.js"],
-  // rules: {
-  //   "license-header/header": ["error", "../../../resources/license-header.js"],
-  // },
+  rules: {
+    "license-header/header": ["error", "../../resources/license-header.js"],
+  },
 };

--- a/packages/example/README.md
+++ b/packages/example/README.md
@@ -1,0 +1,3 @@
+# TypeScript example
+
+Simple example showing usage of our library's types in TypeScript.

--- a/packages/example/jest.config.js
+++ b/packages/example/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  ...require("../../jest.config"),
+};

--- a/packages/example/package-lock.json
+++ b/packages/example/package-lock.json
@@ -4,6 +4,625 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@babel/code-frame": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+			"integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+			"requires": {
+				"@babel/highlight": "^7.10.4"
+			}
+		},
+		"@babel/core": {
+			"version": "7.11.6",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.11.6.tgz",
+			"integrity": "sha512-Wpcv03AGnmkgm6uS6k8iwhIwTrcP0m17TL1n1sy7qD0qelDu4XNeW0dN0mHfa+Gei211yDaLoEe/VlbXQzM4Bg==",
+			"requires": {
+				"@babel/code-frame": "^7.10.4",
+				"@babel/generator": "^7.11.6",
+				"@babel/helper-module-transforms": "^7.11.0",
+				"@babel/helpers": "^7.10.4",
+				"@babel/parser": "^7.11.5",
+				"@babel/template": "^7.10.4",
+				"@babel/traverse": "^7.11.5",
+				"@babel/types": "^7.11.5",
+				"convert-source-map": "^1.7.0",
+				"debug": "^4.1.0",
+				"gensync": "^1.0.0-beta.1",
+				"json5": "^2.1.2",
+				"lodash": "^4.17.19",
+				"resolve": "^1.3.2",
+				"semver": "^5.4.1",
+				"source-map": "^0.5.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+				}
+			}
+		},
+		"@babel/generator": {
+			"version": "7.11.6",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.6.tgz",
+			"integrity": "sha512-DWtQ1PV3r+cLbySoHrwn9RWEgKMBLLma4OBQloPRyDYvc5msJM9kvTLo1YnlJd1P/ZuKbdli3ijr5q3FvAF3uA==",
+			"requires": {
+				"@babel/types": "^7.11.5",
+				"jsesc": "^2.5.1",
+				"source-map": "^0.5.0"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+				}
+			}
+		},
+		"@babel/helper-function-name": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
+			"integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
+			"requires": {
+				"@babel/helper-get-function-arity": "^7.10.4",
+				"@babel/template": "^7.10.4",
+				"@babel/types": "^7.10.4"
+			}
+		},
+		"@babel/helper-get-function-arity": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
+			"integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
+			"requires": {
+				"@babel/types": "^7.10.4"
+			}
+		},
+		"@babel/helper-member-expression-to-functions": {
+			"version": "7.11.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.11.0.tgz",
+			"integrity": "sha512-JbFlKHFntRV5qKw3YC0CvQnDZ4XMwgzzBbld7Ly4Mj4cbFy3KywcR8NtNctRToMWJOVvLINJv525Gd6wwVEx/Q==",
+			"requires": {
+				"@babel/types": "^7.11.0"
+			}
+		},
+		"@babel/helper-module-imports": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz",
+			"integrity": "sha512-nEQJHqYavI217oD9+s5MUBzk6x1IlvoS9WTPfgG43CbMEeStE0v+r+TucWdx8KFGowPGvyOkDT9+7DHedIDnVw==",
+			"requires": {
+				"@babel/types": "^7.10.4"
+			}
+		},
+		"@babel/helper-module-transforms": {
+			"version": "7.11.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.11.0.tgz",
+			"integrity": "sha512-02EVu8COMuTRO1TAzdMtpBPbe6aQ1w/8fePD2YgQmxZU4gpNWaL9gK3Jp7dxlkUlUCJOTaSeA+Hrm1BRQwqIhg==",
+			"requires": {
+				"@babel/helper-module-imports": "^7.10.4",
+				"@babel/helper-replace-supers": "^7.10.4",
+				"@babel/helper-simple-access": "^7.10.4",
+				"@babel/helper-split-export-declaration": "^7.11.0",
+				"@babel/template": "^7.10.4",
+				"@babel/types": "^7.11.0",
+				"lodash": "^4.17.19"
+			}
+		},
+		"@babel/helper-optimise-call-expression": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz",
+			"integrity": "sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==",
+			"requires": {
+				"@babel/types": "^7.10.4"
+			}
+		},
+		"@babel/helper-plugin-utils": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+			"integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg=="
+		},
+		"@babel/helper-replace-supers": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.4.tgz",
+			"integrity": "sha512-sPxZfFXocEymYTdVK1UNmFPBN+Hv5mJkLPsYWwGBxZAxaWfFu+xqp7b6qWD0yjNuNL2VKc6L5M18tOXUP7NU0A==",
+			"requires": {
+				"@babel/helper-member-expression-to-functions": "^7.10.4",
+				"@babel/helper-optimise-call-expression": "^7.10.4",
+				"@babel/traverse": "^7.10.4",
+				"@babel/types": "^7.10.4"
+			}
+		},
+		"@babel/helper-simple-access": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.10.4.tgz",
+			"integrity": "sha512-0fMy72ej/VEvF8ULmX6yb5MtHG4uH4Dbd6I/aHDb/JVg0bbivwt9Wg+h3uMvX+QSFtwr5MeItvazbrc4jtRAXw==",
+			"requires": {
+				"@babel/template": "^7.10.4",
+				"@babel/types": "^7.10.4"
+			}
+		},
+		"@babel/helper-split-export-declaration": {
+			"version": "7.11.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
+			"integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
+			"requires": {
+				"@babel/types": "^7.11.0"
+			}
+		},
+		"@babel/helper-validator-identifier": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+			"integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
+		},
+		"@babel/helpers": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.10.4.tgz",
+			"integrity": "sha512-L2gX/XeUONeEbI78dXSrJzGdz4GQ+ZTA/aazfUsFaWjSe95kiCuOZ5HsXvkiw3iwF+mFHSRUfJU8t6YavocdXA==",
+			"requires": {
+				"@babel/template": "^7.10.4",
+				"@babel/traverse": "^7.10.4",
+				"@babel/types": "^7.10.4"
+			}
+		},
+		"@babel/highlight": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+			"integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+			"requires": {
+				"@babel/helper-validator-identifier": "^7.10.4",
+				"chalk": "^2.0.0",
+				"js-tokens": "^4.0.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"color-convert": {
+					"version": "1.9.3",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+					"requires": {
+						"color-name": "1.1.3"
+					}
+				},
+				"color-name": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
+		"@babel/parser": {
+			"version": "7.11.5",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.5.tgz",
+			"integrity": "sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q=="
+		},
+		"@babel/plugin-syntax-async-generators": {
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+			"integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			}
+		},
+		"@babel/plugin-syntax-bigint": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
+			"integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			}
+		},
+		"@babel/plugin-syntax-class-properties": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.10.4.tgz",
+			"integrity": "sha512-GCSBF7iUle6rNugfURwNmCGG3Z/2+opxAMLs1nND4bhEG5PuxTIggDBoeYYSujAlLtsupzOHYJQgPS3pivwXIA==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-syntax-import-meta": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+			"integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-syntax-json-strings": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+			"integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			}
+		},
+		"@babel/plugin-syntax-logical-assignment-operators": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+			"integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-syntax-nullish-coalescing-operator": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+			"integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			}
+		},
+		"@babel/plugin-syntax-numeric-separator": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+			"integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			}
+		},
+		"@babel/plugin-syntax-object-rest-spread": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+			"integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			}
+		},
+		"@babel/plugin-syntax-optional-catch-binding": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+			"integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			}
+		},
+		"@babel/plugin-syntax-optional-chaining": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+			"integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			}
+		},
+		"@babel/template": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
+			"integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
+			"requires": {
+				"@babel/code-frame": "^7.10.4",
+				"@babel/parser": "^7.10.4",
+				"@babel/types": "^7.10.4"
+			}
+		},
+		"@babel/traverse": {
+			"version": "7.11.5",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.5.tgz",
+			"integrity": "sha512-EjiPXt+r7LiCZXEfRpSJd+jUMnBd4/9OUv7Nx3+0u9+eimMwJmG0Q98lw4/289JCoxSE8OolDMNZaaF/JZ69WQ==",
+			"requires": {
+				"@babel/code-frame": "^7.10.4",
+				"@babel/generator": "^7.11.5",
+				"@babel/helper-function-name": "^7.10.4",
+				"@babel/helper-split-export-declaration": "^7.11.0",
+				"@babel/parser": "^7.11.5",
+				"@babel/types": "^7.11.5",
+				"debug": "^4.1.0",
+				"globals": "^11.1.0",
+				"lodash": "^4.17.19"
+			}
+		},
+		"@babel/types": {
+			"version": "7.11.5",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
+			"integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
+			"requires": {
+				"@babel/helper-validator-identifier": "^7.10.4",
+				"lodash": "^4.17.19",
+				"to-fast-properties": "^2.0.0"
+			}
+		},
+		"@bcoe/v8-coverage": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+			"integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
+		},
+		"@cnakazawa/watch": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.4.tgz",
+			"integrity": "sha512-v9kIhKwjeZThiWrLmj0y17CWoyddASLj9O2yvbZkbvw/N3rWOYy9zkV66ursAoVr0mV15bL8g0c4QZUE6cdDoQ==",
+			"requires": {
+				"exec-sh": "^0.3.2",
+				"minimist": "^1.2.0"
+			}
+		},
+		"@inrupt/solid-client-authn-browser": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-browser/-/solid-client-authn-browser-0.2.1.tgz",
+			"integrity": "sha512-JbHEdSnoMc+vieT6+FiR5Hf0fzvOKX/q/ZwMbIpTknFBxcdVyZ/SA6dxVbXIGSCUTUFVQeNudGC+DgkzvJ75/w==",
+			"requires": {
+				"@inrupt/solid-client-authn-core": "^0.2.1",
+				"@types/form-urlencoded": "^2.0.1",
+				"@types/jjv": "^1.0.29",
+				"@types/jsonwebtoken": "^8.5.0",
+				"@types/lodash.clonedeep": "^4.5.6",
+				"@types/node": "^14.6.2",
+				"@types/node-jose": "^1.1.5",
+				"@types/url-parse": "^1.4.3",
+				"@types/uuid": "^8.3.0",
+				"build-module": "^1.0.7",
+				"cross-fetch": "^3.0.6",
+				"crypto-random-string": "^3.2.0",
+				"form-urlencoded": "^4.2.1",
+				"jose": "^2.0.2",
+				"jsonwebtoken": "^8.5.1",
+				"lodash.clonedeep": "^4.5.0",
+				"node-jose": "^2.0.0",
+				"reflect-metadata": "^0.1.13",
+				"tsyringe": "^4.3.0",
+				"url-parse": "^1.4.7",
+				"uuid": "^8.3.0"
+			}
+		},
+		"@inrupt/solid-client-authn-core": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-core/-/solid-client-authn-core-0.2.1.tgz",
+			"integrity": "sha512-1HoKfAuIpsxw7E5Fx1um+gA0lDunmhPXp4Ndxx4qqJDyy7m/ym4+b1CTGzA44GNyIeQrRMpHMmChaAN/XCgbKQ==",
+			"requires": {
+				"@types/form-urlencoded": "^2.0.1",
+				"@types/jjv": "^1.0.29",
+				"@types/jsonwebtoken": "^8.5.0",
+				"@types/lodash.clonedeep": "^4.5.6",
+				"@types/node": "^14.11.2",
+				"@types/node-jose": "^1.1.5",
+				"@types/url-parse": "^1.4.3",
+				"@types/uuid": "^8.3.0",
+				"build-module": "^1.0.7",
+				"cross-fetch": "^3.0.6",
+				"crypto-random-string": "^3.2.0",
+				"form-urlencoded": "^4.2.1",
+				"jest": "^25.1.0",
+				"jose": "^2.0.2",
+				"jsonwebtoken": "^8.5.1",
+				"lodash.clonedeep": "^4.5.0",
+				"node-jose": "^2.0.0",
+				"reflect-metadata": "^0.1.13",
+				"tsyringe": "^4.3.0",
+				"url-parse": "^1.4.7",
+				"uuid": "^8.3.0"
+			}
+		},
+		"@istanbuljs/load-nyc-config": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+			"integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
+			"requires": {
+				"camelcase": "^5.3.1",
+				"find-up": "^4.1.0",
+				"get-package-type": "^0.1.0",
+				"js-yaml": "^3.13.1",
+				"resolve-from": "^5.0.0"
+			}
+		},
+		"@istanbuljs/schema": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.2.tgz",
+			"integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw=="
+		},
+		"@jest/console": {
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/@jest/console/-/console-25.5.0.tgz",
+			"integrity": "sha512-T48kZa6MK1Y6k4b89sexwmSF4YLeZS/Udqg3Jj3jG/cHH+N/sLFCEoXEDMOKugJQ9FxPN1osxIknvKkxt6MKyw==",
+			"requires": {
+				"@jest/types": "^25.5.0",
+				"chalk": "^3.0.0",
+				"jest-message-util": "^25.5.0",
+				"jest-util": "^25.5.0",
+				"slash": "^3.0.0"
+			}
+		},
+		"@jest/core": {
+			"version": "25.5.4",
+			"resolved": "https://registry.npmjs.org/@jest/core/-/core-25.5.4.tgz",
+			"integrity": "sha512-3uSo7laYxF00Dg/DMgbn4xMJKmDdWvZnf89n8Xj/5/AeQ2dOQmn6b6Hkj/MleyzZWXpwv+WSdYWl4cLsy2JsoA==",
+			"requires": {
+				"@jest/console": "^25.5.0",
+				"@jest/reporters": "^25.5.1",
+				"@jest/test-result": "^25.5.0",
+				"@jest/transform": "^25.5.1",
+				"@jest/types": "^25.5.0",
+				"ansi-escapes": "^4.2.1",
+				"chalk": "^3.0.0",
+				"exit": "^0.1.2",
+				"graceful-fs": "^4.2.4",
+				"jest-changed-files": "^25.5.0",
+				"jest-config": "^25.5.4",
+				"jest-haste-map": "^25.5.1",
+				"jest-message-util": "^25.5.0",
+				"jest-regex-util": "^25.2.6",
+				"jest-resolve": "^25.5.1",
+				"jest-resolve-dependencies": "^25.5.4",
+				"jest-runner": "^25.5.4",
+				"jest-runtime": "^25.5.4",
+				"jest-snapshot": "^25.5.1",
+				"jest-util": "^25.5.0",
+				"jest-validate": "^25.5.0",
+				"jest-watcher": "^25.5.0",
+				"micromatch": "^4.0.2",
+				"p-each-series": "^2.1.0",
+				"realpath-native": "^2.0.0",
+				"rimraf": "^3.0.0",
+				"slash": "^3.0.0",
+				"strip-ansi": "^6.0.0"
+			}
+		},
+		"@jest/environment": {
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-25.5.0.tgz",
+			"integrity": "sha512-U2VXPEqL07E/V7pSZMSQCvV5Ea4lqOlT+0ZFijl/i316cRMHvZ4qC+jBdryd+lmRetjQo0YIQr6cVPNxxK87mA==",
+			"requires": {
+				"@jest/fake-timers": "^25.5.0",
+				"@jest/types": "^25.5.0",
+				"jest-mock": "^25.5.0"
+			}
+		},
+		"@jest/fake-timers": {
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-25.5.0.tgz",
+			"integrity": "sha512-9y2+uGnESw/oyOI3eww9yaxdZyHq7XvprfP/eeoCsjqKYts2yRlsHS/SgjPDV8FyMfn2nbMy8YzUk6nyvdLOpQ==",
+			"requires": {
+				"@jest/types": "^25.5.0",
+				"jest-message-util": "^25.5.0",
+				"jest-mock": "^25.5.0",
+				"jest-util": "^25.5.0",
+				"lolex": "^5.0.0"
+			}
+		},
+		"@jest/globals": {
+			"version": "25.5.2",
+			"resolved": "https://registry.npmjs.org/@jest/globals/-/globals-25.5.2.tgz",
+			"integrity": "sha512-AgAS/Ny7Q2RCIj5kZ+0MuKM1wbF0WMLxbCVl/GOMoCNbODRdJ541IxJ98xnZdVSZXivKpJlNPIWa3QmY0l4CXA==",
+			"requires": {
+				"@jest/environment": "^25.5.0",
+				"@jest/types": "^25.5.0",
+				"expect": "^25.5.0"
+			}
+		},
+		"@jest/reporters": {
+			"version": "25.5.1",
+			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-25.5.1.tgz",
+			"integrity": "sha512-3jbd8pPDTuhYJ7vqiHXbSwTJQNavczPs+f1kRprRDxETeE3u6srJ+f0NPuwvOmk+lmunZzPkYWIFZDLHQPkviw==",
+			"requires": {
+				"@bcoe/v8-coverage": "^0.2.3",
+				"@jest/console": "^25.5.0",
+				"@jest/test-result": "^25.5.0",
+				"@jest/transform": "^25.5.1",
+				"@jest/types": "^25.5.0",
+				"chalk": "^3.0.0",
+				"collect-v8-coverage": "^1.0.0",
+				"exit": "^0.1.2",
+				"glob": "^7.1.2",
+				"graceful-fs": "^4.2.4",
+				"istanbul-lib-coverage": "^3.0.0",
+				"istanbul-lib-instrument": "^4.0.0",
+				"istanbul-lib-report": "^3.0.0",
+				"istanbul-lib-source-maps": "^4.0.0",
+				"istanbul-reports": "^3.0.2",
+				"jest-haste-map": "^25.5.1",
+				"jest-resolve": "^25.5.1",
+				"jest-util": "^25.5.0",
+				"jest-worker": "^25.5.0",
+				"node-notifier": "^6.0.0",
+				"slash": "^3.0.0",
+				"source-map": "^0.6.0",
+				"string-length": "^3.1.0",
+				"terminal-link": "^2.0.0",
+				"v8-to-istanbul": "^4.1.3"
+			}
+		},
+		"@jest/source-map": {
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-25.5.0.tgz",
+			"integrity": "sha512-eIGx0xN12yVpMcPaVpjXPnn3N30QGJCJQSkEDUt9x1fI1Gdvb07Ml6K5iN2hG7NmMP6FDmtPEssE3z6doOYUwQ==",
+			"requires": {
+				"callsites": "^3.0.0",
+				"graceful-fs": "^4.2.4",
+				"source-map": "^0.6.0"
+			}
+		},
+		"@jest/test-result": {
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-25.5.0.tgz",
+			"integrity": "sha512-oV+hPJgXN7IQf/fHWkcS99y0smKLU2czLBJ9WA0jHITLst58HpQMtzSYxzaBvYc6U5U6jfoMthqsUlUlbRXs0A==",
+			"requires": {
+				"@jest/console": "^25.5.0",
+				"@jest/types": "^25.5.0",
+				"@types/istanbul-lib-coverage": "^2.0.0",
+				"collect-v8-coverage": "^1.0.0"
+			}
+		},
+		"@jest/test-sequencer": {
+			"version": "25.5.4",
+			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-25.5.4.tgz",
+			"integrity": "sha512-pTJGEkSeg1EkCO2YWq6hbFvKNXk8ejqlxiOg1jBNLnWrgXOkdY6UmqZpwGFXNnRt9B8nO1uWMzLLZ4eCmhkPNA==",
+			"requires": {
+				"@jest/test-result": "^25.5.0",
+				"graceful-fs": "^4.2.4",
+				"jest-haste-map": "^25.5.1",
+				"jest-runner": "^25.5.4",
+				"jest-runtime": "^25.5.4"
+			}
+		},
+		"@jest/transform": {
+			"version": "25.5.1",
+			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-25.5.1.tgz",
+			"integrity": "sha512-Y8CEoVwXb4QwA6Y/9uDkn0Xfz0finGkieuV0xkdF9UtZGJeLukD5nLkaVrVsODB1ojRWlaoD0AJZpVHCSnJEvg==",
+			"requires": {
+				"@babel/core": "^7.1.0",
+				"@jest/types": "^25.5.0",
+				"babel-plugin-istanbul": "^6.0.0",
+				"chalk": "^3.0.0",
+				"convert-source-map": "^1.4.0",
+				"fast-json-stable-stringify": "^2.0.0",
+				"graceful-fs": "^4.2.4",
+				"jest-haste-map": "^25.5.1",
+				"jest-regex-util": "^25.2.6",
+				"jest-util": "^25.5.0",
+				"micromatch": "^4.0.2",
+				"pirates": "^4.0.1",
+				"realpath-native": "^2.0.0",
+				"slash": "^3.0.0",
+				"source-map": "^0.6.1",
+				"write-file-atomic": "^3.0.0"
+			}
+		},
+		"@jest/types": {
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
+			"integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
+			"requires": {
+				"@types/istanbul-lib-coverage": "^2.0.0",
+				"@types/istanbul-reports": "^1.1.1",
+				"@types/yargs": "^15.0.0",
+				"chalk": "^3.0.0"
+			}
+		},
+		"@panva/asn1.js": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@panva/asn1.js/-/asn1.js-1.0.0.tgz",
+			"integrity": "sha512-UdkG3mLEqXgnlKsWanWcgb6dOjUzJ+XC5f+aWw30qrtjxeNUSfKX1cd5FBzOaXQumoe9nIqeZUvrRJS03HCCtw=="
+		},
 		"@rollup/plugin-commonjs": {
 			"version": "15.1.0",
 			"resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-15.1.0.tgz",
@@ -52,17 +671,140 @@
 				}
 			}
 		},
+		"@sinonjs/commons": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.1.tgz",
+			"integrity": "sha512-892K+kWUUi3cl+LlqEWIDrhvLgdL79tECi8JZUyq6IviKy/DNhuzCRlbHUjxK89f4ypPMMaFnFuR9Ie6DoIMsw==",
+			"requires": {
+				"type-detect": "4.0.8"
+			}
+		},
+		"@types/babel__core": {
+			"version": "7.1.10",
+			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.10.tgz",
+			"integrity": "sha512-x8OM8XzITIMyiwl5Vmo2B1cR1S1Ipkyv4mdlbJjMa1lmuKvKY9FrBbEANIaMlnWn5Rf7uO+rC/VgYabNkE17Hw==",
+			"requires": {
+				"@babel/parser": "^7.1.0",
+				"@babel/types": "^7.0.0",
+				"@types/babel__generator": "*",
+				"@types/babel__template": "*",
+				"@types/babel__traverse": "*"
+			}
+		},
+		"@types/babel__generator": {
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.2.tgz",
+			"integrity": "sha512-MdSJnBjl+bdwkLskZ3NGFp9YcXGx5ggLpQQPqtgakVhsWK0hTtNYhjpZLlWQTviGTvF8at+Bvli3jV7faPdgeQ==",
+			"requires": {
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@types/babel__template": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.0.3.tgz",
+			"integrity": "sha512-uCoznIPDmnickEi6D0v11SBpW0OuVqHJCa7syXqQHy5uktSCreIlt0iglsCnmvz8yCb38hGcWeseA8cWJSwv5Q==",
+			"requires": {
+				"@babel/parser": "^7.1.0",
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@types/babel__traverse": {
+			"version": "7.0.15",
+			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.15.tgz",
+			"integrity": "sha512-Pzh9O3sTK8V6I1olsXpCfj2k/ygO2q1X0vhhnDrEQyYLHZesWz+zMZMVcwXLCYf0U36EtmyYaFGPfXlTtDHe3A==",
+			"requires": {
+				"@babel/types": "^7.3.0"
+			}
+		},
 		"@types/estree": {
 			"version": "0.0.39",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
 			"integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
 			"dev": true
 		},
+		"@types/form-urlencoded": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@types/form-urlencoded/-/form-urlencoded-2.0.1.tgz",
+			"integrity": "sha512-Kz3LwezuNvsQF8ZcswMv4b5ZhKmjTkH2Rxle6l/520Npvaxho6b4HN9lStp6HhGrZsL/rwJHpWK9vM1RA7uZbw=="
+		},
+		"@types/graceful-fs": {
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.3.tgz",
+			"integrity": "sha512-AiHRaEB50LQg0pZmm659vNBb9f4SJ0qrAnteuzhSeAUcJKxoYgEnprg/83kppCnc2zvtCKbdZry1a5pVY3lOTQ==",
+			"requires": {
+				"@types/node": "*"
+			}
+		},
+		"@types/istanbul-lib-coverage": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
+			"integrity": "sha512-sz7iLqvVUg1gIedBOvlkxPlc8/uVzyS5OwGz1cKjXzkl3FpL3al0crU8YGU1WoHkxn0Wxbw5tyi6hvzJKNzFsw=="
+		},
+		"@types/istanbul-lib-report": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+			"integrity": "sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==",
+			"requires": {
+				"@types/istanbul-lib-coverage": "*"
+			}
+		},
+		"@types/istanbul-reports": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
+			"integrity": "sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==",
+			"requires": {
+				"@types/istanbul-lib-coverage": "*",
+				"@types/istanbul-lib-report": "*"
+			}
+		},
+		"@types/jjv": {
+			"version": "1.0.29",
+			"resolved": "https://registry.npmjs.org/@types/jjv/-/jjv-1.0.29.tgz",
+			"integrity": "sha1-KzlLFAQCUtVThNIG+q+jHKRgx8Q="
+		},
+		"@types/jsonwebtoken": {
+			"version": "8.5.0",
+			"resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-8.5.0.tgz",
+			"integrity": "sha512-9bVao7LvyorRGZCw0VmH/dr7Og+NdjYSsKAxB43OQoComFbBgsEpoR9JW6+qSq/ogwVBg8GI2MfAlk4SYI4OLg==",
+			"requires": {
+				"@types/node": "*"
+			}
+		},
+		"@types/lodash": {
+			"version": "4.14.161",
+			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.161.tgz",
+			"integrity": "sha512-EP6O3Jkr7bXvZZSZYlsgt5DIjiGr0dXP1/jVEwVLTFgg0d+3lWVQkRavYVQszV7dYUwvg0B8R0MBDpcmXg7XIA=="
+		},
+		"@types/lodash.clonedeep": {
+			"version": "4.5.6",
+			"resolved": "https://registry.npmjs.org/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.6.tgz",
+			"integrity": "sha512-cE1jYr2dEg1wBImvXlNtp0xDoS79rfEdGozQVgliDZj1uERH4k+rmEMTudP9b4VQ8O6nRb5gPqft0QzEQGMQgA==",
+			"requires": {
+				"@types/lodash": "*"
+			}
+		},
 		"@types/node": {
 			"version": "14.11.5",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.5.tgz",
-			"integrity": "sha512-jVFzDV6NTbrLMxm4xDSIW/gKnk8rQLF9wAzLWIOg+5nU6ACrIMndeBdXci0FGtqJbP9tQvm6V39eshc96TO2wQ==",
-			"dev": true
+			"integrity": "sha512-jVFzDV6NTbrLMxm4xDSIW/gKnk8rQLF9wAzLWIOg+5nU6ACrIMndeBdXci0FGtqJbP9tQvm6V39eshc96TO2wQ=="
+		},
+		"@types/node-jose": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@types/node-jose/-/node-jose-1.1.5.tgz",
+			"integrity": "sha512-fScnd7GdaHC31PYouWR0xYSOXQLrmxPhLM92CYlVy4UetSwis2u5e6khMazj1Xyidt8zPeRU0PHLmI+mpamhGQ==",
+			"requires": {
+				"@types/node": "*"
+			}
+		},
+		"@types/normalize-package-data": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+			"integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA=="
+		},
+		"@types/prettier": {
+			"version": "1.19.1",
+			"resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-1.19.1.tgz",
+			"integrity": "sha512-5qOlnZscTn4xxM5MeGXAMOsIOIKIbh9e85zJWfBRVPlRMEVawzoPhINYbRGkBZCI8LxvBe7tJCdWiarA99OZfQ=="
 		},
 		"@types/resolve": {
 			"version": "1.17.1",
@@ -73,21 +815,394 @@
 				"@types/node": "*"
 			}
 		},
+		"@types/stack-utils": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
+			"integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw=="
+		},
+		"@types/url-parse": {
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/@types/url-parse/-/url-parse-1.4.3.tgz",
+			"integrity": "sha512-4kHAkbV/OfW2kb5BLVUuUMoumB3CP8rHqlw48aHvFy5tf9ER0AfOonBlX29l/DD68G70DmyhRlSYfQPSYpC5Vw=="
+		},
+		"@types/uuid": {
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.0.tgz",
+			"integrity": "sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ=="
+		},
+		"@types/yargs": {
+			"version": "15.0.7",
+			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.7.tgz",
+			"integrity": "sha512-Gf4u3EjaPNcC9cTu4/j2oN14nSVhr8PQ+BvBcBQHAhDZfl0bVIiLgvnRXv/dn58XhTm9UXvBpvJpDlwV65QxOA==",
+			"requires": {
+				"@types/yargs-parser": "*"
+			}
+		},
+		"@types/yargs-parser": {
+			"version": "15.0.0",
+			"resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-15.0.0.tgz",
+			"integrity": "sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw=="
+		},
+		"abab": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
+			"integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q=="
+		},
+		"acorn": {
+			"version": "7.4.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+			"integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+		},
+		"acorn-globals": {
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.4.tgz",
+			"integrity": "sha512-clfQEh21R+D0leSbUdWf3OcfqyaCSAQ8Ryq00bofSekfr9W8u1jyYZo6ir0xu9Gtcf7BjcHJpnbZH7JOCpP60A==",
+			"requires": {
+				"acorn": "^6.0.1",
+				"acorn-walk": "^6.0.1"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "6.4.2",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
+					"integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ=="
+				}
+			}
+		},
+		"acorn-walk": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.2.0.tgz",
+			"integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA=="
+		},
+		"ajv": {
+			"version": "6.12.5",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.5.tgz",
+			"integrity": "sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==",
+			"requires": {
+				"fast-deep-equal": "^3.1.1",
+				"fast-json-stable-stringify": "^2.0.0",
+				"json-schema-traverse": "^0.4.1",
+				"uri-js": "^4.2.2"
+			}
+		},
+		"ansi-escapes": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
+			"integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
+			"requires": {
+				"type-fest": "^0.11.0"
+			},
+			"dependencies": {
+				"type-fest": {
+					"version": "0.11.0",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
+					"integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ=="
+				}
+			}
+		},
+		"ansi-regex": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+			"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+		},
+		"ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"requires": {
+				"color-convert": "^2.0.1"
+			}
+		},
+		"anymatch": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+			"integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+			"requires": {
+				"normalize-path": "^3.0.0",
+				"picomatch": "^2.0.4"
+			}
+		},
+		"argparse": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"requires": {
+				"sprintf-js": "~1.0.2"
+			}
+		},
+		"arr-diff": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+			"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+		},
+		"arr-flatten": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+		},
+		"arr-union": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
+		},
+		"array-equal": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
+		},
+		"array-unique": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+			"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+		},
+		"asn1": {
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+			"integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+			"requires": {
+				"safer-buffer": "~2.1.0"
+			}
+		},
+		"assert-plus": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+		},
+		"assign-symbols": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
+		},
+		"astral-regex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+			"integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg=="
+		},
+		"asynckit": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+		},
+		"atob": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
+		},
+		"aws-sign2": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+		},
+		"aws4": {
+			"version": "1.10.1",
+			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.1.tgz",
+			"integrity": "sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA=="
+		},
+		"babel-jest": {
+			"version": "25.5.1",
+			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-25.5.1.tgz",
+			"integrity": "sha512-9dA9+GmMjIzgPnYtkhBg73gOo/RHqPmLruP3BaGL4KEX3Dwz6pI8auSN8G8+iuEG90+GSswyKvslN+JYSaacaQ==",
+			"requires": {
+				"@jest/transform": "^25.5.1",
+				"@jest/types": "^25.5.0",
+				"@types/babel__core": "^7.1.7",
+				"babel-plugin-istanbul": "^6.0.0",
+				"babel-preset-jest": "^25.5.0",
+				"chalk": "^3.0.0",
+				"graceful-fs": "^4.2.4",
+				"slash": "^3.0.0"
+			}
+		},
+		"babel-plugin-istanbul": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.0.0.tgz",
+			"integrity": "sha512-AF55rZXpe7trmEylbaE1Gv54wn6rwU03aptvRoVIGP8YykoSxqdVLV1TfwflBCE/QtHmqtP8SWlTENqbK8GCSQ==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@istanbuljs/load-nyc-config": "^1.0.0",
+				"@istanbuljs/schema": "^0.1.2",
+				"istanbul-lib-instrument": "^4.0.0",
+				"test-exclude": "^6.0.0"
+			}
+		},
+		"babel-plugin-jest-hoist": {
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-25.5.0.tgz",
+			"integrity": "sha512-u+/W+WAjMlvoocYGTwthAiQSxDcJAyHpQ6oWlHdFZaaN+Rlk8Q7iiwDPg2lN/FyJtAYnKjFxbn7xus4HCFkg5g==",
+			"requires": {
+				"@babel/template": "^7.3.3",
+				"@babel/types": "^7.3.3",
+				"@types/babel__traverse": "^7.0.6"
+			}
+		},
+		"babel-preset-current-node-syntax": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-0.1.4.tgz",
+			"integrity": "sha512-5/INNCYhUGqw7VbVjT/hb3ucjgkVHKXY7lX3ZjlN4gm565VyFmJUrJ/h+h16ECVB38R/9SF6aACydpKMLZ/c9w==",
+			"requires": {
+				"@babel/plugin-syntax-async-generators": "^7.8.4",
+				"@babel/plugin-syntax-bigint": "^7.8.3",
+				"@babel/plugin-syntax-class-properties": "^7.8.3",
+				"@babel/plugin-syntax-import-meta": "^7.8.3",
+				"@babel/plugin-syntax-json-strings": "^7.8.3",
+				"@babel/plugin-syntax-logical-assignment-operators": "^7.8.3",
+				"@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+				"@babel/plugin-syntax-numeric-separator": "^7.8.3",
+				"@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+				"@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+				"@babel/plugin-syntax-optional-chaining": "^7.8.3"
+			}
+		},
+		"babel-preset-jest": {
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-25.5.0.tgz",
+			"integrity": "sha512-8ZczygctQkBU+63DtSOKGh7tFL0CeCuz+1ieud9lJ1WPQ9O6A1a/r+LGn6Y705PA6whHQ3T1XuB/PmpfNYf8Fw==",
+			"requires": {
+				"babel-plugin-jest-hoist": "^25.5.0",
+				"babel-preset-current-node-syntax": "^0.1.2"
+			}
+		},
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-			"dev": true
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+		},
+		"base": {
+			"version": "0.11.2",
+			"resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+			"integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+			"requires": {
+				"cache-base": "^1.0.1",
+				"class-utils": "^0.3.5",
+				"component-emitter": "^1.2.1",
+				"define-property": "^1.0.0",
+				"isobject": "^3.0.1",
+				"mixin-deep": "^1.2.0",
+				"pascalcase": "^0.1.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"requires": {
+						"is-descriptor": "^1.0.0"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				}
+			}
+		},
+		"base64-js": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+			"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+		},
+		"base64url": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
+			"integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A=="
+		},
+		"bcrypt-pbkdf": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+			"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+			"requires": {
+				"tweetnacl": "^0.14.3"
+			}
 		},
 		"brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-			"dev": true,
 			"requires": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
 			}
+		},
+		"braces": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+			"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+			"requires": {
+				"fill-range": "^7.0.1"
+			}
+		},
+		"browser-process-hrtime": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
+			"integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow=="
+		},
+		"browser-resolve": {
+			"version": "1.11.3",
+			"resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.3.tgz",
+			"integrity": "sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==",
+			"requires": {
+				"resolve": "1.1.7"
+			},
+			"dependencies": {
+				"resolve": {
+					"version": "1.1.7",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+					"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
+				}
+			}
+		},
+		"bser": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
+			"integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
+			"requires": {
+				"node-int64": "^0.4.0"
+			}
+		},
+		"buffer": {
+			"version": "5.6.0",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+			"integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+			"requires": {
+				"base64-js": "^1.0.2",
+				"ieee754": "^1.1.4"
+			}
+		},
+		"buffer-equal-constant-time": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+			"integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+		},
+		"buffer-from": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+		},
+		"build-module": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/build-module/-/build-module-1.0.7.tgz",
+			"integrity": "sha1-XaGSnAneihf16lhrH2zBwg8oFXw="
 		},
 		"builtin-modules": {
 			"version": "3.1.0",
@@ -95,38 +1210,614 @@
 			"integrity": "sha512-k0KL0aWZuBt2lrxrcASWDfwOLMnodeQjodT/1SxEQAXsHANgo6ZC/VEaSEHCXt7aSTZ4/4H5LKa+tBXmW7Vtvw==",
 			"dev": true
 		},
+		"cache-base": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+			"integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+			"requires": {
+				"collection-visit": "^1.0.0",
+				"component-emitter": "^1.2.1",
+				"get-value": "^2.0.6",
+				"has-value": "^1.0.0",
+				"isobject": "^3.0.1",
+				"set-value": "^2.0.0",
+				"to-object-path": "^0.3.0",
+				"union-value": "^1.0.0",
+				"unset-value": "^1.0.0"
+			}
+		},
+		"callsites": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
+		},
+		"camelcase": {
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+		},
+		"capture-exit": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-2.0.0.tgz",
+			"integrity": "sha512-PiT/hQmTonHhl/HFGN+Lx3JJUznrVYJ3+AQsnthneZbvW7x+f08Tk7yLJTLEOUvBTbduLeeBkxEaYXUOUrRq6g==",
+			"requires": {
+				"rsvp": "^4.8.4"
+			}
+		},
+		"caseless": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+		},
+		"chalk": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+			"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+			"requires": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			}
+		},
+		"ci-info": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+			"integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="
+		},
+		"class-utils": {
+			"version": "0.3.6",
+			"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+			"integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+			"requires": {
+				"arr-union": "^3.1.0",
+				"define-property": "^0.2.5",
+				"isobject": "^3.0.0",
+				"static-extend": "^0.1.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"requires": {
+						"is-descriptor": "^0.1.0"
+					}
+				}
+			}
+		},
+		"cliui": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+			"integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+			"requires": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.0",
+				"wrap-ansi": "^6.2.0"
+			}
+		},
+		"co": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+		},
+		"collect-v8-coverage": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.1.tgz",
+			"integrity": "sha512-iBPtljfCNcTKNAto0KEtDfZ3qzjJvqE3aTGZsbhjSBlorqpXJlaWWtPO35D+ZImoC3KWejX64o+yPGxhWSTzfg=="
+		},
+		"collection-visit": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+			"integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+			"requires": {
+				"map-visit": "^1.0.0",
+				"object-visit": "^1.0.0"
+			}
+		},
+		"color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"requires": {
+				"color-name": "~1.1.4"
+			}
+		},
+		"color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+		},
+		"combined-stream": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+			"requires": {
+				"delayed-stream": "~1.0.0"
+			}
+		},
 		"commondir": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
 			"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
 			"dev": true
 		},
+		"component-emitter": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+			"integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
+		},
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-			"dev": true
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+		},
+		"convert-source-map": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+			"integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+			"requires": {
+				"safe-buffer": "~5.1.1"
+			}
+		},
+		"copy-descriptor": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
+		},
+		"core-util-is": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
 		},
 		"cross-fetch": {
 			"version": "3.0.6",
 			"resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.6.tgz",
 			"integrity": "sha512-KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==",
-			"dev": true,
 			"requires": {
 				"node-fetch": "2.6.1"
 			}
 		},
+		"cross-spawn": {
+			"version": "6.0.5",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+			"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+			"requires": {
+				"nice-try": "^1.0.4",
+				"path-key": "^2.0.1",
+				"semver": "^5.5.0",
+				"shebang-command": "^1.2.0",
+				"which": "^1.2.9"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+				},
+				"which": {
+					"version": "1.3.1",
+					"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+					"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+					"requires": {
+						"isexe": "^2.0.0"
+					}
+				}
+			}
+		},
+		"crypto-random-string": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-3.3.0.tgz",
+			"integrity": "sha512-teWAwfMb1d6brahYyKqcBEb5Yp8PJPvPOdOonXDnvaKOTmKDFNVE8E3Y2XQuzjNV/3XMwHbrX9fHWvrhRKt4Gg==",
+			"requires": {
+				"type-fest": "^0.8.1"
+			}
+		},
+		"cssom": {
+			"version": "0.4.4",
+			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
+			"integrity": "sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw=="
+		},
+		"cssstyle": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
+			"integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
+			"requires": {
+				"cssom": "~0.3.6"
+			},
+			"dependencies": {
+				"cssom": {
+					"version": "0.3.8",
+					"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+					"integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
+				}
+			}
+		},
+		"dashdash": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+			"requires": {
+				"assert-plus": "^1.0.0"
+			}
+		},
+		"data-urls": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.1.0.tgz",
+			"integrity": "sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==",
+			"requires": {
+				"abab": "^2.0.0",
+				"whatwg-mimetype": "^2.2.0",
+				"whatwg-url": "^7.0.0"
+			}
+		},
+		"debug": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+			"integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+			"requires": {
+				"ms": "2.1.2"
+			}
+		},
+		"decamelize": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+		},
+		"decode-uri-component": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+		},
+		"deep-is": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+		},
 		"deepmerge": {
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-			"integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
-			"dev": true
+			"integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
+		},
+		"define-property": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+			"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+			"requires": {
+				"is-descriptor": "^1.0.2",
+				"isobject": "^3.0.1"
+			},
+			"dependencies": {
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				}
+			}
+		},
+		"delayed-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+		},
+		"detect-newline": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+			"integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA=="
+		},
+		"diff-sequences": {
+			"version": "25.2.6",
+			"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-25.2.6.tgz",
+			"integrity": "sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg=="
+		},
+		"domexception": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
+			"integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+			"requires": {
+				"webidl-conversions": "^4.0.2"
+			}
+		},
+		"ecc-jsbn": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+			"integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+			"requires": {
+				"jsbn": "~0.1.0",
+				"safer-buffer": "^2.1.0"
+			}
+		},
+		"ecdsa-sig-formatter": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+			"integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+			"requires": {
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+		},
+		"end-of-stream": {
+			"version": "1.4.4",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+			"integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+			"requires": {
+				"once": "^1.4.0"
+			}
+		},
+		"error-ex": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+			"integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+			"requires": {
+				"is-arrayish": "^0.2.1"
+			}
+		},
+		"es6-promise": {
+			"version": "4.2.8",
+			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+			"integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
+		},
+		"escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+		},
+		"escodegen": {
+			"version": "1.14.3",
+			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
+			"integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
+			"requires": {
+				"esprima": "^4.0.1",
+				"estraverse": "^4.2.0",
+				"esutils": "^2.0.2",
+				"optionator": "^0.8.1",
+				"source-map": "~0.6.1"
+			}
+		},
+		"esprima": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+		},
+		"estraverse": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="
 		},
 		"estree-walker": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.1.tgz",
 			"integrity": "sha512-tF0hv+Yi2Ot1cwj9eYHtxC0jB9bmjacjQs6ZBTj82H8JwUywFuc+7E83NWfNMwHXZc11mjfFcVXPe9gEP4B8dg==",
 			"dev": true
+		},
+		"esutils": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
+		},
+		"exec-sh": {
+			"version": "0.3.4",
+			"resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.3.4.tgz",
+			"integrity": "sha512-sEFIkc61v75sWeOe72qyrqg2Qg0OuLESziUDk/O/z2qgS15y2gWVFrI6f2Qn/qw/0/NCfCEsmNA4zOjkwEZT1A=="
+		},
+		"execa": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+			"integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+			"requires": {
+				"cross-spawn": "^6.0.0",
+				"get-stream": "^4.0.0",
+				"is-stream": "^1.1.0",
+				"npm-run-path": "^2.0.0",
+				"p-finally": "^1.0.0",
+				"signal-exit": "^3.0.0",
+				"strip-eof": "^1.0.0"
+			}
+		},
+		"exit": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+			"integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw="
+		},
+		"expand-brackets": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+			"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+			"requires": {
+				"debug": "^2.3.3",
+				"define-property": "^0.2.5",
+				"extend-shallow": "^2.0.1",
+				"posix-character-classes": "^0.1.0",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.1"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"requires": {
+						"is-descriptor": "^0.1.0"
+					}
+				},
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
+			}
+		},
+		"expect": {
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/expect/-/expect-25.5.0.tgz",
+			"integrity": "sha512-w7KAXo0+6qqZZhovCaBVPSIqQp7/UTcx4M9uKt2m6pd2VB1voyC8JizLRqeEqud3AAVP02g+hbErDu5gu64tlA==",
+			"requires": {
+				"@jest/types": "^25.5.0",
+				"ansi-styles": "^4.0.0",
+				"jest-get-type": "^25.2.6",
+				"jest-matcher-utils": "^25.5.0",
+				"jest-message-util": "^25.5.0",
+				"jest-regex-util": "^25.2.6"
+			}
+		},
+		"extend": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+		},
+		"extend-shallow": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+			"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+			"requires": {
+				"assign-symbols": "^1.0.0",
+				"is-extendable": "^1.0.1"
+			},
+			"dependencies": {
+				"is-extendable": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+					"requires": {
+						"is-plain-object": "^2.0.4"
+					}
+				}
+			}
+		},
+		"extglob": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+			"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+			"requires": {
+				"array-unique": "^0.3.2",
+				"define-property": "^1.0.0",
+				"expand-brackets": "^2.1.4",
+				"extend-shallow": "^2.0.1",
+				"fragment-cache": "^0.2.1",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"requires": {
+						"is-descriptor": "^1.0.0"
+					}
+				},
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				}
+			}
+		},
+		"extsprintf": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+		},
+		"fast-deep-equal": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+		},
+		"fast-json-stable-stringify": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+		},
+		"fast-levenshtein": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+		},
+		"fb-watchman": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.1.tgz",
+			"integrity": "sha512-DkPJKQeY6kKwmuMretBhr7G6Vodr7bFwDYTXIkfG1gjvNpaxBTQV3PbXg6bR1c1UP4jPOX0jHUbbHANL9vRjVg==",
+			"requires": {
+				"bser": "2.1.1"
+			}
+		},
+		"fill-range": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+			"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+			"requires": {
+				"to-regex-range": "^5.0.1"
+			}
 		},
 		"find-cache-dir": {
 			"version": "3.3.1",
@@ -143,10 +1834,42 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
 			"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-			"dev": true,
 			"requires": {
 				"locate-path": "^5.0.0",
 				"path-exists": "^4.0.0"
+			}
+		},
+		"for-in": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+		},
+		"forever-agent": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+		},
+		"form-data": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+			"integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+			"requires": {
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.6",
+				"mime-types": "^2.1.12"
+			}
+		},
+		"form-urlencoded": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/form-urlencoded/-/form-urlencoded-4.2.1.tgz",
+			"integrity": "sha512-0eFJroOH2qaqc/630d4YZpmsyKmh6sfq/1z3YMXvFab0O6teGnf8640C7gufikwbQJFaC6nPlG4d/GiYVN+Dcw=="
+		},
+		"fragment-cache": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+			"integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+			"requires": {
+				"map-cache": "^0.2.2"
 			}
 		},
 		"fs-extra": {
@@ -163,21 +1886,54 @@
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-			"dev": true
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
 		"fsevents": {
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
 			"integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
-			"dev": true,
 			"optional": true
+		},
+		"gensync": {
+			"version": "1.0.0-beta.1",
+			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
+			"integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg=="
+		},
+		"get-caller-file": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+		},
+		"get-package-type": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+			"integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q=="
+		},
+		"get-stream": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+			"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+			"requires": {
+				"pump": "^3.0.0"
+			}
+		},
+		"get-value": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+			"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
+		},
+		"getpass": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+			"requires": {
+				"assert-plus": "^1.0.0"
+			}
 		},
 		"glob": {
 			"version": "7.1.6",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
 			"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-			"dev": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -187,17 +1943,152 @@
 				"path-is-absolute": "^1.0.0"
 			}
 		},
+		"globals": {
+			"version": "11.12.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
+		},
 		"graceful-fs": {
 			"version": "4.2.4",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-			"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
-			"dev": true
+			"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
+		},
+		"growly": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
+			"integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
+			"optional": true
+		},
+		"har-schema": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+		},
+		"har-validator": {
+			"version": "5.1.5",
+			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+			"integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+			"requires": {
+				"ajv": "^6.12.3",
+				"har-schema": "^2.0.0"
+			}
+		},
+		"has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+		},
+		"has-value": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+			"integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+			"requires": {
+				"get-value": "^2.0.6",
+				"has-values": "^1.0.0",
+				"isobject": "^3.0.0"
+			}
+		},
+		"has-values": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+			"integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+			"requires": {
+				"is-number": "^3.0.0",
+				"kind-of": "^4.0.0"
+			},
+			"dependencies": {
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"requires": {
+						"kind-of": "^3.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"kind-of": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
+		},
+		"hosted-git-info": {
+			"version": "2.8.8",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
+			"integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg=="
+		},
+		"html-encoding-sniffer": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
+			"integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
+			"requires": {
+				"whatwg-encoding": "^1.0.1"
+			}
+		},
+		"html-escaper": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+			"integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="
+		},
+		"http-signature": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+			"requires": {
+				"assert-plus": "^1.0.0",
+				"jsprim": "^1.2.2",
+				"sshpk": "^1.7.0"
+			}
+		},
+		"human-signals": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
+			"integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw=="
+		},
+		"iconv-lite": {
+			"version": "0.4.24",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+			"requires": {
+				"safer-buffer": ">= 2.1.2 < 3"
+			}
+		},
+		"ieee754": {
+			"version": "1.1.13",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+			"integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+		},
+		"import-local": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/import-local/-/import-local-3.0.2.tgz",
+			"integrity": "sha512-vjL3+w0oulAVZ0hBHnxa/Nm5TAurf9YLQJDhqRZyqb+VKGOB6LU8t9H1Nr5CIo16vh9XfJTOoHwU0B71S557gA==",
+			"requires": {
+				"pkg-dir": "^4.2.0",
+				"resolve-cwd": "^3.0.0"
+			}
+		},
+		"imurmurhash": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
 		},
 		"inflight": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-			"dev": true,
 			"requires": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -206,14 +2097,123 @@
 		"inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-			"dev": true
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+		},
+		"ip-regex": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
+			"integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk="
+		},
+		"is-accessor-descriptor": {
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+			"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+			"requires": {
+				"kind-of": "^3.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
+		},
+		"is-arrayish": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+		},
+		"is-buffer": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+		},
+		"is-ci": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+			"integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+			"requires": {
+				"ci-info": "^2.0.0"
+			}
+		},
+		"is-data-descriptor": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+			"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+			"requires": {
+				"kind-of": "^3.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
+		},
+		"is-descriptor": {
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+			"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+			"requires": {
+				"is-accessor-descriptor": "^0.1.6",
+				"is-data-descriptor": "^0.1.4",
+				"kind-of": "^5.0.0"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+				}
+			}
+		},
+		"is-docker": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.1.1.tgz",
+			"integrity": "sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw==",
+			"optional": true
+		},
+		"is-extendable": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+		},
+		"is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+		},
+		"is-generator-fn": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+			"integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ=="
 		},
 		"is-module": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
 			"integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
 			"dev": true
+		},
+		"is-number": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+		},
+		"is-plain-object": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+			"requires": {
+				"isobject": "^3.0.1"
+			}
 		},
 		"is-reference": {
 			"version": "1.2.1",
@@ -222,6 +2222,651 @@
 			"dev": true,
 			"requires": {
 				"@types/estree": "*"
+			}
+		},
+		"is-stream": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+		},
+		"is-typedarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+		},
+		"is-windows": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
+		},
+		"is-wsl": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+			"integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+			"optional": true,
+			"requires": {
+				"is-docker": "^2.0.0"
+			}
+		},
+		"isarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+		},
+		"isexe": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+		},
+		"isobject": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+		},
+		"isstream": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+		},
+		"istanbul-lib-coverage": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
+			"integrity": "sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg=="
+		},
+		"istanbul-lib-instrument": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz",
+			"integrity": "sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==",
+			"requires": {
+				"@babel/core": "^7.7.5",
+				"@istanbuljs/schema": "^0.1.2",
+				"istanbul-lib-coverage": "^3.0.0",
+				"semver": "^6.3.0"
+			}
+		},
+		"istanbul-lib-report": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+			"integrity": "sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==",
+			"requires": {
+				"istanbul-lib-coverage": "^3.0.0",
+				"make-dir": "^3.0.0",
+				"supports-color": "^7.1.0"
+			}
+		},
+		"istanbul-lib-source-maps": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.0.tgz",
+			"integrity": "sha512-c16LpFRkR8vQXyHZ5nLpY35JZtzj1PQY1iZmesUbf1FZHbIupcWfjgOXBY9YHkLEQ6puz1u4Dgj6qmU/DisrZg==",
+			"requires": {
+				"debug": "^4.1.1",
+				"istanbul-lib-coverage": "^3.0.0",
+				"source-map": "^0.6.1"
+			}
+		},
+		"istanbul-reports": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.2.tgz",
+			"integrity": "sha512-9tZvz7AiR3PEDNGiV9vIouQ/EAcqMXFmkcA1CDFTwOB98OZVDL0PH9glHotf5Ugp6GCOTypfzGWI/OqjWNCRUw==",
+			"requires": {
+				"html-escaper": "^2.0.0",
+				"istanbul-lib-report": "^3.0.0"
+			}
+		},
+		"jest": {
+			"version": "25.5.4",
+			"resolved": "https://registry.npmjs.org/jest/-/jest-25.5.4.tgz",
+			"integrity": "sha512-hHFJROBTqZahnO+X+PMtT6G2/ztqAZJveGqz//FnWWHurizkD05PQGzRZOhF3XP6z7SJmL+5tCfW8qV06JypwQ==",
+			"requires": {
+				"@jest/core": "^25.5.4",
+				"import-local": "^3.0.2",
+				"jest-cli": "^25.5.4"
+			},
+			"dependencies": {
+				"jest-cli": {
+					"version": "25.5.4",
+					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-25.5.4.tgz",
+					"integrity": "sha512-rG8uJkIiOUpnREh1768/N3n27Cm+xPFkSNFO91tgg+8o2rXeVLStz+vkXkGr4UtzH6t1SNbjwoiswd7p4AhHTw==",
+					"requires": {
+						"@jest/core": "^25.5.4",
+						"@jest/test-result": "^25.5.0",
+						"@jest/types": "^25.5.0",
+						"chalk": "^3.0.0",
+						"exit": "^0.1.2",
+						"graceful-fs": "^4.2.4",
+						"import-local": "^3.0.2",
+						"is-ci": "^2.0.0",
+						"jest-config": "^25.5.4",
+						"jest-util": "^25.5.0",
+						"jest-validate": "^25.5.0",
+						"prompts": "^2.0.1",
+						"realpath-native": "^2.0.0",
+						"yargs": "^15.3.1"
+					}
+				}
+			}
+		},
+		"jest-changed-files": {
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-25.5.0.tgz",
+			"integrity": "sha512-EOw9QEqapsDT7mKF162m8HFzRPbmP8qJQny6ldVOdOVBz3ACgPm/1nAn5fPQ/NDaYhX/AHkrGwwkCncpAVSXcw==",
+			"requires": {
+				"@jest/types": "^25.5.0",
+				"execa": "^3.2.0",
+				"throat": "^5.0.0"
+			},
+			"dependencies": {
+				"cross-spawn": {
+					"version": "7.0.3",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+					"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+					"requires": {
+						"path-key": "^3.1.0",
+						"shebang-command": "^2.0.0",
+						"which": "^2.0.1"
+					}
+				},
+				"execa": {
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/execa/-/execa-3.4.0.tgz",
+					"integrity": "sha512-r9vdGQk4bmCuK1yKQu1KTwcT2zwfWdbdaXfCtAh+5nU/4fSX+JAb7vZGvI5naJrQlvONrEB20jeruESI69530g==",
+					"requires": {
+						"cross-spawn": "^7.0.0",
+						"get-stream": "^5.0.0",
+						"human-signals": "^1.1.1",
+						"is-stream": "^2.0.0",
+						"merge-stream": "^2.0.0",
+						"npm-run-path": "^4.0.0",
+						"onetime": "^5.1.0",
+						"p-finally": "^2.0.0",
+						"signal-exit": "^3.0.2",
+						"strip-final-newline": "^2.0.0"
+					}
+				},
+				"get-stream": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+					"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+					"requires": {
+						"pump": "^3.0.0"
+					}
+				},
+				"is-stream": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+					"integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
+				},
+				"npm-run-path": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+					"integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+					"requires": {
+						"path-key": "^3.0.0"
+					}
+				},
+				"p-finally": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
+					"integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw=="
+				},
+				"path-key": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+					"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
+				},
+				"shebang-command": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+					"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+					"requires": {
+						"shebang-regex": "^3.0.0"
+					}
+				},
+				"shebang-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+					"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
+				}
+			}
+		},
+		"jest-config": {
+			"version": "25.5.4",
+			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-25.5.4.tgz",
+			"integrity": "sha512-SZwR91SwcdK6bz7Gco8qL7YY2sx8tFJYzvg216DLihTWf+LKY/DoJXpM9nTzYakSyfblbqeU48p/p7Jzy05Atg==",
+			"requires": {
+				"@babel/core": "^7.1.0",
+				"@jest/test-sequencer": "^25.5.4",
+				"@jest/types": "^25.5.0",
+				"babel-jest": "^25.5.1",
+				"chalk": "^3.0.0",
+				"deepmerge": "^4.2.2",
+				"glob": "^7.1.1",
+				"graceful-fs": "^4.2.4",
+				"jest-environment-jsdom": "^25.5.0",
+				"jest-environment-node": "^25.5.0",
+				"jest-get-type": "^25.2.6",
+				"jest-jasmine2": "^25.5.4",
+				"jest-regex-util": "^25.2.6",
+				"jest-resolve": "^25.5.1",
+				"jest-util": "^25.5.0",
+				"jest-validate": "^25.5.0",
+				"micromatch": "^4.0.2",
+				"pretty-format": "^25.5.0",
+				"realpath-native": "^2.0.0"
+			}
+		},
+		"jest-diff": {
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-25.5.0.tgz",
+			"integrity": "sha512-z1kygetuPiREYdNIumRpAHY6RXiGmp70YHptjdaxTWGmA085W3iCnXNx0DhflK3vwrKmrRWyY1wUpkPMVxMK7A==",
+			"requires": {
+				"chalk": "^3.0.0",
+				"diff-sequences": "^25.2.6",
+				"jest-get-type": "^25.2.6",
+				"pretty-format": "^25.5.0"
+			}
+		},
+		"jest-docblock": {
+			"version": "25.3.0",
+			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-25.3.0.tgz",
+			"integrity": "sha512-aktF0kCar8+zxRHxQZwxMy70stc9R1mOmrLsT5VO3pIT0uzGRSDAXxSlz4NqQWpuLjPpuMhPRl7H+5FRsvIQAg==",
+			"requires": {
+				"detect-newline": "^3.0.0"
+			}
+		},
+		"jest-each": {
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-25.5.0.tgz",
+			"integrity": "sha512-QBogUxna3D8vtiItvn54xXde7+vuzqRrEeaw8r1s+1TG9eZLVJE5ZkKoSUlqFwRjnlaA4hyKGiu9OlkFIuKnjA==",
+			"requires": {
+				"@jest/types": "^25.5.0",
+				"chalk": "^3.0.0",
+				"jest-get-type": "^25.2.6",
+				"jest-util": "^25.5.0",
+				"pretty-format": "^25.5.0"
+			}
+		},
+		"jest-environment-jsdom": {
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-25.5.0.tgz",
+			"integrity": "sha512-7Jr02ydaq4jaWMZLY+Skn8wL5nVIYpWvmeatOHL3tOcV3Zw8sjnPpx+ZdeBfc457p8jCR9J6YCc+Lga0oIy62A==",
+			"requires": {
+				"@jest/environment": "^25.5.0",
+				"@jest/fake-timers": "^25.5.0",
+				"@jest/types": "^25.5.0",
+				"jest-mock": "^25.5.0",
+				"jest-util": "^25.5.0",
+				"jsdom": "^15.2.1"
+			}
+		},
+		"jest-environment-node": {
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-25.5.0.tgz",
+			"integrity": "sha512-iuxK6rQR2En9EID+2k+IBs5fCFd919gVVK5BeND82fYeLWPqvRcFNPKu9+gxTwfB5XwBGBvZ0HFQa+cHtIoslA==",
+			"requires": {
+				"@jest/environment": "^25.5.0",
+				"@jest/fake-timers": "^25.5.0",
+				"@jest/types": "^25.5.0",
+				"jest-mock": "^25.5.0",
+				"jest-util": "^25.5.0",
+				"semver": "^6.3.0"
+			}
+		},
+		"jest-get-type": {
+			"version": "25.2.6",
+			"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.2.6.tgz",
+			"integrity": "sha512-DxjtyzOHjObRM+sM1knti6or+eOgcGU4xVSb2HNP1TqO4ahsT+rqZg+nyqHWJSvWgKC5cG3QjGFBqxLghiF/Ig=="
+		},
+		"jest-haste-map": {
+			"version": "25.5.1",
+			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-25.5.1.tgz",
+			"integrity": "sha512-dddgh9UZjV7SCDQUrQ+5t9yy8iEgKc1AKqZR9YDww8xsVOtzPQSMVLDChc21+g29oTRexb9/B0bIlZL+sWmvAQ==",
+			"requires": {
+				"@jest/types": "^25.5.0",
+				"@types/graceful-fs": "^4.1.2",
+				"anymatch": "^3.0.3",
+				"fb-watchman": "^2.0.0",
+				"fsevents": "^2.1.2",
+				"graceful-fs": "^4.2.4",
+				"jest-serializer": "^25.5.0",
+				"jest-util": "^25.5.0",
+				"jest-worker": "^25.5.0",
+				"micromatch": "^4.0.2",
+				"sane": "^4.0.3",
+				"walker": "^1.0.7",
+				"which": "^2.0.2"
+			}
+		},
+		"jest-jasmine2": {
+			"version": "25.5.4",
+			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-25.5.4.tgz",
+			"integrity": "sha512-9acbWEfbmS8UpdcfqnDO+uBUgKa/9hcRh983IHdM+pKmJPL77G0sWAAK0V0kr5LK3a8cSBfkFSoncXwQlRZfkQ==",
+			"requires": {
+				"@babel/traverse": "^7.1.0",
+				"@jest/environment": "^25.5.0",
+				"@jest/source-map": "^25.5.0",
+				"@jest/test-result": "^25.5.0",
+				"@jest/types": "^25.5.0",
+				"chalk": "^3.0.0",
+				"co": "^4.6.0",
+				"expect": "^25.5.0",
+				"is-generator-fn": "^2.0.0",
+				"jest-each": "^25.5.0",
+				"jest-matcher-utils": "^25.5.0",
+				"jest-message-util": "^25.5.0",
+				"jest-runtime": "^25.5.4",
+				"jest-snapshot": "^25.5.1",
+				"jest-util": "^25.5.0",
+				"pretty-format": "^25.5.0",
+				"throat": "^5.0.0"
+			}
+		},
+		"jest-leak-detector": {
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-25.5.0.tgz",
+			"integrity": "sha512-rV7JdLsanS8OkdDpZtgBf61L5xZ4NnYLBq72r6ldxahJWWczZjXawRsoHyXzibM5ed7C2QRjpp6ypgwGdKyoVA==",
+			"requires": {
+				"jest-get-type": "^25.2.6",
+				"pretty-format": "^25.5.0"
+			}
+		},
+		"jest-matcher-utils": {
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-25.5.0.tgz",
+			"integrity": "sha512-VWI269+9JS5cpndnpCwm7dy7JtGQT30UHfrnM3mXl22gHGt/b7NkjBqXfbhZ8V4B7ANUsjK18PlSBmG0YH7gjw==",
+			"requires": {
+				"chalk": "^3.0.0",
+				"jest-diff": "^25.5.0",
+				"jest-get-type": "^25.2.6",
+				"pretty-format": "^25.5.0"
+			}
+		},
+		"jest-message-util": {
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-25.5.0.tgz",
+			"integrity": "sha512-ezddz3YCT/LT0SKAmylVyWWIGYoKHOFOFXx3/nA4m794lfVUskMcwhip6vTgdVrOtYdjeQeis2ypzes9mZb4EA==",
+			"requires": {
+				"@babel/code-frame": "^7.0.0",
+				"@jest/types": "^25.5.0",
+				"@types/stack-utils": "^1.0.1",
+				"chalk": "^3.0.0",
+				"graceful-fs": "^4.2.4",
+				"micromatch": "^4.0.2",
+				"slash": "^3.0.0",
+				"stack-utils": "^1.0.1"
+			}
+		},
+		"jest-mock": {
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-25.5.0.tgz",
+			"integrity": "sha512-eXWuTV8mKzp/ovHc5+3USJMYsTBhyQ+5A1Mak35dey/RG8GlM4YWVylZuGgVXinaW6tpvk/RSecmF37FKUlpXA==",
+			"requires": {
+				"@jest/types": "^25.5.0"
+			}
+		},
+		"jest-pnp-resolver": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
+			"integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w=="
+		},
+		"jest-regex-util": {
+			"version": "25.2.6",
+			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-25.2.6.tgz",
+			"integrity": "sha512-KQqf7a0NrtCkYmZZzodPftn7fL1cq3GQAFVMn5Hg8uKx/fIenLEobNanUxb7abQ1sjADHBseG/2FGpsv/wr+Qw=="
+		},
+		"jest-resolve": {
+			"version": "25.5.1",
+			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-25.5.1.tgz",
+			"integrity": "sha512-Hc09hYch5aWdtejsUZhA+vSzcotf7fajSlPA6EZPE1RmPBAD39XtJhvHWFStid58iit4IPDLI/Da4cwdDmAHiQ==",
+			"requires": {
+				"@jest/types": "^25.5.0",
+				"browser-resolve": "^1.11.3",
+				"chalk": "^3.0.0",
+				"graceful-fs": "^4.2.4",
+				"jest-pnp-resolver": "^1.2.1",
+				"read-pkg-up": "^7.0.1",
+				"realpath-native": "^2.0.0",
+				"resolve": "^1.17.0",
+				"slash": "^3.0.0"
+			}
+		},
+		"jest-resolve-dependencies": {
+			"version": "25.5.4",
+			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-25.5.4.tgz",
+			"integrity": "sha512-yFmbPd+DAQjJQg88HveObcGBA32nqNZ02fjYmtL16t1xw9bAttSn5UGRRhzMHIQbsep7znWvAvnD4kDqOFM0Uw==",
+			"requires": {
+				"@jest/types": "^25.5.0",
+				"jest-regex-util": "^25.2.6",
+				"jest-snapshot": "^25.5.1"
+			}
+		},
+		"jest-runner": {
+			"version": "25.5.4",
+			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-25.5.4.tgz",
+			"integrity": "sha512-V/2R7fKZo6blP8E9BL9vJ8aTU4TH2beuqGNxHbxi6t14XzTb+x90B3FRgdvuHm41GY8ch4xxvf0ATH4hdpjTqg==",
+			"requires": {
+				"@jest/console": "^25.5.0",
+				"@jest/environment": "^25.5.0",
+				"@jest/test-result": "^25.5.0",
+				"@jest/types": "^25.5.0",
+				"chalk": "^3.0.0",
+				"exit": "^0.1.2",
+				"graceful-fs": "^4.2.4",
+				"jest-config": "^25.5.4",
+				"jest-docblock": "^25.3.0",
+				"jest-haste-map": "^25.5.1",
+				"jest-jasmine2": "^25.5.4",
+				"jest-leak-detector": "^25.5.0",
+				"jest-message-util": "^25.5.0",
+				"jest-resolve": "^25.5.1",
+				"jest-runtime": "^25.5.4",
+				"jest-util": "^25.5.0",
+				"jest-worker": "^25.5.0",
+				"source-map-support": "^0.5.6",
+				"throat": "^5.0.0"
+			}
+		},
+		"jest-runtime": {
+			"version": "25.5.4",
+			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-25.5.4.tgz",
+			"integrity": "sha512-RWTt8LeWh3GvjYtASH2eezkc8AehVoWKK20udV6n3/gC87wlTbE1kIA+opCvNWyyPeBs6ptYsc6nyHUb1GlUVQ==",
+			"requires": {
+				"@jest/console": "^25.5.0",
+				"@jest/environment": "^25.5.0",
+				"@jest/globals": "^25.5.2",
+				"@jest/source-map": "^25.5.0",
+				"@jest/test-result": "^25.5.0",
+				"@jest/transform": "^25.5.1",
+				"@jest/types": "^25.5.0",
+				"@types/yargs": "^15.0.0",
+				"chalk": "^3.0.0",
+				"collect-v8-coverage": "^1.0.0",
+				"exit": "^0.1.2",
+				"glob": "^7.1.3",
+				"graceful-fs": "^4.2.4",
+				"jest-config": "^25.5.4",
+				"jest-haste-map": "^25.5.1",
+				"jest-message-util": "^25.5.0",
+				"jest-mock": "^25.5.0",
+				"jest-regex-util": "^25.2.6",
+				"jest-resolve": "^25.5.1",
+				"jest-snapshot": "^25.5.1",
+				"jest-util": "^25.5.0",
+				"jest-validate": "^25.5.0",
+				"realpath-native": "^2.0.0",
+				"slash": "^3.0.0",
+				"strip-bom": "^4.0.0",
+				"yargs": "^15.3.1"
+			}
+		},
+		"jest-serializer": {
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-25.5.0.tgz",
+			"integrity": "sha512-LxD8fY1lByomEPflwur9o4e2a5twSQ7TaVNLlFUuToIdoJuBt8tzHfCsZ42Ok6LkKXWzFWf3AGmheuLAA7LcCA==",
+			"requires": {
+				"graceful-fs": "^4.2.4"
+			}
+		},
+		"jest-snapshot": {
+			"version": "25.5.1",
+			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-25.5.1.tgz",
+			"integrity": "sha512-C02JE1TUe64p2v1auUJ2ze5vcuv32tkv9PyhEb318e8XOKF7MOyXdJ7kdjbvrp3ChPLU2usI7Rjxs97Dj5P0uQ==",
+			"requires": {
+				"@babel/types": "^7.0.0",
+				"@jest/types": "^25.5.0",
+				"@types/prettier": "^1.19.0",
+				"chalk": "^3.0.0",
+				"expect": "^25.5.0",
+				"graceful-fs": "^4.2.4",
+				"jest-diff": "^25.5.0",
+				"jest-get-type": "^25.2.6",
+				"jest-matcher-utils": "^25.5.0",
+				"jest-message-util": "^25.5.0",
+				"jest-resolve": "^25.5.1",
+				"make-dir": "^3.0.0",
+				"natural-compare": "^1.4.0",
+				"pretty-format": "^25.5.0",
+				"semver": "^6.3.0"
+			}
+		},
+		"jest-util": {
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-25.5.0.tgz",
+			"integrity": "sha512-KVlX+WWg1zUTB9ktvhsg2PXZVdkI1NBevOJSkTKYAyXyH4QSvh+Lay/e/v+bmaFfrkfx43xD8QTfgobzlEXdIA==",
+			"requires": {
+				"@jest/types": "^25.5.0",
+				"chalk": "^3.0.0",
+				"graceful-fs": "^4.2.4",
+				"is-ci": "^2.0.0",
+				"make-dir": "^3.0.0"
+			}
+		},
+		"jest-validate": {
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-25.5.0.tgz",
+			"integrity": "sha512-okUFKqhZIpo3jDdtUXUZ2LxGUZJIlfdYBvZb1aczzxrlyMlqdnnws9MOxezoLGhSaFc2XYaHNReNQfj5zPIWyQ==",
+			"requires": {
+				"@jest/types": "^25.5.0",
+				"camelcase": "^5.3.1",
+				"chalk": "^3.0.0",
+				"jest-get-type": "^25.2.6",
+				"leven": "^3.1.0",
+				"pretty-format": "^25.5.0"
+			}
+		},
+		"jest-watcher": {
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-25.5.0.tgz",
+			"integrity": "sha512-XrSfJnVASEl+5+bb51V0Q7WQx65dTSk7NL4yDdVjPnRNpM0hG+ncFmDYJo9O8jaSRcAitVbuVawyXCRoxGrT5Q==",
+			"requires": {
+				"@jest/test-result": "^25.5.0",
+				"@jest/types": "^25.5.0",
+				"ansi-escapes": "^4.2.1",
+				"chalk": "^3.0.0",
+				"jest-util": "^25.5.0",
+				"string-length": "^3.1.0"
+			}
+		},
+		"jest-worker": {
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-25.5.0.tgz",
+			"integrity": "sha512-/dsSmUkIy5EBGfv/IjjqmFxrNAUpBERfGs1oHROyD7yxjG/w+t0GOJDX8O1k32ySmd7+a5IhnJU2qQFcJ4n1vw==",
+			"requires": {
+				"merge-stream": "^2.0.0",
+				"supports-color": "^7.0.0"
+			}
+		},
+		"jose": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/jose/-/jose-2.0.2.tgz",
+			"integrity": "sha512-yD93lsiMA1go/qxSY/vXWBodmIZJIxeB7QhFi8z1yQ3KUwKENqI9UA8VCHlQ5h3x1zWuWZjoY87ByQzkQbIrQg==",
+			"requires": {
+				"@panva/asn1.js": "^1.0.0"
+			}
+		},
+		"js-tokens": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+		},
+		"js-yaml": {
+			"version": "3.14.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
+			"integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
+			"requires": {
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
+			}
+		},
+		"jsbn": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+		},
+		"jsdom": {
+			"version": "15.2.1",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-15.2.1.tgz",
+			"integrity": "sha512-fAl1W0/7T2G5vURSyxBzrJ1LSdQn6Tr5UX/xD4PXDx/PDgwygedfW6El/KIj3xJ7FU61TTYnc/l/B7P49Eqt6g==",
+			"requires": {
+				"abab": "^2.0.0",
+				"acorn": "^7.1.0",
+				"acorn-globals": "^4.3.2",
+				"array-equal": "^1.0.0",
+				"cssom": "^0.4.1",
+				"cssstyle": "^2.0.0",
+				"data-urls": "^1.1.0",
+				"domexception": "^1.0.1",
+				"escodegen": "^1.11.1",
+				"html-encoding-sniffer": "^1.0.2",
+				"nwsapi": "^2.2.0",
+				"parse5": "5.1.0",
+				"pn": "^1.1.0",
+				"request": "^2.88.0",
+				"request-promise-native": "^1.0.7",
+				"saxes": "^3.1.9",
+				"symbol-tree": "^3.2.2",
+				"tough-cookie": "^3.0.1",
+				"w3c-hr-time": "^1.0.1",
+				"w3c-xmlserializer": "^1.1.2",
+				"webidl-conversions": "^4.0.2",
+				"whatwg-encoding": "^1.0.5",
+				"whatwg-mimetype": "^2.3.0",
+				"whatwg-url": "^7.0.0",
+				"ws": "^7.0.0",
+				"xml-name-validator": "^3.0.0"
+			}
+		},
+		"jsesc": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
+		},
+		"json-parse-even-better-errors": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
+		},
+		"json-schema": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+		},
+		"json-schema-traverse": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+		},
+		"json-stringify-safe": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+		},
+		"json5": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+			"integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+			"requires": {
+				"minimist": "^1.2.5"
 			}
 		},
 		"jsonfile": {
@@ -233,14 +2878,159 @@
 				"graceful-fs": "^4.1.6"
 			}
 		},
+		"jsonwebtoken": {
+			"version": "8.5.1",
+			"resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+			"integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+			"requires": {
+				"jws": "^3.2.2",
+				"lodash.includes": "^4.3.0",
+				"lodash.isboolean": "^3.0.3",
+				"lodash.isinteger": "^4.0.4",
+				"lodash.isnumber": "^3.0.3",
+				"lodash.isplainobject": "^4.0.6",
+				"lodash.isstring": "^4.0.1",
+				"lodash.once": "^4.0.0",
+				"ms": "^2.1.1",
+				"semver": "^5.6.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+				}
+			}
+		},
+		"jsprim": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+			"requires": {
+				"assert-plus": "1.0.0",
+				"extsprintf": "1.3.0",
+				"json-schema": "0.2.3",
+				"verror": "1.10.0"
+			}
+		},
+		"jwa": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+			"integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+			"requires": {
+				"buffer-equal-constant-time": "1.0.1",
+				"ecdsa-sig-formatter": "1.0.11",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"jws": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+			"integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+			"requires": {
+				"jwa": "^1.4.1",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"kind-of": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+			"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
+		},
+		"kleur": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+			"integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="
+		},
+		"leven": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+			"integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A=="
+		},
+		"levn": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+			"requires": {
+				"prelude-ls": "~1.1.2",
+				"type-check": "~0.3.2"
+			}
+		},
+		"lines-and-columns": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+			"integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA="
+		},
 		"locate-path": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
 			"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-			"dev": true,
 			"requires": {
 				"p-locate": "^4.1.0"
 			}
+		},
+		"lodash": {
+			"version": "4.17.20",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+			"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+		},
+		"lodash.clonedeep": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+			"integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+		},
+		"lodash.includes": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+			"integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+		},
+		"lodash.isboolean": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+			"integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+		},
+		"lodash.isinteger": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+			"integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+		},
+		"lodash.isnumber": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+			"integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+		},
+		"lodash.isplainobject": {
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+			"integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+		},
+		"lodash.isstring": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+			"integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+		},
+		"lodash.once": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+			"integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
+		},
+		"lodash.sortby": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
+		},
+		"lolex": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/lolex/-/lolex-5.1.2.tgz",
+			"integrity": "sha512-h4hmjAvHTmd+25JSwrtTIuwbKdwg5NzZVRMLn9saij4SZaepCrTCxPr35H/3bjwfMJtN+t3CX8672UIkglz28A==",
+			"requires": {
+				"@sinonjs/commons": "^1.7.0"
+			}
+		},
+		"long": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+			"integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
 		},
 		"magic-string": {
 			"version": "0.25.7",
@@ -255,40 +3045,323 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
 			"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-			"dev": true,
 			"requires": {
 				"semver": "^6.0.0"
 			}
+		},
+		"makeerror": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
+			"integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
+			"requires": {
+				"tmpl": "1.0.x"
+			}
+		},
+		"map-cache": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+			"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
+		},
+		"map-visit": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+			"integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+			"requires": {
+				"object-visit": "^1.0.0"
+			}
+		},
+		"merge-stream": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
+		},
+		"micromatch": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+			"integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+			"requires": {
+				"braces": "^3.0.1",
+				"picomatch": "^2.0.5"
+			}
+		},
+		"mime-db": {
+			"version": "1.44.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
+			"integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
+		},
+		"mime-types": {
+			"version": "2.1.27",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
+			"integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+			"requires": {
+				"mime-db": "1.44.0"
+			}
+		},
+		"mimic-fn": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
 		},
 		"minimatch": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-			"dev": true,
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}
 		},
+		"minimist": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+		},
+		"mixin-deep": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+			"integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
+			"requires": {
+				"for-in": "^1.0.2",
+				"is-extendable": "^1.0.1"
+			},
+			"dependencies": {
+				"is-extendable": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+					"requires": {
+						"is-plain-object": "^2.0.4"
+					}
+				}
+			}
+		},
+		"ms": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+		},
+		"nanomatch": {
+			"version": "1.2.13",
+			"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+			"integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+			"requires": {
+				"arr-diff": "^4.0.0",
+				"array-unique": "^0.3.2",
+				"define-property": "^2.0.2",
+				"extend-shallow": "^3.0.2",
+				"fragment-cache": "^0.2.1",
+				"is-windows": "^1.0.2",
+				"kind-of": "^6.0.2",
+				"object.pick": "^1.3.0",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.1"
+			}
+		},
+		"natural-compare": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
+		},
+		"nice-try": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
+		},
 		"node-fetch": {
 			"version": "2.6.1",
 			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-			"integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
-			"dev": true
+			"integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+		},
+		"node-forge": {
+			"version": "0.10.0",
+			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+			"integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
+		},
+		"node-int64": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+			"integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs="
+		},
+		"node-jose": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/node-jose/-/node-jose-2.0.0.tgz",
+			"integrity": "sha512-j8zoFze1gijl8+DK/dSXXqX7+o2lMYv1XS+ptnXgGV/eloQaqq1YjNtieepbKs9jBS4WTnMOqyKSaQuunJzx0A==",
+			"requires": {
+				"base64url": "^3.0.1",
+				"buffer": "^5.5.0",
+				"es6-promise": "^4.2.8",
+				"lodash": "^4.17.15",
+				"long": "^4.0.0",
+				"node-forge": "^0.10.0",
+				"pako": "^1.0.11",
+				"process": "^0.11.10",
+				"uuid": "^3.3.3"
+			},
+			"dependencies": {
+				"uuid": {
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+					"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+				}
+			}
+		},
+		"node-modules-regexp": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
+			"integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA="
+		},
+		"node-notifier": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-6.0.0.tgz",
+			"integrity": "sha512-SVfQ/wMw+DesunOm5cKqr6yDcvUTDl/yc97ybGHMrteNEY6oekXpNpS3lZwgLlwz0FLgHoiW28ZpmBHUDg37cw==",
+			"optional": true,
+			"requires": {
+				"growly": "^1.3.0",
+				"is-wsl": "^2.1.1",
+				"semver": "^6.3.0",
+				"shellwords": "^0.1.1",
+				"which": "^1.3.1"
+			},
+			"dependencies": {
+				"which": {
+					"version": "1.3.1",
+					"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+					"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+					"optional": true,
+					"requires": {
+						"isexe": "^2.0.0"
+					}
+				}
+			}
+		},
+		"normalize-package-data": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+			"integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+			"requires": {
+				"hosted-git-info": "^2.1.4",
+				"resolve": "^1.10.0",
+				"semver": "2 || 3 || 4 || 5",
+				"validate-npm-package-license": "^3.0.1"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+				}
+			}
+		},
+		"normalize-path": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
+		},
+		"npm-run-path": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+			"requires": {
+				"path-key": "^2.0.0"
+			}
+		},
+		"nwsapi": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
+			"integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ=="
+		},
+		"oauth-sign": {
+			"version": "0.9.0",
+			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+		},
+		"object-copy": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+			"integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+			"requires": {
+				"copy-descriptor": "^0.1.0",
+				"define-property": "^0.2.5",
+				"kind-of": "^3.0.3"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"requires": {
+						"is-descriptor": "^0.1.0"
+					}
+				},
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
+		},
+		"object-visit": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+			"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+			"requires": {
+				"isobject": "^3.0.0"
+			}
+		},
+		"object.pick": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+			"integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+			"requires": {
+				"isobject": "^3.0.1"
+			}
 		},
 		"once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-			"dev": true,
 			"requires": {
 				"wrappy": "1"
 			}
+		},
+		"onetime": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+			"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+			"requires": {
+				"mimic-fn": "^2.1.0"
+			}
+		},
+		"optionator": {
+			"version": "0.8.3",
+			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+			"integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+			"requires": {
+				"deep-is": "~0.1.3",
+				"fast-levenshtein": "~2.0.6",
+				"levn": "~0.3.0",
+				"prelude-ls": "~1.1.2",
+				"type-check": "~0.3.2",
+				"word-wrap": "~1.2.3"
+			}
+		},
+		"p-each-series": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.1.0.tgz",
+			"integrity": "sha512-ZuRs1miPT4HrjFa+9fRfOFXxGJfORgelKV9f9nNOWw2gl6gVsRaVDOQP0+MI0G0wGKns1Yacsu0GjOFbTK0JFQ=="
+		},
+		"p-finally": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
 		},
 		"p-limit": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
 			"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-			"dev": true,
 			"requires": {
 				"p-try": "^2.0.0"
 			}
@@ -297,7 +3370,6 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
 			"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-			"dev": true,
 			"requires": {
 				"p-limit": "^2.2.0"
 			}
@@ -305,49 +3377,347 @@
 		"p-try": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-			"dev": true
+			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+		},
+		"pako": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+			"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+		},
+		"parse-json": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.1.0.tgz",
+			"integrity": "sha512-+mi/lmVVNKFNVyLXV31ERiy2CY5E1/F6QtJFEzoChPRwwngMNXRDQ9GJ5WdE2Z2P4AujsOi0/+2qHID68KwfIQ==",
+			"requires": {
+				"@babel/code-frame": "^7.0.0",
+				"error-ex": "^1.3.1",
+				"json-parse-even-better-errors": "^2.3.0",
+				"lines-and-columns": "^1.1.6"
+			}
+		},
+		"parse5": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.0.tgz",
+			"integrity": "sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ=="
+		},
+		"pascalcase": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+			"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
 		},
 		"path-exists": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-			"dev": true
+			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
 		},
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-			"dev": true
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+		},
+		"path-key": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
 		},
 		"path-parse": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
-			"dev": true
+			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+		},
+		"performance-now": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
 		},
 		"picomatch": {
 			"version": "2.2.2",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
-			"integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
-			"dev": true
+			"integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg=="
+		},
+		"pirates": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.1.tgz",
+			"integrity": "sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==",
+			"requires": {
+				"node-modules-regexp": "^1.0.0"
+			}
 		},
 		"pkg-dir": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
 			"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-			"dev": true,
 			"requires": {
 				"find-up": "^4.0.0"
 			}
+		},
+		"pn": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
+			"integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA=="
+		},
+		"posix-character-classes": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
+		},
+		"prelude-ls": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+		},
+		"pretty-format": {
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
+			"integrity": "sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==",
+			"requires": {
+				"@jest/types": "^25.5.0",
+				"ansi-regex": "^5.0.0",
+				"ansi-styles": "^4.0.0",
+				"react-is": "^16.12.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+				}
+			}
+		},
+		"process": {
+			"version": "0.11.10",
+			"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+			"integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
+		},
+		"prompts": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.3.2.tgz",
+			"integrity": "sha512-Q06uKs2CkNYVID0VqwfAl9mipo99zkBv/n2JtWY89Yxa3ZabWSrs0e2KTudKVa3peLUvYXMefDqIleLPVUBZMA==",
+			"requires": {
+				"kleur": "^3.0.3",
+				"sisteransi": "^1.0.4"
+			}
+		},
+		"psl": {
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+			"integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
+		},
+		"pump": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+			"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+			"requires": {
+				"end-of-stream": "^1.1.0",
+				"once": "^1.3.1"
+			}
+		},
+		"punycode": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+		},
+		"qs": {
+			"version": "6.5.2",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+		},
+		"querystringify": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+			"integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
+		},
+		"react-is": {
+			"version": "16.13.1",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+		},
+		"read-pkg": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+			"integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+			"requires": {
+				"@types/normalize-package-data": "^2.4.0",
+				"normalize-package-data": "^2.5.0",
+				"parse-json": "^5.0.0",
+				"type-fest": "^0.6.0"
+			},
+			"dependencies": {
+				"type-fest": {
+					"version": "0.6.0",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+					"integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg=="
+				}
+			}
+		},
+		"read-pkg-up": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+			"integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+			"requires": {
+				"find-up": "^4.1.0",
+				"read-pkg": "^5.2.0",
+				"type-fest": "^0.8.1"
+			}
+		},
+		"realpath-native": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-2.0.0.tgz",
+			"integrity": "sha512-v1SEYUOXXdbBZK8ZuNgO4TBjamPsiSgcFr0aP+tEKpQZK8vooEUqV6nm6Cv502mX4NF2EfsnVqtNAHG+/6Ur1Q=="
+		},
+		"reflect-metadata": {
+			"version": "0.1.13",
+			"resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
+			"integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
+		},
+		"regex-not": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+			"integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+			"requires": {
+				"extend-shallow": "^3.0.2",
+				"safe-regex": "^1.1.0"
+			}
+		},
+		"remove-trailing-separator": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+		},
+		"repeat-element": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
+			"integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g=="
+		},
+		"repeat-string": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+		},
+		"request": {
+			"version": "2.88.2",
+			"resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+			"integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+			"requires": {
+				"aws-sign2": "~0.7.0",
+				"aws4": "^1.8.0",
+				"caseless": "~0.12.0",
+				"combined-stream": "~1.0.6",
+				"extend": "~3.0.2",
+				"forever-agent": "~0.6.1",
+				"form-data": "~2.3.2",
+				"har-validator": "~5.1.3",
+				"http-signature": "~1.2.0",
+				"is-typedarray": "~1.0.0",
+				"isstream": "~0.1.2",
+				"json-stringify-safe": "~5.0.1",
+				"mime-types": "~2.1.19",
+				"oauth-sign": "~0.9.0",
+				"performance-now": "^2.1.0",
+				"qs": "~6.5.2",
+				"safe-buffer": "^5.1.2",
+				"tough-cookie": "~2.5.0",
+				"tunnel-agent": "^0.6.0",
+				"uuid": "^3.3.2"
+			},
+			"dependencies": {
+				"tough-cookie": {
+					"version": "2.5.0",
+					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+					"integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+					"requires": {
+						"psl": "^1.1.28",
+						"punycode": "^2.1.1"
+					}
+				},
+				"uuid": {
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+					"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+				}
+			}
+		},
+		"request-promise-core": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
+			"integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
+			"requires": {
+				"lodash": "^4.17.19"
+			}
+		},
+		"request-promise-native": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
+			"integrity": "sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==",
+			"requires": {
+				"request-promise-core": "1.1.4",
+				"stealthy-require": "^1.1.1",
+				"tough-cookie": "^2.3.3"
+			},
+			"dependencies": {
+				"tough-cookie": {
+					"version": "2.5.0",
+					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+					"integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+					"requires": {
+						"psl": "^1.1.28",
+						"punycode": "^2.1.1"
+					}
+				}
+			}
+		},
+		"require-directory": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+		},
+		"require-main-filename": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+			"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
+		},
+		"requires-port": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+			"integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
 		},
 		"resolve": {
 			"version": "1.17.0",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
 			"integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
-			"dev": true,
 			"requires": {
 				"path-parse": "^1.0.6"
+			}
+		},
+		"resolve-cwd": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+			"integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+			"requires": {
+				"resolve-from": "^5.0.0"
+			}
+		},
+		"resolve-from": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+			"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="
+		},
+		"resolve-url": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
+		},
+		"ret": {
+			"version": "0.1.15",
+			"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
+		},
+		"rimraf": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+			"requires": {
+				"glob": "^7.1.3"
 			}
 		},
 		"rollup": {
@@ -372,11 +3742,377 @@
 				"tslib": "2.0.1"
 			}
 		},
+		"rsvp": {
+			"version": "4.8.5",
+			"resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
+			"integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA=="
+		},
+		"safe-buffer": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+		},
+		"safe-regex": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+			"requires": {
+				"ret": "~0.1.10"
+			}
+		},
+		"safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+		},
+		"sane": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/sane/-/sane-4.1.0.tgz",
+			"integrity": "sha512-hhbzAgTIX8O7SHfp2c8/kREfEn4qO/9q8C9beyY6+tvZ87EpoZ3i1RIEvp27YBswnNbY9mWd6paKVmKbAgLfZA==",
+			"requires": {
+				"@cnakazawa/watch": "^1.0.3",
+				"anymatch": "^2.0.0",
+				"capture-exit": "^2.0.0",
+				"exec-sh": "^0.3.2",
+				"execa": "^1.0.0",
+				"fb-watchman": "^2.0.0",
+				"micromatch": "^3.1.4",
+				"minimist": "^1.1.1",
+				"walker": "~1.0.5"
+			},
+			"dependencies": {
+				"anymatch": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+					"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+					"requires": {
+						"micromatch": "^3.1.4",
+						"normalize-path": "^2.1.1"
+					}
+				},
+				"braces": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+					"requires": {
+						"arr-flatten": "^1.1.0",
+						"array-unique": "^0.3.2",
+						"extend-shallow": "^2.0.1",
+						"fill-range": "^4.0.0",
+						"isobject": "^3.0.1",
+						"repeat-element": "^1.1.2",
+						"snapdragon": "^0.8.1",
+						"snapdragon-node": "^2.0.1",
+						"split-string": "^3.0.2",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"fill-range": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+					"requires": {
+						"extend-shallow": "^2.0.1",
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1",
+						"to-regex-range": "^2.1.0"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"requires": {
+						"kind-of": "^3.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"micromatch": {
+					"version": "3.1.10",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+					"requires": {
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"braces": "^2.3.1",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"extglob": "^2.0.4",
+						"fragment-cache": "^0.2.1",
+						"kind-of": "^6.0.2",
+						"nanomatch": "^1.2.9",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.2"
+					}
+				},
+				"normalize-path": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+					"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+					"requires": {
+						"remove-trailing-separator": "^1.0.1"
+					}
+				},
+				"to-regex-range": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+					"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+					"requires": {
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1"
+					}
+				}
+			}
+		},
+		"saxes": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/saxes/-/saxes-3.1.11.tgz",
+			"integrity": "sha512-Ydydq3zC+WYDJK1+gRxRapLIED9PWeSuuS41wqyoRmzvhhh9nc+QQrVMKJYzJFULazeGhzSV0QleN2wD3boh2g==",
+			"requires": {
+				"xmlchars": "^2.1.1"
+			}
+		},
 		"semver": {
 			"version": "6.3.0",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-			"dev": true
+			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+		},
+		"set-blocking": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+		},
+		"set-value": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+			"integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
+			"requires": {
+				"extend-shallow": "^2.0.1",
+				"is-extendable": "^0.1.1",
+				"is-plain-object": "^2.0.3",
+				"split-string": "^3.0.1"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				}
+			}
+		},
+		"shebang-command": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+			"requires": {
+				"shebang-regex": "^1.0.0"
+			}
+		},
+		"shebang-regex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+		},
+		"shellwords": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
+			"integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
+			"optional": true
+		},
+		"signal-exit": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
+			"integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
+		},
+		"sisteransi": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+			"integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="
+		},
+		"slash": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
+		},
+		"snapdragon": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+			"integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+			"requires": {
+				"base": "^0.11.1",
+				"debug": "^2.2.0",
+				"define-property": "^0.2.5",
+				"extend-shallow": "^2.0.1",
+				"map-cache": "^0.2.2",
+				"source-map": "^0.5.6",
+				"source-map-resolve": "^0.5.0",
+				"use": "^3.1.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"requires": {
+						"is-descriptor": "^0.1.0"
+					}
+				},
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+				}
+			}
+		},
+		"snapdragon-node": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+			"integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+			"requires": {
+				"define-property": "^1.0.0",
+				"isobject": "^3.0.0",
+				"snapdragon-util": "^3.0.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"requires": {
+						"is-descriptor": "^1.0.0"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				}
+			}
+		},
+		"snapdragon-util": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+			"integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+			"requires": {
+				"kind-of": "^3.2.0"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
+		},
+		"source-map": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+		},
+		"source-map-resolve": {
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
+			"integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
+			"requires": {
+				"atob": "^2.1.2",
+				"decode-uri-component": "^0.2.0",
+				"resolve-url": "^0.2.1",
+				"source-map-url": "^0.4.0",
+				"urix": "^0.1.0"
+			}
+		},
+		"source-map-support": {
+			"version": "0.5.19",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+			"integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+			"requires": {
+				"buffer-from": "^1.0.0",
+				"source-map": "^0.6.0"
+			}
+		},
+		"source-map-url": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
 		},
 		"sourcemap-codec": {
 			"version": "1.4.8",
@@ -384,11 +4120,332 @@
 			"integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
 			"dev": true
 		},
+		"spdx-correct": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
+			"integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
+			"requires": {
+				"spdx-expression-parse": "^3.0.0",
+				"spdx-license-ids": "^3.0.0"
+			}
+		},
+		"spdx-exceptions": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+			"integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A=="
+		},
+		"spdx-expression-parse": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+			"integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+			"requires": {
+				"spdx-exceptions": "^2.1.0",
+				"spdx-license-ids": "^3.0.0"
+			}
+		},
+		"spdx-license-ids": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.6.tgz",
+			"integrity": "sha512-+orQK83kyMva3WyPf59k1+Y525csj5JejicWut55zeTWANuN17qSiSLUXWtzHeNWORSvT7GLDJ/E/XiIWoXBTw=="
+		},
+		"split-string": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+			"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+			"requires": {
+				"extend-shallow": "^3.0.0"
+			}
+		},
+		"sprintf-js": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+		},
+		"sshpk": {
+			"version": "1.16.1",
+			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+			"integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+			"requires": {
+				"asn1": "~0.2.3",
+				"assert-plus": "^1.0.0",
+				"bcrypt-pbkdf": "^1.0.0",
+				"dashdash": "^1.12.0",
+				"ecc-jsbn": "~0.1.1",
+				"getpass": "^0.1.1",
+				"jsbn": "~0.1.0",
+				"safer-buffer": "^2.0.2",
+				"tweetnacl": "~0.14.0"
+			}
+		},
+		"stack-utils": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
+			"integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA=="
+		},
+		"static-extend": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+			"integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+			"requires": {
+				"define-property": "^0.2.5",
+				"object-copy": "^0.1.0"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"requires": {
+						"is-descriptor": "^0.1.0"
+					}
+				}
+			}
+		},
+		"stealthy-require": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
+		},
+		"string-length": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/string-length/-/string-length-3.1.0.tgz",
+			"integrity": "sha512-Ttp5YvkGm5v9Ijagtaz1BnN+k9ObpvS0eIBblPMp2YWL8FBmi9qblQ9fexc2k/CXFgrTIteU3jAw3payCnwSTA==",
+			"requires": {
+				"astral-regex": "^1.0.0",
+				"strip-ansi": "^5.2.0"
+			},
+			"dependencies": {
+				"strip-ansi": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+					"requires": {
+						"ansi-regex": "^4.1.0"
+					}
+				}
+			}
+		},
+		"string-width": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+			"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+			"requires": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.0"
+			}
+		},
+		"strip-ansi": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+			"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+			"requires": {
+				"ansi-regex": "^5.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+				}
+			}
+		},
+		"strip-bom": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+			"integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w=="
+		},
+		"strip-eof": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+		},
+		"strip-final-newline": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+			"integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="
+		},
+		"supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"requires": {
+				"has-flag": "^4.0.0"
+			}
+		},
+		"supports-hyperlinks": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.1.0.tgz",
+			"integrity": "sha512-zoE5/e+dnEijk6ASB6/qrK+oYdm2do1hjoLWrqUC/8WEIW1gbxFcKuBof7sW8ArN6e+AYvsE8HBGiVRWL/F5CA==",
+			"requires": {
+				"has-flag": "^4.0.0",
+				"supports-color": "^7.0.0"
+			}
+		},
+		"symbol-tree": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+			"integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
+		},
+		"terminal-link": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
+			"integrity": "sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==",
+			"requires": {
+				"ansi-escapes": "^4.2.1",
+				"supports-hyperlinks": "^2.0.0"
+			}
+		},
+		"test-exclude": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+			"integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+			"requires": {
+				"@istanbuljs/schema": "^0.1.2",
+				"glob": "^7.1.4",
+				"minimatch": "^3.0.4"
+			}
+		},
+		"throat": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz",
+			"integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA=="
+		},
+		"tmpl": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
+			"integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE="
+		},
+		"to-fast-properties": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+		},
+		"to-object-path": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+			"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+			"requires": {
+				"kind-of": "^3.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
+		},
+		"to-regex": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+			"integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+			"requires": {
+				"define-property": "^2.0.2",
+				"extend-shallow": "^3.0.2",
+				"regex-not": "^1.0.2",
+				"safe-regex": "^1.1.0"
+			}
+		},
+		"to-regex-range": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+			"requires": {
+				"is-number": "^7.0.0"
+			}
+		},
+		"tough-cookie": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
+			"integrity": "sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==",
+			"requires": {
+				"ip-regex": "^2.1.0",
+				"psl": "^1.1.28",
+				"punycode": "^2.1.1"
+			}
+		},
+		"tr46": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+			"integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+			"requires": {
+				"punycode": "^2.1.0"
+			}
+		},
 		"tslib": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.1.tgz",
 			"integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ==",
 			"dev": true
+		},
+		"tsyringe": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.3.0.tgz",
+			"integrity": "sha512-Vzty1M/EQXSsEE8aoIOLl1l793chcPyQAnFJaS1mFDtFvNPY+jknSPwMIF6yfcjua+2GTgwxWFzuA3cjIx4NZA==",
+			"requires": {
+				"tslib": "^1.9.3"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "1.14.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.0.tgz",
+					"integrity": "sha512-+Zw5lu0D9tvBMjGP8LpvMb0u2WW2QV3y+D8mO6J+cNzCYIN4sVy43Bf9vl92nqFahutN0I8zHa7cc4vihIshnw=="
+				}
+			}
+		},
+		"tunnel-agent": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+			"requires": {
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"tweetnacl": {
+			"version": "0.14.5",
+			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+		},
+		"type-check": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+			"requires": {
+				"prelude-ls": "~1.1.2"
+			}
+		},
+		"type-detect": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
+		},
+		"type-fest": {
+			"version": "0.8.1",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+			"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="
+		},
+		"typedarray-to-buffer": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+			"integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+			"requires": {
+				"is-typedarray": "^1.0.0"
+			}
+		},
+		"union-value": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+			"integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
+			"requires": {
+				"arr-union": "^3.1.0",
+				"get-value": "^2.0.6",
+				"is-extendable": "^0.1.1",
+				"set-value": "^2.0.1"
+			}
 		},
 		"universalify": {
 			"version": "0.1.2",
@@ -396,11 +4453,254 @@
 			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
 			"dev": true
 		},
+		"unset-value": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+			"integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+			"requires": {
+				"has-value": "^0.3.1",
+				"isobject": "^3.0.0"
+			},
+			"dependencies": {
+				"has-value": {
+					"version": "0.3.1",
+					"resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+					"integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+					"requires": {
+						"get-value": "^2.0.3",
+						"has-values": "^0.1.4",
+						"isobject": "^2.0.0"
+					},
+					"dependencies": {
+						"isobject": {
+							"version": "2.1.0",
+							"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+							"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+							"requires": {
+								"isarray": "1.0.0"
+							}
+						}
+					}
+				},
+				"has-values": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+					"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
+				}
+			}
+		},
+		"uri-js": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
+			"integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
+			"requires": {
+				"punycode": "^2.1.0"
+			}
+		},
+		"urix": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+			"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
+		},
+		"url-parse": {
+			"version": "1.4.7",
+			"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",
+			"integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
+			"requires": {
+				"querystringify": "^2.1.1",
+				"requires-port": "^1.0.0"
+			}
+		},
+		"use": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
+			"integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
+		},
+		"uuid": {
+			"version": "8.3.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.1.tgz",
+			"integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg=="
+		},
+		"v8-to-istanbul": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-4.1.4.tgz",
+			"integrity": "sha512-Rw6vJHj1mbdK8edjR7+zuJrpDtKIgNdAvTSAcpYfgMIw+u2dPDntD3dgN4XQFLU2/fvFQdzj+EeSGfd/jnY5fQ==",
+			"requires": {
+				"@types/istanbul-lib-coverage": "^2.0.1",
+				"convert-source-map": "^1.6.0",
+				"source-map": "^0.7.3"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.7.3",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+					"integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
+				}
+			}
+		},
+		"validate-npm-package-license": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+			"integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+			"requires": {
+				"spdx-correct": "^3.0.0",
+				"spdx-expression-parse": "^3.0.0"
+			}
+		},
+		"verror": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+			"requires": {
+				"assert-plus": "^1.0.0",
+				"core-util-is": "1.0.2",
+				"extsprintf": "^1.2.0"
+			}
+		},
+		"w3c-hr-time": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
+			"integrity": "sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==",
+			"requires": {
+				"browser-process-hrtime": "^1.0.0"
+			}
+		},
+		"w3c-xmlserializer": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-1.1.2.tgz",
+			"integrity": "sha512-p10l/ayESzrBMYWRID6xbuCKh2Fp77+sA0doRuGn4tTIMrrZVeqfpKjXHY+oDh3K4nLdPgNwMTVP6Vp4pvqbNg==",
+			"requires": {
+				"domexception": "^1.0.1",
+				"webidl-conversions": "^4.0.2",
+				"xml-name-validator": "^3.0.0"
+			}
+		},
+		"walker": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
+			"integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
+			"requires": {
+				"makeerror": "1.0.x"
+			}
+		},
+		"webidl-conversions": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+			"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
+		},
+		"whatwg-encoding": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
+			"integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
+			"requires": {
+				"iconv-lite": "0.4.24"
+			}
+		},
+		"whatwg-mimetype": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
+			"integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g=="
+		},
+		"whatwg-url": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+			"integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+			"requires": {
+				"lodash.sortby": "^4.7.0",
+				"tr46": "^1.0.1",
+				"webidl-conversions": "^4.0.2"
+			}
+		},
+		"which": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+			"requires": {
+				"isexe": "^2.0.0"
+			}
+		},
+		"which-module": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+		},
+		"word-wrap": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+			"integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
+		},
+		"wrap-ansi": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+			"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+			"requires": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			}
+		},
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-			"dev": true
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+		},
+		"write-file-atomic": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+			"integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+			"requires": {
+				"imurmurhash": "^0.1.4",
+				"is-typedarray": "^1.0.0",
+				"signal-exit": "^3.0.2",
+				"typedarray-to-buffer": "^3.1.5"
+			}
+		},
+		"ws": {
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
+			"integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA=="
+		},
+		"xml-name-validator": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+			"integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw=="
+		},
+		"xmlchars": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+			"integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
+		},
+		"y18n": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+			"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+		},
+		"yargs": {
+			"version": "15.4.1",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+			"integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+			"requires": {
+				"cliui": "^6.0.0",
+				"decamelize": "^1.2.0",
+				"find-up": "^4.1.0",
+				"get-caller-file": "^2.0.1",
+				"require-directory": "^2.1.1",
+				"require-main-filename": "^2.0.0",
+				"set-blocking": "^2.0.0",
+				"string-width": "^4.2.0",
+				"which-module": "^2.0.0",
+				"y18n": "^4.0.0",
+				"yargs-parser": "^18.1.2"
+			}
+		},
+		"yargs-parser": {
+			"version": "18.1.3",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+			"integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+			"requires": {
+				"camelcase": "^5.0.0",
+				"decamelize": "^1.2.0"
+			}
 		}
 	}
 }

--- a/packages/example/package-lock.json
+++ b/packages/example/package-lock.json
@@ -1,0 +1,406 @@
+{
+	"name": "@inrupt/solid-client-authn-example-typescipt",
+	"version": "0.0.1",
+	"lockfileVersion": 1,
+	"requires": true,
+	"dependencies": {
+		"@rollup/plugin-commonjs": {
+			"version": "15.1.0",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-15.1.0.tgz",
+			"integrity": "sha512-xCQqz4z/o0h2syQ7d9LskIMvBSH4PX5PjYdpSSvgS+pQik3WahkQVNWg3D8XJeYjZoVWnIUQYDghuEMRGrmQYQ==",
+			"dev": true,
+			"requires": {
+				"@rollup/pluginutils": "^3.1.0",
+				"commondir": "^1.0.1",
+				"estree-walker": "^2.0.1",
+				"glob": "^7.1.6",
+				"is-reference": "^1.2.1",
+				"magic-string": "^0.25.7",
+				"resolve": "^1.17.0"
+			}
+		},
+		"@rollup/plugin-node-resolve": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-9.0.0.tgz",
+			"integrity": "sha512-gPz+utFHLRrd41WMP13Jq5mqqzHL3OXrfj3/MkSyB6UBIcuNt9j60GCbarzMzdf1VHFpOxfQh/ez7wyadLMqkg==",
+			"dev": true,
+			"requires": {
+				"@rollup/pluginutils": "^3.1.0",
+				"@types/resolve": "1.17.1",
+				"builtin-modules": "^3.1.0",
+				"deepmerge": "^4.2.2",
+				"is-module": "^1.0.0",
+				"resolve": "^1.17.0"
+			}
+		},
+		"@rollup/pluginutils": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+			"integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+			"dev": true,
+			"requires": {
+				"@types/estree": "0.0.39",
+				"estree-walker": "^1.0.1",
+				"picomatch": "^2.2.2"
+			},
+			"dependencies": {
+				"estree-walker": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+					"integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+					"dev": true
+				}
+			}
+		},
+		"@types/estree": {
+			"version": "0.0.39",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+			"integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+			"dev": true
+		},
+		"@types/node": {
+			"version": "14.11.5",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.5.tgz",
+			"integrity": "sha512-jVFzDV6NTbrLMxm4xDSIW/gKnk8rQLF9wAzLWIOg+5nU6ACrIMndeBdXci0FGtqJbP9tQvm6V39eshc96TO2wQ==",
+			"dev": true
+		},
+		"@types/resolve": {
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
+			"integrity": "sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*"
+			}
+		},
+		"balanced-match": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+			"dev": true
+		},
+		"brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
+			"requires": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"builtin-modules": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.1.0.tgz",
+			"integrity": "sha512-k0KL0aWZuBt2lrxrcASWDfwOLMnodeQjodT/1SxEQAXsHANgo6ZC/VEaSEHCXt7aSTZ4/4H5LKa+tBXmW7Vtvw==",
+			"dev": true
+		},
+		"commondir": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+			"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+			"dev": true
+		},
+		"concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"dev": true
+		},
+		"cross-fetch": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.6.tgz",
+			"integrity": "sha512-KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==",
+			"dev": true,
+			"requires": {
+				"node-fetch": "2.6.1"
+			}
+		},
+		"deepmerge": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+			"integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+			"dev": true
+		},
+		"estree-walker": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.1.tgz",
+			"integrity": "sha512-tF0hv+Yi2Ot1cwj9eYHtxC0jB9bmjacjQs6ZBTj82H8JwUywFuc+7E83NWfNMwHXZc11mjfFcVXPe9gEP4B8dg==",
+			"dev": true
+		},
+		"find-cache-dir": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
+			"integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
+			"dev": true,
+			"requires": {
+				"commondir": "^1.0.1",
+				"make-dir": "^3.0.2",
+				"pkg-dir": "^4.1.0"
+			}
+		},
+		"find-up": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+			"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+			"dev": true,
+			"requires": {
+				"locate-path": "^5.0.0",
+				"path-exists": "^4.0.0"
+			}
+		},
+		"fs-extra": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+			"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^4.0.0",
+				"universalify": "^0.1.0"
+			}
+		},
+		"fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+			"dev": true
+		},
+		"fsevents": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+			"integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+			"dev": true,
+			"optional": true
+		},
+		"glob": {
+			"version": "7.1.6",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+			"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+			"dev": true,
+			"requires": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			}
+		},
+		"graceful-fs": {
+			"version": "4.2.4",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+			"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+			"dev": true
+		},
+		"inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"dev": true,
+			"requires": {
+				"once": "^1.3.0",
+				"wrappy": "1"
+			}
+		},
+		"inherits": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"dev": true
+		},
+		"is-module": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+			"integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
+			"dev": true
+		},
+		"is-reference": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
+			"integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
+			"dev": true,
+			"requires": {
+				"@types/estree": "*"
+			}
+		},
+		"jsonfile": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+			"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "^4.1.6"
+			}
+		},
+		"locate-path": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+			"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+			"dev": true,
+			"requires": {
+				"p-locate": "^4.1.0"
+			}
+		},
+		"magic-string": {
+			"version": "0.25.7",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
+			"integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+			"dev": true,
+			"requires": {
+				"sourcemap-codec": "^1.4.4"
+			}
+		},
+		"make-dir": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+			"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+			"dev": true,
+			"requires": {
+				"semver": "^6.0.0"
+			}
+		},
+		"minimatch": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"dev": true,
+			"requires": {
+				"brace-expansion": "^1.1.7"
+			}
+		},
+		"node-fetch": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+			"integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+			"dev": true
+		},
+		"once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"dev": true,
+			"requires": {
+				"wrappy": "1"
+			}
+		},
+		"p-limit": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+			"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+			"dev": true,
+			"requires": {
+				"p-try": "^2.0.0"
+			}
+		},
+		"p-locate": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+			"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+			"dev": true,
+			"requires": {
+				"p-limit": "^2.2.0"
+			}
+		},
+		"p-try": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+			"dev": true
+		},
+		"path-exists": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+			"dev": true
+		},
+		"path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+			"dev": true
+		},
+		"path-parse": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+			"dev": true
+		},
+		"picomatch": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+			"integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+			"dev": true
+		},
+		"pkg-dir": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+			"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+			"dev": true,
+			"requires": {
+				"find-up": "^4.0.0"
+			}
+		},
+		"resolve": {
+			"version": "1.17.0",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+			"integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+			"dev": true,
+			"requires": {
+				"path-parse": "^1.0.6"
+			}
+		},
+		"rollup": {
+			"version": "2.28.2",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.28.2.tgz",
+			"integrity": "sha512-8txbsFBFLmm9Xdt4ByTOGa9Muonmc8MfNjnGAR8U8scJlF1ZW7AgNZa7aqBXaKtlvnYP/ab++fQIq9dB9NWUbg==",
+			"dev": true,
+			"requires": {
+				"fsevents": "~2.1.2"
+			}
+		},
+		"rollup-plugin-typescript2": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.27.3.tgz",
+			"integrity": "sha512-gmYPIFmALj9D3Ga1ZbTZAKTXq1JKlTQBtj299DXhqYz9cL3g/AQfUvbb2UhH+Nf++cCq941W2Mv7UcrcgLzJJg==",
+			"dev": true,
+			"requires": {
+				"@rollup/pluginutils": "^3.1.0",
+				"find-cache-dir": "^3.3.1",
+				"fs-extra": "8.1.0",
+				"resolve": "1.17.0",
+				"tslib": "2.0.1"
+			}
+		},
+		"semver": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+			"dev": true
+		},
+		"sourcemap-codec": {
+			"version": "1.4.8",
+			"resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+			"integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+			"dev": true
+		},
+		"tslib": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.1.tgz",
+			"integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ==",
+			"dev": true
+		},
+		"universalify": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+			"dev": true
+		},
+		"wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"dev": true
+		}
+	}
+}

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -12,9 +12,9 @@
     "clean-module": "rm -rf ./dist",
     "clean-browser": "rm -rf ./browserDist",
     "build": "rollup --config rollup.config.js",
-    "lint": "eslint --max-warnings=0 \\\"src/**/*.ts\\\"",
-    "lint-fix": "eslint --max-warnings=0 --fix \\\"src/**\\\"",
-    "format": "prettier --write \\\"src/**\\\" \\\"__tests__/**\\\"",
+    "lint": "eslint --max-warnings=0 \"src/**/*.ts\"",
+    "lint-fix": "eslint --max-warnings=0 --fix \"src/**\"",
+    "format": "prettier --write \"src/**\" \"__tests__/**\"",
     "licenses": "license-checker --csv --out licenses.csv --production --failOn \"AGPL-1.0-only; AGPL-1.0-or-later; AGPL-3.0-only; AGPL-3.0-or-later; Beerware; CC-BY-NC-1.0; CC-BY-NC-2.0; CC-BY-NC-2.5; CC-BY-NC-3.0; CC-BY-NC-4.0; CC-BY-NC-ND-1.0; CC-BY-NC-ND-2.0; CC-BY-NC-ND-2.5; CC-BY-NC-ND-3.0; CC-BY-NC-ND-4.0; CC-BY-NC-SA-1.0; CC-BY-NC-SA-2.0; CC-BY-NC-SA-2.5; CC-BY-NC-SA-3.0; CC-BY-NC-SA-4.0; CPAL-1.0; EUPL-1.0; EUPL-1.1; EUPL-1.1;  GPL-1.0-only; GPL-1.0-or-later; GPL-2.0-only;  GPL-2.0-or-later; GPL-3.0; GPL-3.0-only; GPL-3.0-or-later; SISSL;  SISSL-1.2; WTFPL\"",
     "test": "npm run lint && npm run licenses && npm run test-unit",
     "test-unit": "jest --coverage --verbose"

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -23,13 +23,12 @@
   "devDependencies": {
     "@rollup/plugin-commonjs": "^15.1.0",
     "@rollup/plugin-node-resolve": "^9.0.0",
-    "cross-fetch": "^3.0.6",
+    "jest": "^25.1.0",
     "rollup": "^2.15.0",
     "rollup-plugin-typescript2": "^0.27.1"
   },
   "dependencies": {
-    "@inrupt/solid-client-authn-browser": "^0.2.0",
-    "url-parse": "^1.4.7"
+    "@inrupt/solid-client-authn-browser": "^0.2.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@inrupt/solid-client-authn-example-typescipt",
+  "version": "0.0.1",
+  "description": "Simple example of TypeScript usage of types from the solid-client-authn library.",
+  "homepage": "https://github.com/inrupt/solid-client-authn-js/tree/master/packages/oidc-dpop-client-browser/",
+  "bugs": "https://github.com/inrupt/solid-client-authn-js/issues",
+  "main": "dist/index.js",
+  "module": "dist/index.es.js",
+  "types": "dist/index.d.ts",
+  "sideEffects": false,
+  "scripts": {
+    "clean-module": "rm -rf ./dist",
+    "clean-browser": "rm -rf ./browserDist",
+    "build": "rollup --config rollup.config.js",
+    "lint": "eslint --max-warnings=0 \\\"src/**/*.ts\\\"",
+    "lint-fix": "eslint --max-warnings=0 --fix \\\"src/**\\\"",
+    "format": "prettier --write \\\"src/**\\\" \\\"__tests__/**\\\"",
+    "licenses": "license-checker --csv --out licenses.csv --production --failOn \"AGPL-1.0-only; AGPL-1.0-or-later; AGPL-3.0-only; AGPL-3.0-or-later; Beerware; CC-BY-NC-1.0; CC-BY-NC-2.0; CC-BY-NC-2.5; CC-BY-NC-3.0; CC-BY-NC-4.0; CC-BY-NC-ND-1.0; CC-BY-NC-ND-2.0; CC-BY-NC-ND-2.5; CC-BY-NC-ND-3.0; CC-BY-NC-ND-4.0; CC-BY-NC-SA-1.0; CC-BY-NC-SA-2.0; CC-BY-NC-SA-2.5; CC-BY-NC-SA-3.0; CC-BY-NC-SA-4.0; CPAL-1.0; EUPL-1.0; EUPL-1.1; EUPL-1.1;  GPL-1.0-only; GPL-1.0-or-later; GPL-2.0-only;  GPL-2.0-or-later; GPL-3.0; GPL-3.0-only; GPL-3.0-or-later; SISSL;  SISSL-1.2; WTFPL\"",
+    "test": "npm run lint && npm run licenses && npm run test-unit",
+    "test-unit": "jest --coverage --verbose"
+  },
+  "license": "MIT",
+  "devDependencies": {
+    "@rollup/plugin-commonjs": "^15.1.0",
+    "@rollup/plugin-node-resolve": "^9.0.0",
+    "cross-fetch": "^3.0.6",
+    "rollup": "^2.15.0",
+    "rollup-plugin-typescript2": "^0.27.1"
+  },
+  "dependencies": {
+    "@inrupt/solid-client-authn-browser": "^0.2.0",
+    "url-parse": "^1.4.7"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/example/rollup.config.js
+++ b/packages/example/rollup.config.js
@@ -1,0 +1,36 @@
+import pkg from "./package.json";
+import typescript from "rollup-plugin-typescript2";
+import nodeResolve from "@rollup/plugin-node-resolve";
+import commonjs from "@rollup/plugin-commonjs";
+
+export default {
+  input: "./src/index.ts",
+  output: [
+    {
+      file: pkg.main,
+      format: "cjs",
+    },
+    {
+      file: pkg.module,
+      format: "esm",
+    },
+    {
+      dir: "umd",
+      format: "umd",
+      name: "ExampleTypeScript",
+    },
+  ],
+  plugins: [
+    typescript({
+      // Use our own version of TypeScript, rather than the one bundled with the plugin:
+      typescript: require("typescript"),
+      tsconfigOverride: {
+        compilerOptions: {
+          module: "esnext",
+        },
+      },
+    }),
+    nodeResolve(),
+    commonjs(),
+  ],
+};

--- a/packages/example/src/index.spec.ts
+++ b/packages/example/src/index.spec.ts
@@ -25,43 +25,23 @@ import {
   IStorage,
 } from "@inrupt/solid-client-authn-browser";
 
-/**
- * Simple implementation of our exported types.
- */
-export class MyExportTestingClass
-  implements ILoginInputOptions, ISessionInfo, IStorage {
-  // From: ILoginInputOptions.
-  public readonly clientName: string;
+import { MyExportTestingClass } from "./index";
 
-  // From: ISessionInfo.
-  public readonly isLoggedIn: boolean;
-  public readonly sessionId: string;
+describe("Test exports", () => {
+  it("exports storage", async () => {
+    const testImpl: ILoginInputOptions = new MyExportTestingClass();
+    expect(testImpl.clientName).toBe("Some client application name");
+  });
 
-  constructor() {
-    this.clientName = "Some client application name";
+  it("exports storage", async () => {
+    const testImpl: ISessionInfo = new MyExportTestingClass();
+    expect(testImpl.isLoggedIn).toBeTruthy();
+    expect(testImpl.sessionId).toBe("Required Session ID");
+  });
 
-    this.isLoggedIn = true;
-    this.sessionId = "Required Session ID";
-  }
-
-  async get(key: string): Promise<string | undefined> {
-    return Promise.resolve("no problem!");
-  }
-
-  async set(key: string, value: string): Promise<void> {
-    return Promise.resolve();
-  }
-
-  async delete(key: string): Promise<void> {
-    return Promise.resolve();
-  }
-}
-
-const testImpl = new MyExportTestingClass();
-
-console.log(`Client name: [${testImpl.clientName}]`);
-console.log(`Is logged in: [${testImpl.isLoggedIn}]`);
-console.log(`Session ID [${testImpl.sessionId}]`);
-testImpl
-  .get("whatever")
-  .then((response) => console.log(`Storage value: [${response}]`));
+  it("exports storage", async () => {
+    const testImpl: IStorage = new MyExportTestingClass();
+    const storedValue = await testImpl.get("whatever");
+    expect(storedValue).toBe("no problem!");
+  });
+});

--- a/packages/example/src/index.ts
+++ b/packages/example/src/index.ts
@@ -44,14 +44,17 @@ export class MyExportTestingClass
     this.sessionId = "Required Session ID";
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async get(key: string): Promise<string | undefined> {
     return Promise.resolve("no problem!");
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async set(key: string, value: string): Promise<void> {
     return Promise.resolve();
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async delete(key: string): Promise<void> {
     return Promise.resolve();
   }

--- a/packages/example/src/index.ts
+++ b/packages/example/src/index.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { ILoginInputOptions } from "@inrupt/solid-client-authn-browser";
+
+class MySessionInfo implements ILoginInputOptions {
+  public readonly clientName: string;
+  public readonly popUp: boolean;
+
+  constructor() {
+    this.clientName = "Some client application name";
+    this.popUp = false;
+  }
+}
+
+const testValue: ILoginInputOptions = new MySessionInfo();
+console.log(`Client name is: [${testValue.clientName}]`);

--- a/packages/example/tsconfig.json
+++ b/packages/example/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../tsconfig.build.json",
+
+  "compilerOptions": {
+    "lib": ["es2018", "dom"],
+    "outDir": "./dist"
+  },
+
+  "typedocOptions": {
+    "out": "website/docs/api/example/typescript"
+  },
+
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": ["*.spec.ts"]
+}


### PR DESCRIPTION
We might not merge this PR ever - it was really just a quick learning exercise while testing that our TS types could be exposed and used easily by external code.
It **_might_** be handy for automated testing, but it seems awkward to maintain the explicit interface references, and I suspect our other tests (integration and end-2-end in particular) make more sense for testing that more comprehensively (although this example is so simple and self-contained, it might still have some value...?!).