### PR TITLE
Prevents DCR from hanging in React components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 - The Authorization header was not set properly, which made it impossible to access private resources.
 - The types consumed/returned by the API are now exported for convenience.
+- The URL parsing library did not parse properly some redirection IRIs, this is now fixed.
+- The dynamic client registration could hang depending on the environment it was deployed in, this is now resolved.
 
 ## [0.2.0]
 

--- a/packages/browser/__tests__/login/oidc/ClientRegistrar.spec.ts
+++ b/packages/browser/__tests__/login/oidc/ClientRegistrar.spec.ts
@@ -168,7 +168,7 @@ describe("ClientRegistrar", () => {
           }
         )
       ).rejects.toThrowError(
-        "Client registration failed: [Error: Dynamic client registration failed: bad stuff that's an error - ]"
+        "Client registration failed: [Error: Dynamic client registration failed: bad stuff that's an error - undefined]"
       );
     });
 

--- a/packages/browser/__tests__/login/oidc/ClientRegistrar.spec.ts
+++ b/packages/browser/__tests__/login/oidc/ClientRegistrar.spec.ts
@@ -168,7 +168,7 @@ describe("ClientRegistrar", () => {
           }
         )
       ).rejects.toThrowError(
-        "Client registration failed: [Error: Dynamic client registration failed: bad stuff that's an error - undefined]"
+        "Client registration failed: [Error: Dynamic client registration failed: bad stuff that's an error - ]"
       );
     });
 

--- a/packages/browser/__tests__/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
+++ b/packages/browser/__tests__/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
@@ -29,7 +29,8 @@ import {
   IClientRegistrarOptions,
   IIssuerConfigFetcher,
 } from "@inrupt/solid-client-authn-core";
-import AuthCodeRedirectHandler, {
+import {
+  AuthCodeRedirectHandler,
   exchangeDpopToken,
 } from "../../../../src/login/oidc/redirectHandler/AuthCodeRedirectHandler";
 import { RedirectorMock } from "../../../../src/login/oidc/__mocks__/Redirector";
@@ -180,11 +181,13 @@ describe("AuthCodeRedirectHandler", () => {
       ).toBe(true);
     });
 
-    it("Rejects an invalid url", async () => {
+    it("throws on invalid url", async () => {
       const authCodeRedirectHandler = getAuthCodeRedirectHandler();
-      expect(
-        await authCodeRedirectHandler.canHandle("beep boop I am a robot")
-      ).toBe(false);
+      await expect(() =>
+        authCodeRedirectHandler.canHandle("beep boop I am a robot")
+      ).rejects.toThrow(
+        "[beep boop I am a robot] is not a valid URL, and cannot be used as a redirect URL."
+      );
     });
 
     it("Rejects a valid url with the incorrect query", async () => {
@@ -216,11 +219,13 @@ describe("AuthCodeRedirectHandler", () => {
   });
 
   describe("handle", () => {
-    it("returns an unauthenticated session on non-redirect URL", async () => {
+    it("throws on non-redirect URL", async () => {
       const authCodeRedirectHandler = getAuthCodeRedirectHandler();
-      const mySession = await authCodeRedirectHandler.handle("https://my.app");
-      expect(mySession.isLoggedIn).toEqual(false);
-      expect(mySession.webId).toBeUndefined();
+      await expect(
+        authCodeRedirectHandler.handle("https://my.app")
+      ).rejects.toThrow(
+        "AuthCodeRedirectHandler cannot handle [https://my.app]"
+      );
     });
 
     it("Makes a code request to the correct place", async () => {

--- a/packages/browser/__tests__/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
+++ b/packages/browser/__tests__/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
@@ -186,7 +186,7 @@ describe("AuthCodeRedirectHandler", () => {
       await expect(() =>
         authCodeRedirectHandler.canHandle("beep boop I am a robot")
       ).rejects.toThrow(
-        "[beep boop I am a robot] is not a valid URL, and cannot be used as a redirect URL."
+        "[beep boop I am a robot] is not a valid URL, and cannot be used as a redirect URL: TypeError: Invalid URL: beep boop I am a robot"
       );
     });
 
@@ -224,7 +224,7 @@ describe("AuthCodeRedirectHandler", () => {
       await expect(
         authCodeRedirectHandler.handle("https://my.app")
       ).rejects.toThrow(
-        "AuthCodeRedirectHandler cannot handle [https://my.app]"
+        "AuthCodeRedirectHandler cannot handle [https://my.app]: it is missing one of [code, state]."
       );
     });
 

--- a/packages/browser/__tests__/login/oidc/redirectHandler/FallbackRedirectHandler.spec.ts
+++ b/packages/browser/__tests__/login/oidc/redirectHandler/FallbackRedirectHandler.spec.ts
@@ -44,7 +44,7 @@ describe("FallbackRedirectHandler", () => {
       await expect(
         redirectHandler.canHandle("beep boop I am a robot")
       ).rejects.toThrow(
-        "[beep boop I am a robot] is not a valid URL, and cannot be used as a redirect URL."
+        "[beep boop I am a robot] is not a valid URL, and cannot be used as a redirect URL: TypeError: Invalid URL: beep boop I am a robot"
       );
     });
   });

--- a/packages/browser/__tests__/login/oidc/redirectHandler/FallbackRedirectHandler.spec.ts
+++ b/packages/browser/__tests__/login/oidc/redirectHandler/FallbackRedirectHandler.spec.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import "reflect-metadata";
+import { FallbackRedirectHandler } from "../../../../src/login/oidc/redirectHandler/FallbackRedirectHandler";
+
+describe("FallbackRedirectHandler", () => {
+  describe("canHandle", () => {
+    it("always accept the given IRI", async () => {
+      const redirectHandler = new FallbackRedirectHandler();
+      expect(
+        await redirectHandler.canHandle(
+          "https://coolparty.com/?code=someCode&state=oauth2_state_value"
+        )
+      ).toBe(true);
+      expect(await redirectHandler.canHandle("https://coolparty.com/")).toBe(
+        true
+      );
+      expect(
+        await redirectHandler.canHandle("https://coolparty.com/?test=test")
+      ).toBe(true);
+    });
+
+    it("throws on invalid url", async () => {
+      const redirectHandler = new FallbackRedirectHandler();
+      await expect(
+        redirectHandler.canHandle("beep boop I am a robot")
+      ).rejects.toThrow(
+        "[beep boop I am a robot] is not a valid URL, and cannot be used as a redirect URL."
+      );
+    });
+  });
+
+  describe("handle", () => {
+    it("returns an unauthenticated session", async () => {
+      const redirectHandler = new FallbackRedirectHandler();
+      const mySession = await redirectHandler.handle("https://my.app");
+      expect(mySession.isLoggedIn).toEqual(false);
+      expect(mySession.webId).toBeUndefined();
+    });
+  });
+});

--- a/packages/browser/__tests__/login/oidc/redirectHandler/ImplicitRedirectHandler.spec.ts
+++ b/packages/browser/__tests__/login/oidc/redirectHandler/ImplicitRedirectHandler.spec.ts
@@ -76,7 +76,7 @@ describe("ImplicitRedirectHandler", () => {
       await expect(() =>
         redirectHandler.canHandle("beep boop I am a robot")
       ).rejects.toThrow(
-        "[beep boop I am a robot] is not a valid URL, and cannot be used as a redirect URL."
+        "[beep boop I am a robot] is not a valid URL, and cannot be used as a redirect URL: TypeError: Invalid URL: beep boop I am a robot"
       );
     });
 
@@ -94,7 +94,7 @@ describe("ImplicitRedirectHandler", () => {
     it("throws on non-redirect URL", async () => {
       const redirectHandler = getImplicitRedirectHandler();
       await expect(redirectHandler.handle("https://my.app")).rejects.toThrow(
-        "ImplicitRedirectHandler cannot handle [https://my.app]"
+        "ImplicitRedirectHandler cannot handle [https://my.app]: it is missing one or more of [id_token, access_token, state]."
       );
     });
 

--- a/packages/browser/src/dependencies.ts
+++ b/packages/browser/src/dependencies.ts
@@ -55,7 +55,8 @@ import LegacyImplicitFlowOidcHandler from "./login/oidc/oidcHandlers/LegacyImpli
 import RefreshTokenOidcHandler from "./login/oidc/oidcHandlers/RefreshTokenOidcHandler";
 import Fetcher, { IFetcher } from "./util/Fetcher";
 import IssuerConfigFetcher from "./login/oidc/IssuerConfigFetcher";
-import GeneralRedirectHandler from "./login/oidc/redirectHandler/GeneralRedirectHandler";
+import { ImplicitRedirectHandler } from "./login/oidc/redirectHandler/ImplicitRedirectHandler";
+import { FallbackRedirectHandler } from "./login/oidc/redirectHandler/FallbackRedirectHandler";
 import EnvironmentDetector, {
   IEnvironmentDetector,
   detectEnvironment,
@@ -65,7 +66,7 @@ import UrlRepresenationConverter, {
   IUrlRepresentationConverter,
 } from "./util/UrlRepresenationConverter";
 import SessionInfoManager from "./sessionInfo/SessionInfoManager";
-import AuthCodeRedirectHandler from "./login/oidc/redirectHandler/AuthCodeRedirectHandler";
+import { AuthCodeRedirectHandler } from "./login/oidc/redirectHandler/AuthCodeRedirectHandler";
 import AggregateRedirectHandler from "./login/oidc/redirectHandler/AggregateRedirectHandler";
 import BrowserStorage from "./storage/BrowserStorage";
 import TokenSaver, {
@@ -178,10 +179,15 @@ container.register<IRedirectHandler>("redirectHandlers", {
   useClass: AuthCodeRedirectHandler,
 });
 container.register<IRedirectHandler>("redirectHandlers", {
-  useClass: GeneralRedirectHandler,
+  useClass: ImplicitRedirectHandler,
 });
 container.register<ITokenSaver>("tokenSaver", {
   useClass: TokenSaver,
+});
+// This catch-all class will always be able to handle the
+// redirect IRI, so it must be registered last in the container
+container.register<IRedirectHandler>("redirectHandlers", {
+  useClass: FallbackRedirectHandler,
 });
 
 // Login/OIDC/Issuer

--- a/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
+++ b/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
@@ -91,9 +91,9 @@ export class AuthCodeRedirectHandler implements IRedirectHandler {
         myUrl.searchParams.get("code") !== null &&
         myUrl.searchParams.get("state") !== null
       );
-    } catch {
+    } catch (e) {
       throw new Error(
-        `[${redirectUrl}] is not a valid URL, and cannot be used as a redirect URL.`
+        `[${redirectUrl}] is not a valid URL, and cannot be used as a redirect URL: ${e.toString()}`
       );
     }
   }
@@ -102,7 +102,9 @@ export class AuthCodeRedirectHandler implements IRedirectHandler {
     redirectUrl: string
   ): Promise<ISessionInfo & { fetch: typeof fetch }> {
     if (!(await this.canHandle(redirectUrl))) {
-      throw new Error(`AuthCodeRedirectHandler cannot handle [${redirectUrl}]`);
+      throw new Error(
+        `AuthCodeRedirectHandler cannot handle [${redirectUrl}]: it is missing one of [code, state].`
+      );
     }
     const url = new UrlParse(redirectUrl, true);
     const oauthState = url.query.state as string;

--- a/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
+++ b/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
@@ -24,7 +24,7 @@
  * @packageDocumentation
  */
 
-import URL from "url-parse";
+import UrlParse from "url-parse";
 import { inject, injectable } from "tsyringe";
 import {
   IClient,
@@ -47,16 +47,15 @@ import {
   buildDpopFetch,
 } from "../../../authenticatedFetch/fetchFactory";
 import { JSONWebKey } from "jose";
-import { getUnauthenticatedSession } from "../../../sessionInfo/SessionInfoManager";
 
 export async function exchangeDpopToken(
   sessionId: string,
-  issuer: URL,
+  issuer: UrlParse,
   issuerFetcher: IIssuerConfigFetcher,
   clientRegistrar: IClientRegistrar,
   code: string,
   codeVerifier: string,
-  redirectUrl: URL
+  redirectUrl: UrlParse
 ): Promise<TokenEndpointDpopResponse> {
   const issuerConfig: IIssuerConfig = await issuerFetcher.fetchConfig(issuer);
   const client: IClient = await clientRegistrar.getClient(
@@ -75,7 +74,7 @@ export async function exchangeDpopToken(
  * @hidden
  */
 @injectable()
-export default class AuthCodeRedirectHandler implements IRedirectHandler {
+export class AuthCodeRedirectHandler implements IRedirectHandler {
   constructor(
     @inject("storageUtility") private storageUtility: IStorageUtility,
     @inject("sessionInfoManager")
@@ -86,23 +85,26 @@ export default class AuthCodeRedirectHandler implements IRedirectHandler {
   ) {}
 
   async canHandle(redirectUrl: string): Promise<boolean> {
-    const url = new URL(redirectUrl, true);
-    return (
-      url.query !== undefined &&
-      url.query.code !== undefined &&
-      url.query.state !== undefined
-    );
+    try {
+      const myUrl = new URL(redirectUrl);
+      return (
+        myUrl.searchParams.get("code") !== null &&
+        myUrl.searchParams.get("state") !== null
+      );
+    } catch {
+      throw new Error(
+        `[${redirectUrl}] is not a valid URL, and cannot be used as a redirect URL.`
+      );
+    }
   }
 
   async handle(
     redirectUrl: string
   ): Promise<ISessionInfo & { fetch: typeof fetch }> {
     if (!(await this.canHandle(redirectUrl))) {
-      // If the received IRI does not have redirection information, we can only
-      // return an unauthenticated session.
-      return getUnauthenticatedSession();
+      throw new Error(`AuthCodeRedirectHandler cannot handle [${redirectUrl}]`);
     }
-    const url = new URL(redirectUrl, true);
+    const url = new UrlParse(redirectUrl, true);
     const oauthState = url.query.state as string;
 
     const storedSessionId = (await this.storageUtility.getForUser(
@@ -112,7 +114,6 @@ export default class AuthCodeRedirectHandler implements IRedirectHandler {
         errorIfNull: true,
       }
     )) as string;
-
     const isDpop =
       (await this.storageUtility.getForUser(storedSessionId, "dpop")) ===
       "true";
@@ -140,13 +141,13 @@ export default class AuthCodeRedirectHandler implements IRedirectHandler {
 
       tokens = await exchangeDpopToken(
         storedSessionId,
-        new URL(issuer),
+        new UrlParse(issuer),
         this.issuerConfigFetcher,
         this.clientRegistrar,
         // the canHandle function checks that the code is part of the query strings
         url.query["code"] as string,
         codeVerifier,
-        new URL(storedRedirectIri)
+        new UrlParse(storedRedirectIri)
       );
       // The type assertion should not be necessary
       authFetch = await buildDpopFetch(

--- a/packages/browser/src/login/oidc/redirectHandler/FallbackRedirectHandler.ts
+++ b/packages/browser/src/login/oidc/redirectHandler/FallbackRedirectHandler.ts
@@ -44,9 +44,9 @@ export class FallbackRedirectHandler implements IRedirectHandler {
     try {
       new URL(redirectUrl);
       return true;
-    } catch {
+    } catch (e) {
       throw new Error(
-        `[${redirectUrl}] is not a valid URL, and cannot be used as a redirect URL.`
+        `[${redirectUrl}] is not a valid URL, and cannot be used as a redirect URL: ${e.toString()}`
       );
     }
   }

--- a/packages/browser/src/login/oidc/redirectHandler/FallbackRedirectHandler.ts
+++ b/packages/browser/src/login/oidc/redirectHandler/FallbackRedirectHandler.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * @hidden
+ * @packageDocumentation
+ */
+
+import { injectable } from "tsyringe";
+import {
+  IRedirectHandler,
+  ISessionInfo,
+} from "@inrupt/solid-client-authn-core";
+
+import { getUnauthenticatedSession } from "../../../sessionInfo/SessionInfoManager";
+
+/**
+ * This class handles redirect IRIs without any query params, and returns an unauthenticated
+ * session. It serves as a fallback so that consuming libraries don't have to test
+ * for the query params themselves, and can always try to use them as a redirect IRI.
+ * @hidden
+ */
+@injectable()
+export class FallbackRedirectHandler implements IRedirectHandler {
+  async canHandle(redirectUrl: string): Promise<boolean> {
+    try {
+      new URL(redirectUrl);
+      return true;
+    } catch {
+      throw new Error(
+        `[${redirectUrl}] is not a valid URL, and cannot be used as a redirect URL.`
+      );
+    }
+  }
+
+  async handle(
+    // The argument is ignored, but must be present to implement the interface
+    _redirectUrl: string
+  ): Promise<ISessionInfo & { fetch: typeof fetch }> {
+    return getUnauthenticatedSession();
+  }
+}

--- a/packages/oidc-dpop-client-browser/src/dcr/clientRegistrar.spec.ts
+++ b/packages/oidc-dpop-client-browser/src/dcr/clientRegistrar.spec.ts
@@ -179,6 +179,28 @@ describe("registerClient", () => {
     );
   });
 
+  it("throws if the redirect URI is undefined", async () => {
+    const myFetch = jest.fn(
+      async (_input: RequestInfo, _init?: RequestInit): Promise<Response> =>
+        new Response(
+          JSON.stringify({
+            error: "invalid_redirect_uri",
+            // eslint-disable-next-line @typescript-eslint/camelcase
+            error_description: "some description",
+          }),
+          { status: 400 }
+        )
+    );
+    global.fetch = myFetch;
+    const options = getMockOptions();
+
+    await expect(() =>
+      registerClient(options, getMockIssuer())
+    ).rejects.toThrow(
+      "Dynamic client registration failed: the provided redirect uri [undefined] is invalid - some description"
+    );
+  });
+
   it("throws if the client metadata are invalid", async () => {
     const myFetch = jest.fn(
       async (_input: RequestInfo, _init?: RequestInit): Promise<Response> =>

--- a/packages/oidc-dpop-client-browser/src/dcr/clientRegistrar.ts
+++ b/packages/oidc-dpop-client-browser/src/dcr/clientRegistrar.ts
@@ -41,7 +41,7 @@ function processErrorResponse(
   if (responseBody.error === "invalid_redirect_uri") {
     throw new Error(
       `Dynamic client registration failed: the provided redirect uri [${options.redirectUrl?.toString()}] is invalid - ${
-        responseBody.error_description
+        responseBody.error_description ?? ""
       }`
     );
   }
@@ -49,13 +49,15 @@ function processErrorResponse(
     throw new Error(
       `Dynamic client registration failed: the provided client metadata ${JSON.stringify(
         options
-      )} is invalid - ${responseBody.error_description}`
+      )} is invalid - ${responseBody.error_description ?? ""}`
     );
   }
   // We currently don't support software statements, so no related error should happen.
   // If an error outside of the spec happens, no additional context can be provided
   throw new Error(
-    `Dynamic client registration failed: ${responseBody.error} - ${responseBody.error_description}`
+    `Dynamic client registration failed: ${responseBody.error} - ${
+      responseBody.error_description ?? ""
+    }`
   );
 }
 

--- a/packages/oidc-dpop-client-browser/src/dcr/clientRegistrar.ts
+++ b/packages/oidc-dpop-client-browser/src/dcr/clientRegistrar.ts
@@ -41,7 +41,7 @@ function processErrorResponse(
   if (responseBody.error === "invalid_redirect_uri") {
     throw new Error(
       `Dynamic client registration failed: the provided redirect uri [${options.redirectUrl?.toString()}] is invalid - ${
-        responseBody.error_description ?? ""
+        responseBody.error_description
       }`
     );
   }
@@ -49,15 +49,13 @@ function processErrorResponse(
     throw new Error(
       `Dynamic client registration failed: the provided client metadata ${JSON.stringify(
         options
-      )} is invalid - ${responseBody.error_description ?? ""}`
+      )} is invalid - ${responseBody.error_description}`
     );
   }
   // We currently don't support software statements, so no related error should happen.
   // If an error outside of the spec happens, no additional context can be provided
   throw new Error(
-    `Dynamic client registration failed: ${responseBody.error} - ${
-      responseBody.error_description ?? ""
-    }`
+    `Dynamic client registration failed: ${responseBody.error} - ${responseBody.error_description}`
   );
 }
 
@@ -114,7 +112,7 @@ export async function registerClient(
   if (options.registrationAccessToken) {
     headers["Authorization"] = `Bearer ${options.registrationAccessToken}`;
   }
-  const registerResponse = await window.fetch(
+  const registerResponse = await fetch(
     issuerConfig.registrationEndpoint.toString(),
     {
       method: "POST",

--- a/packages/oidc-dpop-client-browser/src/dpop/tokenExchange.ts
+++ b/packages/oidc-dpop-client-browser/src/dpop/tokenExchange.ts
@@ -239,14 +239,11 @@ export async function getTokens(
       /* eslint-enable @typescript-eslint/camelcase */
     }),
   };
-
   const rawTokenResponse = (await (
     await fetch(issuer.tokenEndpoint.toString(), tokenRequestInit)
   ).json()) as Record<string, unknown>;
-
   const tokenResponse = validateTokenEndpointResponse(rawTokenResponse, dpop);
   const webId = await deriveWebIdFromIdToken(tokenResponse.id_token);
-
   return {
     accessToken: tokenResponse.access_token,
     idToken: tokenResponse.id_token,


### PR DESCRIPTION
This PR fixes two bugs impacting podbrowser:

- The DCR hanged without any error message. Now, it uses fetch instead of window.fetch, the bundler fills the appropriate fetch in, and things seem to work out.
- Handling an IRI with no querystrings resulted in a throw. This had been fixed in cc939e9, but the fix actually introduced another bug preventing the implicit flow to execute. This new version of the fix is more in line with the handler pattern: a fallback handler is introduced, and returns an unauthenticated session if neither the auth code or the access token are present in the URL.

- [X] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).