### PR TITLE
Workaround react components issues with localstorage

### DIFF
--- a/packages/oidc-dpop-client-browser/src/cleanup/cleanup.spec.ts
+++ b/packages/oidc-dpop-client-browser/src/cleanup/cleanup.spec.ts
@@ -71,4 +71,21 @@ describe("clearOidcPersistentStorage", () => {
     await clearOidcPersistentStorage();
     expect(clearSpy).toHaveBeenCalled();
   });
+
+  it("removes keys matching expected patterns as a stopgap solution", async () => {
+    window.localStorage.setItem("oidc.someOidcState", "a value");
+    window.localStorage.setItem(
+      "solidClientAuthenticationUser:someSessionId",
+      "a value"
+    );
+    window.localStorage.setItem("anArbitraryKey", "a value");
+    await clearOidcPersistentStorage();
+    expect(window.localStorage.length).toEqual(1);
+  });
+
+  it("doesn't fail if localstorage is empty", async () => {
+    window.localStorage.clear();
+    await clearOidcPersistentStorage();
+    expect(window.localStorage.length).toEqual(0);
+  });
 });

--- a/packages/oidc-dpop-client-browser/src/cleanup/cleanup.ts
+++ b/packages/oidc-dpop-client-browser/src/cleanup/cleanup.ts
@@ -50,4 +50,17 @@ export async function clearOidcPersistentStorage(): Promise<void> {
     response_mode: "query",
   });
   await client.clearStaleState(new WebStorageStateStore({}));
+  const myStorage = window.localStorage;
+  const itemsToRemove = [];
+  for (let i = 0; i <= myStorage.length; i++) {
+    const key = myStorage.key(i);
+    if (
+      key &&
+      (key.match(/^oidc\..+$/) ||
+        key.match(/^solidClientAuthenticationUser:.+$/))
+    ) {
+      itemsToRemove.push(key);
+    }
+  }
+  itemsToRemove.forEach((key) => myStorage.removeItem(key));
 }


### PR DESCRIPTION
This is a stopgap solution, until a cleaner fix is found. For some reason, the functions used to clear the local storage that are working in the demo app aren't working for the react components, which is a problem for podbrowser. This enforces a clean slate, preventing previous client ids to be reused.

- [X] I've added a unit test to test for potential regressions of this bug.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).