### PR TITLE
URL and localStorage cleanup

### DIFF
--- a/packages/browser/__tests__/logout/GeneralLogoutHandler.spec.ts
+++ b/packages/browser/__tests__/logout/GeneralLogoutHandler.spec.ts
@@ -24,7 +24,7 @@ import { mockStorageUtility } from "@inrupt/solid-client-authn-core";
 import { default as LogoutHandler } from "../../src/logout/GeneralLogoutHandler";
 import { mockSessionInfoManager } from "../../src/sessionInfo/__mocks__/SessionInfoManager";
 
-describe("OidcLoginHandler", () => {
+describe("GeneralLogoutHandler", () => {
   const defaultMocks = {
     sessionManager: mockSessionInfoManager(mockStorageUtility({})),
   };

--- a/packages/browser/__tests__/sessionInfo/SessionInfoManager.spec.ts
+++ b/packages/browser/__tests__/sessionInfo/SessionInfoManager.spec.ts
@@ -110,7 +110,7 @@ describe("SessionInfoManager", () => {
       const sessionManager = getSessionInfoManager({
         storageUtility: mockStorageUtility({}, true),
       });
-      await sessionManager.clear("mySession");
+      await sessionManager.clear("Value of sessionId doesn't matter");
       expect(mockClearFunction).toHaveBeenCalled();
     });
 
@@ -132,7 +132,7 @@ describe("SessionInfoManager", () => {
       ).toBeUndefined();
     });
 
-    it("clears local storage from user data", async () => {
+    it("clears local unsecure storage from user data", async () => {
       const mockStorage = mockStorageUtility(
         {
           mySession: {

--- a/packages/browser/__tests__/sessionInfo/SessionInfoManager.spec.ts
+++ b/packages/browser/__tests__/sessionInfo/SessionInfoManager.spec.ts
@@ -24,7 +24,15 @@ import { UuidGeneratorMock } from "../../src/util/__mocks__/UuidGenerator";
 import { AuthenticatedFetcherMock } from "../../src/authenticatedFetch/__mocks__/AuthenticatedFetcher";
 import { LogoutHandlerMock } from "../../src/logout/__mocks__/LogoutHandler";
 import { mockStorageUtility } from "@inrupt/solid-client-authn-core";
-import SessionInfoManager from "../../src/sessionInfo/SessionInfoManager";
+import { SessionInfoManager } from "../../src/sessionInfo/SessionInfoManager";
+
+const mockClearFunction = jest.fn();
+
+jest.mock("@inrupt/oidc-dpop-client-browser", () => {
+  return {
+    clearOidcPersistentStorage: async (): Promise<void> => mockClearFunction(),
+  };
+});
 
 describe("SessionInfoManager", () => {
   const defaultMocks = {
@@ -94,6 +102,61 @@ describe("SessionInfoManager", () => {
       });
       const session = await sessionManager.get("commanderCool");
       expect(session).toBeUndefined();
+    });
+  });
+
+  describe("clear", () => {
+    it("clears oidc data", async () => {
+      const sessionManager = getSessionInfoManager({
+        storageUtility: mockStorageUtility({}, true),
+      });
+      await sessionManager.clear("mySession");
+      expect(mockClearFunction).toHaveBeenCalled();
+    });
+
+    it("clears local secure storage from user data", async () => {
+      const mockStorage = mockStorageUtility(
+        {
+          mySession: {
+            key: "value",
+          },
+        },
+        true
+      );
+      const sessionManager = getSessionInfoManager({
+        storageUtility: mockStorage,
+      });
+      await sessionManager.clear("mySession");
+      expect(
+        await mockStorage.getForUser("mySession", "key", { secure: true })
+      ).toBeUndefined();
+    });
+
+    it("clears local storage from user data", async () => {
+      const mockStorage = mockStorageUtility(
+        {
+          mySession: {
+            key: "value",
+          },
+        },
+        false
+      );
+      const sessionManager = getSessionInfoManager({
+        storageUtility: mockStorage,
+      });
+      await sessionManager.clear("mySession");
+      expect(
+        await mockStorage.getForUser("mySession", "key", { secure: false })
+      ).toBeUndefined();
+    });
+  });
+
+  describe("getAll", () => {
+    it("is not implemented", async () => {
+      const sessionManager = getSessionInfoManager({
+        storageUtility: mockStorageUtility({}),
+      });
+      await expect(sessionManager.getAll).rejects.toThrow("Not implemented");
     });
   });
 });

--- a/packages/browser/src/ClientAuthentication.ts
+++ b/packages/browser/src/ClientAuthentication.ts
@@ -34,8 +34,9 @@ import {
   ISessionInfo,
   ISessionInfoManager,
 } from "@inrupt/solid-client-authn-core";
-import URL from "url-parse";
+import UrlParse from "url-parse";
 import { IFetcher } from "./util/Fetcher";
+import { cleanupRedirectUrl } from "@inrupt/oidc-dpop-client-browser";
 
 /**
  * @hidden
@@ -54,12 +55,12 @@ export default class ClientAuthentication {
     private environmentDetector: IEnvironmentDetector
   ) {}
 
-  private urlOptionToUrl(url?: URL | string): URL | undefined {
+  private urlOptionToUrl(url?: UrlParse | string): UrlParse | undefined {
     if (url) {
       if (typeof url !== "string") {
         return url;
       }
-      return new URL(url);
+      return new UrlParse(url);
     }
     return undefined;
   }
@@ -78,10 +79,16 @@ export default class ClientAuthentication {
     // login).
     await this.sessionInfoManager.clear(sessionId);
 
+    // This workaround should no longer be necessary once no longer use "url-parse"
+    let redirectUrl = options.redirectUrl
+      ? this.urlOptionToUrl(options.redirectUrl)?.toString()
+      : window.location.href;
+    redirectUrl = cleanupRedirectUrl(redirectUrl);
+
     return this.loginHandler.handle({
       sessionId,
       oidcIssuer: this.urlOptionToUrl(options.oidcIssuer),
-      redirectUrl: this.urlOptionToUrl(options.redirectUrl),
+      redirectUrl: this.urlOptionToUrl(redirectUrl),
       clientId: options.clientId,
       clientSecret: options.clientSecret,
       clientName: options.clientName ?? options.clientId,

--- a/packages/browser/src/ClientAuthentication.ts
+++ b/packages/browser/src/ClientAuthentication.ts
@@ -36,7 +36,7 @@ import {
 } from "@inrupt/solid-client-authn-core";
 import UrlParse from "url-parse";
 import { IFetcher } from "./util/Fetcher";
-import { cleanupRedirectUrl } from "@inrupt/oidc-dpop-client-browser";
+import { removeOidcQueryParam } from "@inrupt/oidc-dpop-client-browser";
 
 /**
  * @hidden
@@ -83,7 +83,7 @@ export default class ClientAuthentication {
     let redirectUrl = options.redirectUrl
       ? (this.urlOptionToUrl(options.redirectUrl)?.toString() as string)
       : window.location.href;
-    redirectUrl = cleanupRedirectUrl(redirectUrl);
+    redirectUrl = removeOidcQueryParam(redirectUrl);
 
     return this.loginHandler.handle({
       sessionId,

--- a/packages/browser/src/ClientAuthentication.ts
+++ b/packages/browser/src/ClientAuthentication.ts
@@ -81,7 +81,7 @@ export default class ClientAuthentication {
 
     // This workaround should no longer be necessary once no longer use "url-parse"
     let redirectUrl = options.redirectUrl
-      ? this.urlOptionToUrl(options.redirectUrl)?.toString()
+      ? (this.urlOptionToUrl(options.redirectUrl)?.toString() as string)
       : window.location.href;
     redirectUrl = cleanupRedirectUrl(redirectUrl);
 

--- a/packages/browser/src/dependencies.ts
+++ b/packages/browser/src/dependencies.ts
@@ -65,7 +65,7 @@ import GeneralLogoutHandler from "./logout/GeneralLogoutHandler";
 import UrlRepresenationConverter, {
   IUrlRepresentationConverter,
 } from "./util/UrlRepresenationConverter";
-import SessionInfoManager from "./sessionInfo/SessionInfoManager";
+import { SessionInfoManager } from "./sessionInfo/SessionInfoManager";
 import { AuthCodeRedirectHandler } from "./login/oidc/redirectHandler/AuthCodeRedirectHandler";
 import AggregateRedirectHandler from "./login/oidc/redirectHandler/AggregateRedirectHandler";
 import BrowserStorage from "./storage/BrowserStorage";

--- a/packages/browser/src/sessionInfo/SessionInfoManager.ts
+++ b/packages/browser/src/sessionInfo/SessionInfoManager.ts
@@ -67,7 +67,7 @@ export async function clear(
  * @hidden
  */
 @injectable()
-export default class SessionInfoManager implements ISessionInfoManager {
+export class SessionInfoManager implements ISessionInfoManager {
   constructor(
     @inject("storageUtility") private storageUtility: IStorageUtility
   ) {}

--- a/packages/browser/src/sessionInfo/SessionInfoManager.ts
+++ b/packages/browser/src/sessionInfo/SessionInfoManager.ts
@@ -33,6 +33,7 @@ import {
 } from "@inrupt/solid-client-authn-core";
 import { v4 } from "uuid";
 import { fetch } from "cross-fetch";
+import { clearOidcPersistentStorage } from "@inrupt/oidc-dpop-client-browser";
 
 export function getUnauthenticatedSession(): ISessionInfo & {
   fetch: typeof fetch;
@@ -59,6 +60,7 @@ export async function clear(
     // FIXME: This is needed until the DPoP key is stored safely
     storage.delete("clientKey", { secure: false }),
   ]);
+  await clearOidcPersistentStorage();
 }
 
 /**

--- a/packages/browser/src/sessionInfo/__mocks__/SessionInfoManager.ts
+++ b/packages/browser/src/sessionInfo/__mocks__/SessionInfoManager.ts
@@ -19,7 +19,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import SessionInfoManager from "../SessionInfoManager";
+import { SessionInfoManager } from "../SessionInfoManager";
 import {
   ISessionInfo,
   ISessionInfoManager,

--- a/packages/oidc-dpop-client-browser/src/cleanup/cleanup.spec.ts
+++ b/packages/oidc-dpop-client-browser/src/cleanup/cleanup.spec.ts
@@ -20,7 +20,7 @@
  */
 
 import { it, describe, expect } from "@jest/globals";
-import { cleanupRedirectUrl, clearOidcPersistentStorage } from "./cleanup";
+import { removeOidcQueryParam, clearOidcPersistentStorage } from "./cleanup";
 import { OidcClient } from "oidc-client";
 
 jest.mock("oidc-client", () => {
@@ -35,28 +35,28 @@ jest.mock("oidc-client", () => {
   };
 });
 
-describe("cleanupRedirectUrl", () => {
+describe("removeOidcQueryParam", () => {
   it("removes the 'code' query string if present", () => {
-    expect(cleanupRedirectUrl("https://some.url/?code=aCode")).toEqual(
+    expect(removeOidcQueryParam("https://some.url/?code=aCode")).toEqual(
       "https://some.url/"
     );
   });
 
   it("removes the 'state' query string if present", () => {
-    expect(cleanupRedirectUrl("https://some.url/?state=arkansas")).toEqual(
+    expect(removeOidcQueryParam("https://some.url/?state=arkansas")).toEqual(
       "https://some.url/"
     );
   });
 
   it("returns an URL without query strings as is", () => {
-    expect(cleanupRedirectUrl("https://some.url/")).toEqual(
+    expect(removeOidcQueryParam("https://some.url/")).toEqual(
       "https://some.url/"
     );
   });
 
   it("preserves other query strings", () => {
     expect(
-      cleanupRedirectUrl(
+      removeOidcQueryParam(
         "https://some.url/?code=someCode&state=someState&otherQuery=aValue"
       )
     ).toEqual("https://some.url/?otherQuery=aValue");

--- a/packages/oidc-dpop-client-browser/src/cleanup/cleanup.spec.ts
+++ b/packages/oidc-dpop-client-browser/src/cleanup/cleanup.spec.ts
@@ -31,6 +31,7 @@ jest.mock("oidc-client", () => {
     OidcClient: jest.fn().mockImplementation(() => {
       return mockClient;
     }),
+    WebStorageStateStore: jest.fn().mockImplementation(),
   };
 });
 
@@ -64,9 +65,10 @@ describe("cleanupRedirectUrl", () => {
 
 describe("clearOidcPersistentStorage", () => {
   it("clears oidc-client storage", async () => {
-    // This is a bad test, but I can only test for internal behaviour of oidc-client,
+    // This is a bad test, but we can only test for internal behaviour of oidc-client,
     // or test that the 'clearStaleState' function is called, which is done here.
-    await expect(clearOidcPersistentStorage()).resolves;
-    expect(new OidcClient({})).toHaveBeenCalled();
+    const clearSpy = jest.spyOn(new OidcClient({}), "clearStaleState");
+    await clearOidcPersistentStorage();
+    expect(clearSpy).toHaveBeenCalled();
   });
 });

--- a/packages/oidc-dpop-client-browser/src/cleanup/cleanup.spec.ts
+++ b/packages/oidc-dpop-client-browser/src/cleanup/cleanup.spec.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { it, describe, expect } from "@jest/globals";
+import { cleanupRedirectUrl, clearOidcPersistentStorage } from "./cleanup";
+import { OidcClient } from "oidc-client";
+
+jest.mock("oidc-client", () => {
+  const mockClient = {
+    clearStaleState: jest.fn(),
+  };
+  return {
+    OidcClient: jest.fn().mockImplementation(() => {
+      return mockClient;
+    }),
+  };
+});
+
+describe("cleanupRedirectUrl", () => {
+  it("removes the 'code' query string if present", () => {
+    expect(cleanupRedirectUrl("https://some.url/?code=aCode")).toEqual(
+      "https://some.url/"
+    );
+  });
+
+  it("removes the 'state' query string if present", () => {
+    expect(cleanupRedirectUrl("https://some.url/?state=arkansas")).toEqual(
+      "https://some.url/"
+    );
+  });
+
+  it("returns an URL without query strings as is", () => {
+    expect(cleanupRedirectUrl("https://some.url/")).toEqual(
+      "https://some.url/"
+    );
+  });
+
+  it("preserves other query strings", () => {
+    expect(
+      cleanupRedirectUrl(
+        "https://some.url/?code=someCode&state=someState&otherQuery=aValue"
+      )
+    ).toEqual("https://some.url/?otherQuery=aValue");
+  });
+});
+
+describe("clearOidcPersistentStorage", () => {
+  it("clears oidc-client storage", async () => {
+    // This is a bad test, but I can only test for internal behaviour of oidc-client,
+    // or test that the 'clearStaleState' function is called, which is done here.
+    await expect(clearOidcPersistentStorage()).resolves;
+    expect(new OidcClient({})).toHaveBeenCalled();
+  });
+});

--- a/packages/oidc-dpop-client-browser/src/cleanup/cleanup.ts
+++ b/packages/oidc-dpop-client-browser/src/cleanup/cleanup.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { OidcClient, WebStorageStateStore } from "oidc-client";
+
+/**
+ * Removes OIDC-specific query parameters from a given URL (state, code...)
+ * @param redirectUrl The URL to clean up.
+ * @returns A copy of the URL, without OIDC-specific query params.
+ */
+export function cleanupRedirectUrl(redirectUrl: string): string {
+  const cleanedUrl = new URL(redirectUrl);
+  cleanedUrl.searchParams.delete("code");
+  cleanedUrl.searchParams.delete("state");
+  return cleanedUrl.toString();
+}
+
+/**
+ * Clears any OIDC-related data lingering in the local storage.
+ */
+export async function clearOidcPersistentStorage(): Promise<void> {
+  console.log("Clearing oidc-client local storage");
+  const client = new OidcClient({
+    // TODO: We should look at the various interfaces being used for storage,
+    //  i.e. between oidc-client-js (WebStorageStoreState), localStorage
+    //  (which has an interface Storage), and our own proprietary interface
+    //  IStorage - i.e. we should really just be using the browser Web Storage
+    //  API, e.g. "stateStore: window.localStorage,".
+    // We are instantiating a new instance here, so the only value we need to
+    // explicitly provide is the response mode (default otherwise will look
+    // for a hash '#' fragment!).
+    // eslint-disable-next-line @typescript-eslint/camelcase
+    response_mode: "query",
+  });
+  await client.clearStaleState(new WebStorageStateStore({}));
+}

--- a/packages/oidc-dpop-client-browser/src/cleanup/cleanup.ts
+++ b/packages/oidc-dpop-client-browser/src/cleanup/cleanup.ts
@@ -37,7 +37,6 @@ export function cleanupRedirectUrl(redirectUrl: string): string {
  * Clears any OIDC-related data lingering in the local storage.
  */
 export async function clearOidcPersistentStorage(): Promise<void> {
-  console.log("Clearing oidc-client local storage");
   const client = new OidcClient({
     // TODO: We should look at the various interfaces being used for storage,
     //  i.e. between oidc-client-js (WebStorageStoreState), localStorage

--- a/packages/oidc-dpop-client-browser/src/cleanup/cleanup.ts
+++ b/packages/oidc-dpop-client-browser/src/cleanup/cleanup.ts
@@ -26,7 +26,7 @@ import { OidcClient, WebStorageStateStore } from "oidc-client";
  * @param redirectUrl The URL to clean up.
  * @returns A copy of the URL, without OIDC-specific query params.
  */
-export function cleanupRedirectUrl(redirectUrl: string): string {
+export function removeOidcQueryParam(redirectUrl: string): string {
   const cleanedUrl = new URL(redirectUrl);
   cleanedUrl.searchParams.delete("code");
   cleanedUrl.searchParams.delete("state");

--- a/packages/oidc-dpop-client-browser/src/dpop/tokenExchange.ts
+++ b/packages/oidc-dpop-client-browser/src/dpop/tokenExchange.ts
@@ -25,7 +25,7 @@ import { JSONWebKey } from "jose";
 import { createDpopHeader, decodeJwt } from "./dpop";
 import { generateJwkForDpop } from "./keyGeneration";
 import formurlencoded from "form-urlencoded";
-import { OidcClient, WebStorageStateStore } from "oidc-client";
+import { OidcClient } from "oidc-client";
 
 function hasAccessToken(
   value: { access_token: string } | Record<string, unknown>

--- a/packages/oidc-dpop-client-browser/src/dpop/tokenExchange.ts
+++ b/packages/oidc-dpop-client-browser/src/dpop/tokenExchange.ts
@@ -25,7 +25,7 @@ import { JSONWebKey } from "jose";
 import { createDpopHeader, decodeJwt } from "./dpop";
 import { generateJwkForDpop } from "./keyGeneration";
 import formurlencoded from "form-urlencoded";
-import { OidcClient } from "oidc-client";
+import { OidcClient, WebStorageStateStore } from "oidc-client";
 
 function hasAccessToken(
   value: { access_token: string } | Record<string, unknown>

--- a/packages/oidc-dpop-client-browser/src/index.ts
+++ b/packages/oidc-dpop-client-browser/src/index.ts
@@ -52,7 +52,6 @@ export { generateJwkForDpop, generateJwkRsa } from "./dpop/keyGeneration";
 export {
   getDpopToken,
   getBearerToken,
-  clearOidcPersistentStorage,
   TokenEndpointInput,
   TokenEndpointResponse,
   TokenEndpointDpopResponse,
@@ -62,3 +61,7 @@ export {
   IClientRegistrarOptions,
   IIssuerConfig,
 } from "./common/types";
+export {
+  cleanupRedirectUrl,
+  clearOidcPersistentStorage,
+} from "./cleanup/cleanup";

--- a/packages/oidc-dpop-client-browser/src/index.ts
+++ b/packages/oidc-dpop-client-browser/src/index.ts
@@ -52,6 +52,7 @@ export { generateJwkForDpop, generateJwkRsa } from "./dpop/keyGeneration";
 export {
   getDpopToken,
   getBearerToken,
+  clearOidcPersistentStorage,
   TokenEndpointInput,
   TokenEndpointResponse,
   TokenEndpointDpopResponse,

--- a/packages/oidc-dpop-client-browser/src/index.ts
+++ b/packages/oidc-dpop-client-browser/src/index.ts
@@ -62,6 +62,6 @@ export {
   IIssuerConfig,
 } from "./common/types";
 export {
-  cleanupRedirectUrl,
+  removeOidcQueryParam,
   clearOidcPersistentStorage,
 } from "./cleanup/cleanup";


### PR DESCRIPTION
This PR fixes two bugs: the query strings not being removed of the redirect IRI, and the local storage not being cleared by oidc-client.

Note: still missing some tests, that's why this is a draft.

- [x] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).