### PR TITLE
Support requesting a DPoP token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## [Unreleased]
 
-### New features
+### Security patches
+
+- The support for DPoP was re-implemented in @inrupt/oidc-client-dpop-browser, such that the DPoP JWK is never stored, and only kept inside the closure of the authenticated fetch.
 
 ### Bugfixes
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "demo-app": "cd packages/browser; npm run demo-app",
     "bootstrap": "lerna bootstrap",
     "build": "lerna run build",
-    "clean": "rm --recursive packages/*/dist/ packages/*/node_modules/",
+    "clean": "rm --recursive --force packages/*/dist/ packages/*/node_modules/",
     "build-api-docs": "lerna run build-api-docs",
     "format-all": "prettier --write \"packages/*/src/**\" \"packages/*/__tests__/**\"",
     "licenses-all": "license-checker --production --failOn \"AGPL-1.0-only; AGPL-1.0-or-later; AGPL-3.0-only; AGPL-3.0-or-later; Beerware; CC-BY-NC-1.0; CC-BY-NC-2.0; CC-BY-NC-2.5; CC-BY-NC-3.0; CC-BY-NC-4.0; CC-BY-NC-ND-1.0; CC-BY-NC-ND-2.0; CC-BY-NC-ND-2.5; CC-BY-NC-ND-3.0; CC-BY-NC-ND-4.0; CC-BY-NC-SA-1.0; CC-BY-NC-SA-2.0; CC-BY-NC-SA-2.5; CC-BY-NC-SA-3.0; CC-BY-NC-SA-4.0; CPAL-1.0; EUPL-1.0; EUPL-1.1; EUPL-1.1;  GPL-1.0-only; GPL-1.0-or-later; GPL-2.0-only;  GPL-2.0-or-later; GPL-3.0; GPL-3.0-only; GPL-3.0-or-later; SISSL;  SISSL-1.2; WTFPL\"",

--- a/packages/browser/__tests__/ClientAuthentication.spec.ts
+++ b/packages/browser/__tests__/ClientAuthentication.spec.ts
@@ -60,7 +60,7 @@ describe("ClientAuthentication", () => {
   }
 
   describe("login", () => {
-    it("calls login", async () => {
+    it("calls login, and defaults to a DPoP token", async () => {
       const clientAuthn = getClientAuthentication();
       await clientAuthn.login("mySession", {
         clientId: "coolApp",
@@ -76,6 +76,28 @@ describe("ClientAuthentication", () => {
         clientName: "coolApp",
         clientSecret: undefined,
         handleRedirect: undefined,
+        tokenType: "DPoP",
+      });
+    });
+
+    it("request a bearer token if specified", async () => {
+      const clientAuthn = getClientAuthentication();
+      await clientAuthn.login("mySession", {
+        clientId: "coolApp",
+        redirectUrl: new URL("https://coolapp.com/redirect"),
+        oidcIssuer: new URL("https://idp.com"),
+        tokenType: "Bearer",
+      });
+      expect(defaultMocks.loginHandler.handle).toHaveBeenCalledWith({
+        sessionId: "mySession",
+        clientId: "coolApp",
+        redirectUrl: new URL("https://coolapp.com/redirect"),
+        oidcIssuer: new URL("https://idp.com"),
+        popUp: false,
+        clientName: "coolApp",
+        clientSecret: undefined,
+        handleRedirect: undefined,
+        tokenType: "Bearer",
       });
     });
 

--- a/packages/browser/__tests__/authenticatedFetch/fetchFactory.spec.ts
+++ b/packages/browser/__tests__/authenticatedFetch/fetchFactory.spec.ts
@@ -110,7 +110,7 @@ describe("buildDpopFetch", () => {
     const dpopHeader = fetch.fetch.mock.calls[0][1].headers["DPoP"] as string;
     const decodedHeader = await decodeJwt(dpopHeader, key);
     expect(decodedHeader["htu"]).toEqual("http://some.url");
-    expect(decodedHeader["htm"]).toEqual("get");
+    expect(decodedHeader["htm"]).toEqual("GET");
   });
 
   it("returns a fetch preserving the provided optional headers", async () => {
@@ -132,7 +132,7 @@ describe("buildDpopFetch", () => {
     const dpopHeader = fetch.fetch.mock.calls[0][1].headers["DPoP"] as string;
     const decodedHeader = await decodeJwt(dpopHeader, key);
     expect(decodedHeader["htu"]).toEqual("http://some.url");
-    expect(decodedHeader["htm"]).toEqual("get");
+    expect(decodedHeader["htm"]).toEqual("GET");
 
     expect(
       // @ts-ignore
@@ -164,7 +164,7 @@ describe("buildDpopFetch", () => {
     const dpopHeader = fetch.fetch.mock.calls[0][1].headers["DPoP"] as string;
     const decodedHeader = await decodeJwt(dpopHeader, key);
     expect(decodedHeader["htu"]).toEqual("http://some.url");
-    expect(decodedHeader["htm"]).toEqual("get");
+    expect(decodedHeader["htm"]).toEqual("GET");
   });
 });
 /* eslint-enable @typescript-eslint/ban-ts-ignore */

--- a/packages/browser/__tests__/login/oidc/OidcLoginHandler.spec.ts
+++ b/packages/browser/__tests__/login/oidc/OidcLoginHandler.spec.ts
@@ -54,6 +54,7 @@ describe("OidcLoginHandler", () => {
       oidcIssuer: new URL("https://arbitrary.url"),
       redirectUrl: new URL("https://app.com/redirect"),
       clientId: "coolApp",
+      tokenType: "DPoP",
     });
 
     expect(actualHandler.handle.mock.calls.length).toBe(1);
@@ -78,6 +79,7 @@ describe("OidcLoginHandler", () => {
         oidcIssuer: new URL("https://arbitrary.url"),
         redirectUrl: new URL("https://app.com/redirect"),
         clientId: "coolApp",
+        tokenType: "DPoP",
       })
     ).resolves.toBe(true);
   });

--- a/packages/browser/__tests__/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
+++ b/packages/browser/__tests__/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
@@ -20,62 +20,142 @@
  */
 
 import "reflect-metadata";
+import URL from "url-parse";
 import {
   StorageUtilityMock,
   mockStorageUtility,
+  IClient,
+  IClientRegistrar,
+  IClientRegistrarOptions,
+  IIssuerConfigFetcher,
 } from "@inrupt/solid-client-authn-core";
-import AuthCodeRedirectHandler from "../../../../src/login/oidc/redirectHandler/AuthCodeRedirectHandler";
+import AuthCodeRedirectHandler, {
+  exchangeDpopToken,
+} from "../../../../src/login/oidc/redirectHandler/AuthCodeRedirectHandler";
 import { RedirectorMock } from "../../../../src/login/oidc/__mocks__/Redirector";
 import { SessionInfoManagerMock } from "../../../../src/sessionInfo/__mocks__/SessionInfoManager";
-import { SigninResponse } from "@inrupt/oidc-dpop-client-browser";
+import {
+  IIssuerConfig,
+  TokenEndpointResponse,
+} from "@inrupt/oidc-dpop-client-browser";
+import { JSONWebKey } from "jose";
 
 jest.mock("cross-fetch");
 
-// The following key has been used to sign the mock access token. It is given
-// for an information purpose.
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const _mockJwk = {
-  kty: "EC",
-  kid: "oOArcXxcwvsaG21jAx_D5CHr4BgVCzCEtlfmNFQtU0s",
-  alg: "ES256",
-  crv: "P-256",
-  x: "0dGe_s-urLhD3mpqYqmSXrqUZApVV5ZNxMJXg7Vp-2A",
-  y: "-oMe9gGkpfIrnJ0aiSUHMdjqYVm5ZrGCeQmRKoIIfj8",
-  d: "yR1bCsR7m4hjFCvWo8Jw3OfNR4aiYDAFbBD9nkudJKM",
+const mockJwk = (): JSONWebKey => {
+  return {
+    kty: "EC",
+    kid: "oOArcXxcwvsaG21jAx_D5CHr4BgVCzCEtlfmNFQtU0s",
+    alg: "ES256",
+    crv: "P-256",
+    x: "0dGe_s-urLhD3mpqYqmSXrqUZApVV5ZNxMJXg7Vp-2A",
+    y: "-oMe9gGkpfIrnJ0aiSUHMdjqYVm5ZrGCeQmRKoIIfj8",
+    d: "yR1bCsR7m4hjFCvWo8Jw3OfNR4aiYDAFbBD9nkudJKM",
+  };
 };
 
-// Payload: { sub: "https://my.webid" }
-const mockAccessToken =
-  "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0ZXN0Q2xhaW0iOiJ0ZXN0VmFsdWUiLCJpYXQiOjE2MDIxNTg2NDJ9.wGZ49jU3wNSAFvWvZsjjulmbfRjlIQMp0VY0Q5u2--5vyzeKwfGUmssOW8kftIXG1ikm2iqMb6YRXCO4KGEctQ";
+const mockWebId = (): string => "https://my.webid";
 
-jest.mock("@inrupt/oidc-dpop-client-browser", () => {
+// result of generateMockJwt()
+const mockIdToken = (): string =>
+  "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJodHRwczovL215LndlYmlkIiwiaXNzIjoiaHR0cHM6Ly9zb21lLmlzc3VlciIsImlhdCI6MTYwMjQ5MTk5N30.R0hNKpCR3J8fS6JkTGTuFdz43_2zBMAQvCejSEO5S88DEaMQ4ktOYT__VfPmS7DHLt6Mju-J9bEc4twCnPxXjA";
+
+type AccessJwt = {
+  sub: string;
+  iss: string;
+  aud: string;
+  nbf: number;
+  exp: number;
+  cnf: {
+    jkt: string;
+  };
+};
+
+const mockIssuer = (): IIssuerConfig => {
   return {
-    OidcClient: jest.fn().mockImplementation(() => {
-      return {
-        processSigninResponse: async (): Promise<SigninResponse> => {
-          // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-          // @ts-ignore Ignore because we don't need to mock out all data fields.
-          return Promise.resolve({
-            // eslint-disable-next-line @typescript-eslint/camelcase
-            access_token: mockAccessToken,
-            // eslint-disable-next-line @typescript-eslint/camelcase
-            id_token: "Some ID token",
-          });
-        },
-      };
-    }),
-    decodeJwt: (_jwt: string): Record<string, string> => {
-      return {
-        sub: "https://some.webid",
-      };
+    issuer: new URL("https://some.issuer"),
+    authorizationEndpoint: new URL("https://some.issuer/autorization"),
+    tokenEndpoint: new URL("https://some.issuer/token"),
+    jwksUri: new URL("https://some.issuer/keys"),
+    claimsSupported: ["code", "openid"],
+    subjectTypesSupported: ["public", "pairwise"],
+    registrationEndpoint: new URL("https://some.issuer/registration"),
+    grantTypesSupported: ["authorization_code"],
+  };
+};
+
+const mockAccessTokenDpop = (): AccessJwt => {
+  return {
+    sub: mockWebId(),
+    iss: mockIssuer().issuer.toString(),
+    aud: "https://resource.example.org",
+    nbf: 1562262611,
+    exp: 1562266216,
+    cnf: {
+      jkt: mockJwk().kid as string,
     },
   };
+};
+
+const mockAccessTokenBearer = (): string => "some token";
+
+const mockTokenEndpointBearerResponse = (): TokenEndpointResponse => {
+  return {
+    accessToken: mockAccessTokenBearer(),
+    idToken: mockIdToken(),
+    webid: mockWebId(),
+  };
+};
+
+const mockTokenEndpointDpopResponse = (): TokenEndpointResponse => {
+  return {
+    accessToken: JSON.stringify(mockAccessTokenDpop()),
+    idToken: mockIdToken(),
+    webid: mockWebId(),
+    dpopJwk: mockJwk(),
+  };
+};
+
+jest.mock("@inrupt/oidc-dpop-client-browser", () => {
+  const { createDpopHeader } = jest.requireActual(
+    "@inrupt/oidc-dpop-client-browser"
+  );
+  return {
+    getDpopToken: async (): Promise<TokenEndpointResponse> =>
+      mockTokenEndpointDpopResponse(),
+    getBearerToken: async (): Promise<TokenEndpointResponse> =>
+      mockTokenEndpointBearerResponse(),
+    createDpopHeader: createDpopHeader,
+  };
 });
+
+function mockIssuerConfigFetcher(config: IIssuerConfig): IIssuerConfigFetcher {
+  return {
+    fetchConfig: async (): Promise<IIssuerConfig> => config,
+  };
+}
+
+const mockClient = (): IClient => {
+  return {
+    clientId: "some client",
+  };
+};
+
+function mockClientRegistrar(client: IClient): IClientRegistrar {
+  return {
+    getClient: async (
+      _options: IClientRegistrarOptions,
+      _issuer: IIssuerConfig
+    ): Promise<IClient> => client,
+  };
+}
 
 const defaultMocks = {
   storageUtility: StorageUtilityMock,
   redirector: RedirectorMock,
   sessionInfoManager: SessionInfoManagerMock,
+  clientRegistrar: mockClientRegistrar(mockClient()),
+  issuerConfigFetcher: mockIssuerConfigFetcher(mockIssuer()),
 };
 
 function getAuthCodeRedirectHandler(
@@ -83,7 +163,9 @@ function getAuthCodeRedirectHandler(
 ): AuthCodeRedirectHandler {
   return new AuthCodeRedirectHandler(
     mocks.storageUtility ?? defaultMocks.storageUtility,
-    mocks.sessionInfoManager ?? defaultMocks.sessionInfoManager
+    mocks.sessionInfoManager ?? defaultMocks.sessionInfoManager,
+    mocks.issuerConfigFetcher ?? defaultMocks.issuerConfigFetcher,
+    mocks.clientRegistrar ?? defaultMocks.clientRegistrar
   );
 }
 
@@ -110,6 +192,24 @@ describe("AuthCodeRedirectHandler", () => {
       expect(
         await authCodeRedirectHandler.canHandle(
           "https://coolparty.com/?meep=mop"
+        )
+      ).toBe(false);
+    });
+
+    it("rejects a valid url without authorization code", async () => {
+      const authCodeRedirectHandler = getAuthCodeRedirectHandler();
+      expect(
+        await authCodeRedirectHandler.canHandle(
+          "https://coolparty.com/?state=someState"
+        )
+      ).toBe(false);
+    });
+
+    it("rejects a valid url without state", async () => {
+      const authCodeRedirectHandler = getAuthCodeRedirectHandler();
+      expect(
+        await authCodeRedirectHandler.canHandle(
+          "https://coolparty.com/?code=someCode"
         )
       ).toBe(false);
     });
@@ -153,7 +253,7 @@ describe("AuthCodeRedirectHandler", () => {
 
     // We use ts-ignore comments here only to access mock call arguments
     /* eslint-disable @typescript-eslint/ban-ts-ignore */
-    it("returns an authenticated fetch", async () => {
+    it("returns an authenticated bearer fetch by default", async () => {
       const fetch = jest.requireMock("cross-fetch") as {
         fetch: jest.Mock<
           ReturnType<typeof window.fetch>,
@@ -170,11 +270,64 @@ describe("AuthCodeRedirectHandler", () => {
       await redirectInfo.fetch("https://some.other.url");
       // @ts-ignore
       const header = fetch.fetch.mock.calls[0][1].headers["Authorization"];
-      // We test that the Authorization header matches the structure of a JWT.
       expect(
         // @ts-ignore
         header
-      ).toMatch(/^Bearer .+\..+\..+$/);
+      ).toMatch(/^Bearer some token$/);
     });
+
+    it("returns an authenticated dpop fetch if requested", async () => {
+      const fetch = jest.requireMock("cross-fetch") as {
+        fetch: jest.Mock<
+          ReturnType<typeof window.fetch>,
+          [RequestInfo, RequestInit?]
+        >;
+      };
+
+      const storage = mockStorageUtility({
+        oauth2StateValue: {
+          sessionId: "mySession",
+        },
+        mySession: {
+          dpop: "true",
+          issuer: mockIssuer().issuer.toString(),
+          codeVerifier: "some code verifier",
+        },
+      });
+
+      const authCodeRedirectHandler = getAuthCodeRedirectHandler({
+        storageUtility: storage,
+      });
+      const redirectInfo = await authCodeRedirectHandler.handle(
+        "https://coolsite.com/?code=someCode&state=oauth2StateValue"
+      );
+      await redirectInfo.fetch("https://some.other.url");
+      // @ts-ignore
+      const header = fetch.fetch.mock.calls[0][1].headers["Authorization"];
+      expect(
+        // @ts-ignore
+        header
+      ).toMatch(/^DPoP .+$/);
+    });
+  });
+});
+
+describe("exchangeDpopToken", () => {
+  it("requests a key-bound token", async () => {
+    const mockedIssuer = mockIssuer();
+    const tokens = await exchangeDpopToken(
+      "mySession",
+      mockedIssuer.issuer,
+      mockIssuerConfigFetcher(mockedIssuer),
+      mockClientRegistrar(mockClient()),
+      "some code",
+      "some pkcd token",
+      new URL("https://my.app/redirect")
+    );
+    expect(tokens.accessToken).toEqual(
+      mockTokenEndpointDpopResponse().accessToken
+    );
+    expect(tokens.idToken).toEqual(mockTokenEndpointDpopResponse().idToken);
+    expect(tokens.dpopJwk).toEqual(mockTokenEndpointDpopResponse().dpopJwk);
   });
 });

--- a/packages/browser/__tests__/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
+++ b/packages/browser/__tests__/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
@@ -267,6 +267,11 @@ describe("AuthCodeRedirectHandler", () => {
       const redirectInfo = await authCodeRedirectHandler.handle(
         "https://coolsite.com/?code=someCode&state=oauth2_state_value"
       );
+      // This will call the oidc-dpop-client-browser module, which is mocked at
+      // the top of this file. The purpose of this test is to check that, if
+      // no additional information is given, the `getBearerToken` method is called
+      // (as opposed to the getDpopToken one), which here returns a mock token
+      // with the value "some token".
       await redirectInfo.fetch("https://some.other.url");
       // @ts-ignore
       const header = fetch.fetch.mock.calls[0][1].headers["Authorization"];

--- a/packages/browser/__tests__/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
+++ b/packages/browser/__tests__/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
@@ -103,7 +103,7 @@ const mockTokenEndpointBearerResponse = (): TokenEndpointResponse => {
   return {
     accessToken: mockAccessTokenBearer(),
     idToken: mockIdToken(),
-    webid: mockWebId(),
+    webId: mockWebId(),
   };
 };
 
@@ -111,7 +111,7 @@ const mockTokenEndpointDpopResponse = (): TokenEndpointResponse => {
   return {
     accessToken: JSON.stringify(mockAccessTokenDpop()),
     idToken: mockIdToken(),
-    webid: mockWebId(),
+    webId: mockWebId(),
     dpopJwk: mockJwk(),
   };
 };

--- a/packages/browser/__tests__/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
+++ b/packages/browser/__tests__/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
@@ -321,7 +321,7 @@ describe("exchangeDpopToken", () => {
       mockIssuerConfigFetcher(mockedIssuer),
       mockClientRegistrar(mockClient()),
       "some code",
-      "some pkcd token",
+      "some pkce token",
       new URL("https://my.app/redirect")
     );
     expect(tokens.accessToken).toEqual(

--- a/packages/browser/__tests__/login/popUp/PopUpLoginHandler.spec.ts
+++ b/packages/browser/__tests__/login/popUp/PopUpLoginHandler.spec.ts
@@ -51,6 +51,7 @@ describe("PopUpLoginHandler", () => {
           sessionId: "mySession",
           popUp: true,
           redirectUrl: new URL("/redirect"),
+          tokenType: "DPoP",
         })
       ).toBe(true);
     });
@@ -61,6 +62,7 @@ describe("PopUpLoginHandler", () => {
           sessionId: "mySession",
           popUp: false,
           redirectUrl: new URL("https://coolsite.com/redirect"),
+          tokenType: "DPoP",
         })
       ).toBe(false);
     });
@@ -73,6 +75,7 @@ describe("PopUpLoginHandler", () => {
         handler.handle({
           sessionId: "mySession",
           popUp: true,
+          tokenType: "DPoP",
         })
       ).rejects.toThrow("Popup login is not implemented yet");
     });

--- a/packages/browser/src/ClientAuthentication.ts
+++ b/packages/browser/src/ClientAuthentication.ts
@@ -87,6 +87,8 @@ export default class ClientAuthentication {
       clientName: options.clientName ?? options.clientId,
       popUp: options.popUp || false,
       handleRedirect: options.handleRedirect,
+      // Defaults to DPoP
+      tokenType: options.tokenType ?? "DPoP",
     });
   };
 

--- a/packages/browser/src/login/oidc/OidcLoginHandler.ts
+++ b/packages/browser/src/login/oidc/OidcLoginHandler.ts
@@ -127,7 +127,7 @@ export default class OidcLoginHandler implements ILoginHandler {
     const OidcOptions: IOidcOptions = {
       issuer: options.oidcIssuer as URL,
       // TODO: differentiate if DPoP should be true
-      dpop: true,
+      dpop: options.tokenType === "DPoP",
       redirectUrl: options.redirectUrl as URL,
       issuerConfiguration: issuerConfig,
       client: dynamicClientRegistration,

--- a/packages/browser/src/login/oidc/OidcLoginHandler.ts
+++ b/packages/browser/src/login/oidc/OidcLoginHandler.ts
@@ -127,7 +127,7 @@ export default class OidcLoginHandler implements ILoginHandler {
     const OidcOptions: IOidcOptions = {
       issuer: options.oidcIssuer as URL,
       // TODO: differentiate if DPoP should be true
-      dpop: options.tokenType === "DPoP",
+      dpop: options.tokenType.toLowerCase() === "dpop",
       redirectUrl: options.redirectUrl as URL,
       issuerConfiguration: issuerConfig,
       client: dynamicClientRegistration,

--- a/packages/browser/src/login/oidc/oidcHandlers/AuthorizationCodeWithPkceOidcHandler.ts
+++ b/packages/browser/src/login/oidc/oidcHandlers/AuthorizationCodeWithPkceOidcHandler.ts
@@ -105,6 +105,7 @@ export default class AuthorizationCodeWithPkceOidcHandler
               codeVerifier: req.state._code_verifier,
               issuer: oidcLoginOptions.issuer.toString(),
               redirectUri: oidcLoginOptions.redirectUrl.toString(),
+              dpop: oidcLoginOptions.dpop ? "true" : "false",
             }),
           ]);
 

--- a/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
+++ b/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
@@ -132,6 +132,11 @@ export default class AuthCodeRedirectHandler implements IRedirectHandler {
         "codeVerifier",
         { errorIfNull: true }
       )) as string;
+      const storedRedirectIri = (await this.storageUtility.getForUser(
+        storedSessionId,
+        "redirectUri",
+        { errorIfNull: true }
+      )) as string;
 
       tokens = await exchangeDpopToken(
         storedSessionId,
@@ -141,7 +146,7 @@ export default class AuthCodeRedirectHandler implements IRedirectHandler {
         // the canHandle function checks that the code is part of the query strings
         url.query["code"] as string,
         codeVerifier,
-        url
+        new URL(storedRedirectIri)
       );
       // The type assertion should not be necessary
       authFetch = await buildDpopFetch(

--- a/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
+++ b/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
@@ -161,7 +161,7 @@ export default class AuthCodeRedirectHandler implements IRedirectHandler {
         //  refresh_token from the redirect URL.
         refreshToken:
           "<Refresh token that *is* coming back in the redirect URL is not yet being parsed and provided by oidc-client-js in it's response object>",
-        webId: tokens.webid,
+        webId: tokens.webId,
         isLoggedIn: "true",
       },
       { secure: true }

--- a/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
+++ b/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
@@ -28,13 +28,48 @@ import URL from "url-parse";
 import ConfigurationError from "../../../errors/ConfigurationError";
 import { inject, injectable } from "tsyringe";
 import {
+  IClient,
+  IClientRegistrar,
+  IIssuerConfig,
+  IIssuerConfigFetcher,
   IRedirectHandler,
   ISessionInfo,
   ISessionInfoManager,
   IStorageUtility,
 } from "@inrupt/solid-client-authn-core";
-import { OidcClient, decodeJwt } from "@inrupt/oidc-dpop-client-browser";
-import { buildBearerFetch } from "../../../authenticatedFetch/fetchFactory";
+import {
+  getDpopToken,
+  getBearerToken,
+  TokenEndpointResponse,
+  TokenEndpointDpopResponse,
+} from "@inrupt/oidc-dpop-client-browser";
+import {
+  buildBearerFetch,
+  buildDpopFetch,
+} from "../../../authenticatedFetch/fetchFactory";
+import { JSONWebKey } from "jose";
+
+export async function exchangeDpopToken(
+  sessionId: string,
+  issuer: URL,
+  issuerFetcher: IIssuerConfigFetcher,
+  clientRegistrar: IClientRegistrar,
+  code: string,
+  codeVerifier: string,
+  redirectUrl: URL
+): Promise<TokenEndpointDpopResponse> {
+  const issuerConfig: IIssuerConfig = await issuerFetcher.fetchConfig(issuer);
+  const client: IClient = await clientRegistrar.getClient(
+    { sessionId },
+    issuerConfig
+  );
+  return getDpopToken(issuerConfig, client, {
+    grantType: "authorization_code",
+    code,
+    codeVerifier,
+    redirectUri: redirectUrl.toString(),
+  });
+}
 
 /**
  * @hidden
@@ -44,12 +79,19 @@ export default class AuthCodeRedirectHandler implements IRedirectHandler {
   constructor(
     @inject("storageUtility") private storageUtility: IStorageUtility,
     @inject("sessionInfoManager")
-    private sessionInfoManager: ISessionInfoManager
+    private sessionInfoManager: ISessionInfoManager,
+    @inject("issuerConfigFetcher")
+    private issuerConfigFetcher: IIssuerConfigFetcher,
+    @inject("clientRegistrar") private clientRegistrar: IClientRegistrar
   ) {}
 
   async canHandle(redirectUrl: string): Promise<boolean> {
     const url = new URL(redirectUrl, true);
-    return !!(url.query && url.query.code && url.query.state);
+    return (
+      url.query !== undefined &&
+      url.query.code !== undefined &&
+      url.query.state !== undefined
+    );
   }
 
   async handle(
@@ -71,46 +113,55 @@ export default class AuthCodeRedirectHandler implements IRedirectHandler {
       }
     )) as string;
 
-    let signinResponse;
-    try {
-      signinResponse = await new OidcClient({
-        // TODO: We should look at the various interfaces being used for storage,
-        //  i.e. between oidc-client-js (WebStorageStoreState), localStorage
-        //  (which has an interface Storage), and our own proprietary interface
-        //  IStorage - i.e. we should really just be using the browser Web Storage
-        //  API, e.g. "stateStore: window.localStorage,".
+    const isDpop =
+      (await this.storageUtility.getForUser(storedSessionId, "dpop")) ===
+      "true";
 
-        // We are instantiating a new instance here, so the only value we need to
-        // explicitly provide is the response mode (default otherwise will look
-        // for a hash '#' fragment!).
-        // eslint-disable-next-line @typescript-eslint/camelcase
-        response_mode: "query",
-        // The userinfo endpoint on NSS fails, so disable this for now
-        // Note that in Solid, information should be retrieved from the
-        // profile referenced by the WebId.
-        loadUserInfo: false,
-      }).processSigninResponse(redirectUrl.toString());
-    } catch (err) {
-      throw new Error(
-        `Problem handling Auth Code Grant (Flow) redirect - URL [${redirectUrl}]: ${err}`
+    let tokens: TokenEndpointResponse | TokenEndpointDpopResponse;
+    let authFetch: typeof fetch;
+
+    if (isDpop) {
+      // Since we throw if not found, the type assertion is okay
+      const issuer = (await this.storageUtility.getForUser(
+        storedSessionId,
+        "issuer",
+        { errorIfNull: true }
+      )) as string;
+      const codeVerifier = (await this.storageUtility.getForUser(
+        storedSessionId,
+        "codeVerifier",
+        { errorIfNull: true }
+      )) as string;
+
+      tokens = await exchangeDpopToken(
+        storedSessionId,
+        new URL(issuer),
+        this.issuerConfigFetcher,
+        this.clientRegistrar,
+        // the canHandle function checks that the code is part of the query strings
+        url.query["code"] as string,
+        codeVerifier,
+        url
       );
-    }
-
-    // We need to decode the access_token JWT to extract out the full WebID.
-    const decoded = await decodeJwt(signinResponse.access_token as string);
-    if (!decoded || !decoded.sub) {
-      throw new Error("The idp returned a bad token without a sub.");
+      // The type assertion should not be necessary
+      authFetch = await buildDpopFetch(
+        tokens.accessToken,
+        tokens.dpopJwk as JSONWebKey
+      );
+    } else {
+      tokens = await getBearerToken(url);
+      authFetch = buildBearerFetch(tokens.accessToken);
     }
 
     await this.storageUtility.setForUser(
       storedSessionId,
       {
-        idToken: signinResponse.id_token,
+        idToken: tokens.idToken,
         // TODO: We need a PR to oidc-client-js to add parsing of the
         //  refresh_token from the redirect URL.
         refreshToken:
           "<Refresh token that *is* coming back in the redirect URL is not yet being parsed and provided by oidc-client-js in it's response object>",
-        webId: decoded.sub as string,
+        webId: tokens.webid,
         isLoggedIn: "true",
       },
       { secure: true }
@@ -122,9 +173,7 @@ export default class AuthCodeRedirectHandler implements IRedirectHandler {
     }
 
     return Object.assign(sessionInfo, {
-      // TODO: When handling DPoP, both the key and the token should be returned
-      // by the redirect handler.
-      fetch: buildBearerFetch(signinResponse.access_token),
+      fetch: authFetch,
     });
   }
 }

--- a/packages/core/src/ILoginInputOptions.ts
+++ b/packages/core/src/ILoginInputOptions.ts
@@ -50,4 +50,9 @@ export default interface ILoginInputOptions {
    * If a function is provided, the browser will not auto-redirect and will instead trigger that function to redirect. Required in non-browser environments.
    */
   handleRedirect?: (redirectUrl: string) => unknown;
+  /**
+   * The type of access token you want to use. Using a cookie-based system requires Bearer tokens, but DPoP tokens provide
+   * an additional safety against replay. By default, a DPoP token will be used.
+   */
+  tokenType?: "DPoP" | "Bearer";
 }

--- a/packages/core/src/login/ILoginOptions.ts
+++ b/packages/core/src/login/ILoginOptions.ts
@@ -40,5 +40,6 @@ export default interface ILoginOptions {
   clientSecret?: string;
   clientName?: string;
   popUp?: boolean;
+  tokenType: "DPoP" | "Bearer";
   handleRedirect?: (redirectUrl: string) => unknown;
 }

--- a/packages/oidc-dpop-client-browser/src/dpop/dpop.spec.ts
+++ b/packages/oidc-dpop-client-browser/src/dpop/dpop.spec.ts
@@ -120,7 +120,7 @@ describe("normalizeHttpUriClaim", () => {
 });
 
 describe("createDpopHeader", () => {
-  it("Properly builds a token when given a key", async () => {
+  it("properly builds a token when given a key", async () => {
     const key = await generateJwk("EC", "P-256", { alg: "ES256" });
     const token = await createDpopHeader(
       new URL("https://audience.com/"),
@@ -129,6 +129,22 @@ describe("createDpopHeader", () => {
     );
     const decoded = await decodeJwt(token);
     expect(decoded.htu).toEqual("https://audience.com/");
-    expect(decoded.htm).toEqual("post");
+    expect(decoded.htm).toEqual("POST");
+  });
+
+  it("create the correct JWT headers", async () => {
+    const key = await generateJwk("EC", "P-256", { alg: "ES256" });
+    const publicKey = { ...key, d: undefined };
+    const token = await createDpopHeader(
+      new URL("https://audience.com/"),
+      "post",
+      key
+    );
+    const decoded = await decodeJwt(token, key, {
+      complete: true,
+    });
+    expect((decoded.header as Record<string, string>).alg).toEqual("ES256");
+    expect((decoded.header as Record<string, string>).typ).toEqual("dpop+jwt");
+    expect((decoded.header as Record<string, string>).jwk).toEqual(publicKey);
   });
 });

--- a/packages/oidc-dpop-client-browser/src/dpop/dpop.ts
+++ b/packages/oidc-dpop-client-browser/src/dpop/dpop.ts
@@ -109,13 +109,14 @@ export async function createDpopHeader(
   return signJwt(
     {
       htu: normalizeHttpUriClaim(audience),
-      htm: method,
+      htm: method.toUpperCase(),
       jti: v4(),
     },
     key,
     {
       header: {
-        jwk: privateJwkToPublicJwk(key),
+        // TODO: Add a test
+        jwk: await privateJwkToPublicJwk(key),
         typ: "dpop+jwt",
       },
       expiresIn: "1 hour",

--- a/packages/oidc-dpop-client-browser/src/dpop/tokenExchange.spec.ts
+++ b/packages/oidc-dpop-client-browser/src/dpop/tokenExchange.spec.ts
@@ -96,10 +96,10 @@ async function generateMockJwt(): Promise<void> {
     sub: "https://my.webid",
     iss: mockIssuer().issuer.toString(),
   };
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const jwt = await signJwt(payload, mockJwk(), {
     algorithm: "ES256",
   });
+  console.log(jwt.toString());
 }
 
 // result of generateMockJwt()

--- a/packages/oidc-dpop-client-browser/src/dpop/tokenExchange.spec.ts
+++ b/packages/oidc-dpop-client-browser/src/dpop/tokenExchange.spec.ts
@@ -249,6 +249,8 @@ describe("getTokens", () => {
 
   // This test is currently disabled due to the behaviours of both NSS and the ID broker, which return
   // token_type: 'Bearer' even when returning a DPoP token.
+  // https://github.com/solid/oidc-op/issues/26
+  // Fixed, but unreleased for the ESS (current version: inrupt-oidc-server-0.5.2)
   it.skip("throws if a key-bound token was requested, but a bearer token is returned", async () => {
     const myFetch = jest.fn(mockFetch(JSON.stringify(mockBearerTokens()), 200));
     global.fetch = myFetch;

--- a/packages/oidc-dpop-client-browser/src/dpop/tokenExchange.ts
+++ b/packages/oidc-dpop-client-browser/src/dpop/tokenExchange.ts
@@ -272,12 +272,12 @@ export async function getBearerToken(
       `Problem handling Auth Code Grant (Flow) redirect - URL [${redirectUrl}]: ${err}`
     );
   }
-  const webid = await deriveWebidFromIdToken(signinResponse.id_token);
+  const webId = await deriveWebIdFromIdToken(signinResponse.id_token);
 
   return {
     accessToken: signinResponse.access_token,
     idToken: signinResponse.id_token,
-    webid,
+    webId,
     // TODO: Properly handle refresh token
     // refreshToken: signinResponse.refresh_token
   };

--- a/packages/oidc-dpop-client-browser/src/dpop/tokenExchange.ts
+++ b/packages/oidc-dpop-client-browser/src/dpop/tokenExchange.ts
@@ -167,8 +167,10 @@ export function validateTokenEndpointResponse(
     );
   }
 
-  // TODO: Due to what seems to be a bug in the ID broker, a DPoP token is returned
-  // with a token_type 'Bearer'. To work around this, this test is curretnly disabled.
+  // TODO: Due to a bug in both the ESS ID broker AND NSS (what were the odds), a DPoP token is returned
+  // with a token_type 'Bearer'. To work around this, this test is currently disabled.
+  // https://github.com/solid/oidc-op/issues/26
+  // Fixed, but unreleased for the ESS (current version: inrupt-oidc-server-0.5.2)
   // if (dpop && tokenResponse.token_type.toLowerCase() !== "dpop") {
   //   throw new Error(
   //     `Invalid token endpoint response: requested a [DPoP] token, but got a 'token_type' value of [${tokenResponse.token_type}].`

--- a/packages/oidc-dpop-client-browser/src/dpop/tokenExchange.ts
+++ b/packages/oidc-dpop-client-browser/src/dpop/tokenExchange.ts
@@ -167,8 +167,7 @@ export function validateTokenEndpointResponse(
     );
   }
 
-
-  // TODO: Due to what seems to be a bug in the ID broker, a DPoP token is returned 
+  // TODO: Due to what seems to be a bug in the ID broker, a DPoP token is returned
   // with a token_type 'Bearer'. To work around this, this test is curretnly disabled.
   // if (dpop && tokenResponse.token_type.toLowerCase() !== "dpop") {
   //   throw new Error(
@@ -197,21 +196,18 @@ export async function getTokens(
   let dpopJwk: JSONWebKey | undefined = undefined;
   if (dpop) {
     dpopJwk = await generateJwkForDpop();
-    console.log(`Generated JWK: ${JSON.stringify(dpopJwk)}`)
     headers["DPoP"] = await createDpopHeader(
       issuer.tokenEndpoint,
       "POST",
       dpopJwk
     );
-    console.log(`Resulting header: ${headers["DPoP"]}`)
   }
-  // TODO: is this necessary ? it's present in OAuth2 in action book, but not in spec
-  // It appears to be necessary against ESS. Pending test against NSS
-  // TODO: add test
+
+  // TODO: Find out where this is specified.
   if (client.clientSecret) {
-    headers["Authorization"] = `Basic ${
-      btoa(`${client.clientId}:${client.clientSecret}`)
-    }`
+    headers["Authorization"] = `Basic ${btoa(
+      `${client.clientId}:${client.clientSecret}`
+    )}`;
   }
 
   const tokenRequestInit: RequestInit & {

--- a/packages/oidc-dpop-client-browser/src/dpop/tokenExchange.ts
+++ b/packages/oidc-dpop-client-browser/src/dpop/tokenExchange.ts
@@ -189,6 +189,12 @@ export async function getTokens(
   issuer: IIssuerConfig,
   client: IClient,
   data: TokenEndpointInput,
+  dpop: true
+): Promise<TokenEndpointDpopResponse>;
+export async function getTokens(
+  issuer: IIssuerConfig,
+  client: IClient,
+  data: TokenEndpointInput,
   dpop: boolean
 ): Promise<TokenEndpointResponse> {
   validatePreconditions(issuer, data);
@@ -301,8 +307,5 @@ export async function getDpopToken(
   client: IClient,
   data: TokenEndpointInput
 ): Promise<TokenEndpointDpopResponse> {
-  // The type assertion is okay, because the absence of the jwk would throw an error
-  return getTokens(issuer, client, data, true) as Promise<
-    TokenEndpointDpopResponse
-  >;
+  return getTokens(issuer, client, data, true);
 }

--- a/packages/oidc-dpop-client-browser/src/dpop/tokenExchange.ts
+++ b/packages/oidc-dpop-client-browser/src/dpop/tokenExchange.ts
@@ -272,6 +272,12 @@ export async function getBearerToken(
       // The userinfo endpoint on NSS fails, so disable this for now
       // Note that in Solid, information should be retrieved from the
       // profile referenced by the WebId.
+      // TODO: Note that this is heavy-handed, and that this userinfo check verifies
+      // that the `sub` caim in the id token you get along with the access token
+      // matches the sub claim associated to the access token at the userinfo endpoint.
+      // That is a useful check, and in the future it should be only disabled against
+      // NSS, and not in general.
+      // Issue tracker: https://github.com/solid/node-solid-server/issues/1490
       loadUserInfo: false,
     }).processSigninResponse(redirectUrl.toString());
   } catch (err) {

--- a/packages/oidc-dpop-client-browser/src/dpop/tokenExchange.ts
+++ b/packages/oidc-dpop-client-browser/src/dpop/tokenExchange.ts
@@ -195,6 +195,12 @@ export async function getTokens(
   issuer: IIssuerConfig,
   client: IClient,
   data: TokenEndpointInput,
+  dpop: false
+): Promise<TokenEndpointResponse>;
+export async function getTokens(
+  issuer: IIssuerConfig,
+  client: IClient,
+  data: TokenEndpointInput,
   dpop: boolean
 ): Promise<TokenEndpointResponse> {
   validatePreconditions(issuer, data);

--- a/packages/oidc-dpop-client-browser/src/index.ts
+++ b/packages/oidc-dpop-client-browser/src/index.ts
@@ -50,9 +50,11 @@ export {
 } from "./dpop/dpop";
 export { generateJwkForDpop, generateJwkRsa } from "./dpop/keyGeneration";
 export {
-  getTokens,
+  getDpopToken,
+  getBearerToken,
   TokenEndpointInput,
   TokenEndpointResponse,
+  TokenEndpointDpopResponse,
 } from "./dpop/tokenExchange";
 export {
   IClient,


### PR DESCRIPTION
This integrates the DPoP support implemented in the oidc module into the browser module. For consistency, the bearer token exchange is moved to the oidc module as well, so that obtaining either type of token "feels" the same.
After this, the TokenRequester class could be removed, but it will be done in a different PR so that it appears in the git history, so that it is easier to look for.

# Checklist

- [ ] All acceptance criteria are met.
- [x] The changelog has been updated, if applicable.
- [X] New functions/types have been exported in `index.ts`, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).