### PR TITLE
Return unauthenticated session on invalid redirect url

### DIFF
--- a/packages/browser/__tests__/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
+++ b/packages/browser/__tests__/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
@@ -216,11 +216,11 @@ describe("AuthCodeRedirectHandler", () => {
   });
 
   describe("handle", () => {
-    it("Throws an error with invalid input", async () => {
+    it("returns an unauthenticated session on non-redirect URL", async () => {
       const authCodeRedirectHandler = getAuthCodeRedirectHandler();
-      await expect(
-        authCodeRedirectHandler.handle("Bad Input")
-      ).rejects.toThrowError("Cannot handle redirect url [Bad Input]");
+      const mySession = await authCodeRedirectHandler.handle("https://my.app");
+      expect(mySession.isLoggedIn).toEqual(false);
+      expect(mySession.webId).toBeUndefined();
     });
 
     it("Makes a code request to the correct place", async () => {

--- a/packages/browser/__tests__/login/oidc/redirectHandler/GeneralRedirectHandler.spec.ts
+++ b/packages/browser/__tests__/login/oidc/redirectHandler/GeneralRedirectHandler.spec.ts
@@ -89,11 +89,11 @@ describe("GeneralRedirectHandler", () => {
   });
 
   describe("handle", () => {
-    it("Throws an error with invalid input", async () => {
-      const generalRedirectHandler = getGeneralRedirectHandler();
-      await expect(
-        generalRedirectHandler.handle("Bad Input")
-      ).rejects.toThrowError("Cannot handle redirect url [Bad Input]");
+    it("returns an unauthenticated session on non-redirect URL", async () => {
+      const authCodeRedirectHandler = getGeneralRedirectHandler();
+      const mySession = await authCodeRedirectHandler.handle("https://my.app");
+      expect(mySession.isLoggedIn).toEqual(false);
+      expect(mySession.webId).toBeUndefined();
     });
 
     it("Transfers the correct url component to the session creator", async () => {

--- a/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
+++ b/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
@@ -47,8 +47,7 @@ import {
   buildDpopFetch,
 } from "../../../authenticatedFetch/fetchFactory";
 import { JSONWebKey } from "jose";
-import { v4 } from "uuid";
-import { fetch } from "cross-fetch";
+import { getUnauthenticatedSession } from "../../../sessionInfo/SessionInfoManager";
 
 export async function exchangeDpopToken(
   sessionId: string,
@@ -101,11 +100,7 @@ export default class AuthCodeRedirectHandler implements IRedirectHandler {
     if (!(await this.canHandle(redirectUrl))) {
       // If the received IRI does not have redirection information, we can only
       // return an unauthenticated session.
-      return {
-        isLoggedIn: false,
-        sessionId: v4(),
-        fetch: fetch,
-      };
+      return getUnauthenticatedSession();
     }
     const url = new URL(redirectUrl, true);
     const oauthState = url.query.state as string;

--- a/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
+++ b/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
@@ -25,7 +25,6 @@
  */
 
 import URL from "url-parse";
-import ConfigurationError from "../../../errors/ConfigurationError";
 import { inject, injectable } from "tsyringe";
 import {
   IClient,
@@ -48,6 +47,8 @@ import {
   buildDpopFetch,
 } from "../../../authenticatedFetch/fetchFactory";
 import { JSONWebKey } from "jose";
+import { v4 } from "uuid";
+import { fetch } from "cross-fetch";
 
 export async function exchangeDpopToken(
   sessionId: string,
@@ -98,9 +99,13 @@ export default class AuthCodeRedirectHandler implements IRedirectHandler {
     redirectUrl: string
   ): Promise<ISessionInfo & { fetch: typeof fetch }> {
     if (!(await this.canHandle(redirectUrl))) {
-      throw new ConfigurationError(
-        `Cannot handle redirect url [${redirectUrl}]`
-      );
+      // If the received IRI does not have redirection information, we can only
+      // return an unauthenticated session.
+      return {
+        isLoggedIn: false,
+        sessionId: v4(),
+        fetch: fetch,
+      };
     }
     const url = new URL(redirectUrl, true);
     const oauthState = url.query.state as string;

--- a/packages/browser/src/login/oidc/redirectHandler/GeneralRedirectHandler.ts
+++ b/packages/browser/src/login/oidc/redirectHandler/GeneralRedirectHandler.ts
@@ -30,10 +30,10 @@ import {
   ISessionInfoManager,
 } from "@inrupt/solid-client-authn-core";
 import URL from "url-parse";
-import ConfigurationError from "../../..//errors/ConfigurationError";
 import { inject, injectable } from "tsyringe";
 import { ITokenSaver } from "./TokenSaver";
 import { buildBearerFetch } from "../../../authenticatedFetch/fetchFactory";
+import { getUnauthenticatedSession } from "../../../sessionInfo/SessionInfoManager";
 
 /**
  * @hidden
@@ -59,9 +59,9 @@ export default class GeneralRedirectHandler implements IRedirectHandler {
     redirectUrl: string
   ): Promise<ISessionInfo & { fetch: typeof fetch }> {
     if (!(await this.canHandle(redirectUrl))) {
-      throw new ConfigurationError(
-        `Cannot handle redirect url [${redirectUrl}]`
-      );
+      // If the received IRI does not have redirection information, we can only
+      // return an unauthenticated session.
+      return getUnauthenticatedSession();
     }
     const url = new URL(redirectUrl, true);
 

--- a/packages/browser/src/sessionInfo/SessionInfoManager.ts
+++ b/packages/browser/src/sessionInfo/SessionInfoManager.ts
@@ -31,6 +31,18 @@ import {
   ISessionInfoManagerOptions,
   IStorageUtility,
 } from "@inrupt/solid-client-authn-core";
+import { v4 } from "uuid";
+import { fetch } from "cross-fetch";
+
+export function getUnauthenticatedSession(): ISessionInfo & {
+  fetch: typeof fetch;
+} {
+  return {
+    isLoggedIn: false,
+    sessionId: v4(),
+    fetch: fetch,
+  };
+}
 
 /**
  * @param sessionId


### PR DESCRIPTION
If the URL does not contain redirection info as query params, just return an unauthenticated session instead of throwing an error.

Changing this prevents the consuming app to have to worry about the type of IRI it is passing to the library.

- [X] I've added a unit test to test for potential regressions of this bug.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).