### PR TITLE
Pass refresh_token to fetch builders

### DIFF
--- a/packages/browser/__tests__/authenticatedFetch/fetchFactory.spec.ts
+++ b/packages/browser/__tests__/authenticatedFetch/fetchFactory.spec.ts
@@ -40,7 +40,7 @@ describe("buildBearerFetch", () => {
         [RequestInfo, RequestInit?]
       >;
     };
-    const myFetch = buildBearerFetch("myToken");
+    const myFetch = buildBearerFetch("myToken", undefined);
     await myFetch("someUrl");
 
     expect(
@@ -56,7 +56,7 @@ describe("buildBearerFetch", () => {
         [RequestInfo, RequestInit?]
       >;
     };
-    const myFetch = buildBearerFetch("myToken");
+    const myFetch = buildBearerFetch("myToken", undefined);
     await myFetch("someUrl", { headers: { someHeader: "SomeValue" } });
 
     expect(
@@ -77,7 +77,7 @@ describe("buildBearerFetch", () => {
         [RequestInfo, RequestInit?]
       >;
     };
-    const myFetch = buildBearerFetch("myToken");
+    const myFetch = buildBearerFetch("myToken", undefined);
     await myFetch("someUrl", { headers: { Authorization: "some token" } });
 
     expect(
@@ -96,7 +96,7 @@ describe("buildDpopFetch", () => {
       >;
     };
     const key = await generateJWK("EC", "P-256", { alg: "ES256" });
-    const myFetch = await buildDpopFetch("myToken", key);
+    const myFetch = await buildDpopFetch("myToken", undefined, key);
     await myFetch("http://some.url");
 
     expect(
@@ -118,7 +118,7 @@ describe("buildDpopFetch", () => {
       >;
     };
     const key = await generateJWK("EC", "P-256", { alg: "ES256" });
-    const myFetch = await buildDpopFetch("myToken", key);
+    const myFetch = await buildDpopFetch("myToken", undefined, key);
     await myFetch("http://some.url", { headers: { someHeader: "SomeValue" } });
 
     expect(
@@ -145,7 +145,7 @@ describe("buildDpopFetch", () => {
       >;
     };
     const key = await generateJWK("EC", "P-256", { alg: "ES256" });
-    const myFetch = await buildDpopFetch("myToken", key);
+    const myFetch = await buildDpopFetch("myToken", undefined, key);
     await myFetch("http://some.url", {
       headers: {
         Authorization: "some token",

--- a/packages/browser/src/authenticatedFetch/fetchFactory.ts
+++ b/packages/browser/src/authenticatedFetch/fetchFactory.ts
@@ -26,11 +26,17 @@ import { fetch } from "cross-fetch";
 
 /**
  * @param authToken A bearer token.
+ * @param _refreshToken An optional refresh token.
  * @returns A fetch function that adds an Authorization header with the provided
  * bearer token.
  * @hidden
  */
-export function buildBearerFetch(authToken: string): typeof fetch {
+export function buildBearerFetch(
+  authToken: string,
+  // TODO: We need to push this refresh token into a wrapper around the fetch,
+  //  so dependent on that wrapper existing first!
+  _refreshToken: string | undefined
+): typeof fetch {
   return (init, options): Promise<Response> => {
     return fetch(init, {
       ...options,
@@ -44,12 +50,16 @@ export function buildBearerFetch(authToken: string): typeof fetch {
 
 /**
  * @param authToken a DPoP token.
+ * @param _refreshToken An optional refresh token.
  * @param dpopKey The private key the token is bound to.
  * @returns A fetch function that adds an Authorization header with the provided
  * DPoP token, and adds a dpop header.
  */
 export async function buildDpopFetch(
   authToken: string,
+  // TODO: We need to push this refresh token into a wrapper around the fetch,
+  //  so dependent on that wrapper existing first!
+  _refreshToken: string | undefined,
   dpopKey: JSONWebKey
 ): Promise<typeof fetch> {
   return async (init, options): Promise<Response> => {

--- a/packages/browser/src/login/oidc/redirectHandler/GeneralRedirectHandler.ts
+++ b/packages/browser/src/login/oidc/redirectHandler/GeneralRedirectHandler.ts
@@ -78,7 +78,7 @@ export default class GeneralRedirectHandler implements IRedirectHandler {
       );
     }
     return Object.assign(sessionInfo, {
-      fetch: buildBearerFetch(url.query.access_token),
+      fetch: buildBearerFetch(url.query.access_token, undefined),
     });
   }
 }


### PR DESCRIPTION
Just the initial part of adding refresh token support (we need the fetch closure code to be extended first before we can complete this, since now we are only returning an augmented fetch function (so we have nowhere to store the refresh token, or any other sensitive info we may wish to associated with the fetch)).