### PR TITLE
Coverage 100% for Core (mostly secure storage) (#368)

### DIFF
--- a/packages/core/src/storage/StorageUtility.ts
+++ b/packages/core/src/storage/StorageUtility.ts
@@ -53,9 +53,11 @@ export default class StorageUtility implements IStorageUtility {
       ? this.secureStorage
       : this.insecureStorage
     ).get(this.getKey(userId));
+
     if (stored === undefined) {
       return {};
     }
+
     try {
       return JSON.parse(stored);
     } catch (err) {

--- a/packages/core/src/storage/__mocks__/StorageUtility.ts
+++ b/packages/core/src/storage/__mocks__/StorageUtility.ts
@@ -26,6 +26,9 @@ export const StorageUtilitySafeGetResponse = {
   someKey: "someValue",
 };
 
+export const mockUserIdStoringInvalidData =
+  "Mock user testing for invalid stored data (which should be impossible)...";
+
 export const StorageUtilityMock: IStorageUtility = {
   /* eslint-disable @typescript-eslint/no-unused-vars */
   get: async (key: string, options?: { errorIfNull?: boolean }) =>
@@ -90,6 +93,13 @@ export const mockStorageUtility = (
       options?: { errorIfNull?: boolean; secure?: boolean }
     ): Promise<string | undefined> => {
       const store = options?.secure ? secureStore : nonSecureStore;
+
+      if (key.endsWith(mockUserIdStoringInvalidData)) {
+        return new Promise((resolve) =>
+          resolve("This response deliberately cannot be parsed as JSON!")
+        );
+      }
+
       return new Promise((resolve) =>
         resolve(store[key] ? (store[key] as string) : undefined)
       );


### PR DESCRIPTION
This re-applies https://github.com/inrupt/solid-client-authn-js/commit/a28b0b6e2c29b7e72d8f20dd99536425568906b9, which seems to have been lost in when merging the diverged `1.x` branch.