### PR TITLE
Feat/no resolve dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,12 +19,17 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 - The support for DPoP was re-implemented in @inrupt/oidc-client-dpop-browser, such that the DPoP JWK is never stored, and only kept inside the closure of the authenticated fetch.
 
+### Non-breaking changes
+
+- It is now possible to build a `Session` without calling `getClientAuthenticationWithDependencies`, which results in simpler code.
+
 ### Bugfixes
 
 - The Authorization header was not set properly, which made it impossible to access private resources.
 - The types consumed/returned by the API are now exported for convenience.
 - The URL parsing library did not parse properly some redirection IRIs, this is now fixed.
 - The dynamic client registration could hang depending on the environment it was deployed in, this is now resolved.
+- The `login` event was never actually fired because of a bug which is now fixed.
 
 ## [0.2.0]
 

--- a/packages/browser/__tests__/Session.spec.ts
+++ b/packages/browser/__tests__/Session.spec.ts
@@ -153,11 +153,38 @@ describe("Session", () => {
           done();
         }
       };
-      const mySession = new Session({
-        clientAuthentication: mockClientAuthentication(),
-      });
+      const clientAuthentication = mockClientAuthentication();
+      clientAuthentication.handleIncomingRedirect = jest.fn(
+        async (_url: string) => {
+          return {
+            isLoggedIn: true,
+            sessionId: "a session ID",
+            webId: "https://some.webid#them",
+          };
+        }
+      );
+      const mySession = new Session({ clientAuthentication });
       mySession.onLogin(myCallback);
-      await mySession.login({});
+      await mySession.handleIncomingRedirect("https://some.url");
+    });
+
+    it("does not call the registered callback if login isn't successful", async () => {
+      const failCallback = (): void => {
+        fail();
+      };
+      const clientAuthentication = mockClientAuthentication();
+      clientAuthentication.handleIncomingRedirect = jest.fn(
+        async (_url: string) => {
+          return {
+            isLoggedIn: false,
+            sessionId: "a session ID",
+            webId: "https://some.webid#them",
+          };
+        }
+      );
+      const mySession = new Session({ clientAuthentication });
+      mySession.onLogin(failCallback);
+      await mySession.handleIncomingRedirect("https://some.url");
     });
   });
 

--- a/packages/browser/__tests__/Session.spec.ts
+++ b/packages/browser/__tests__/Session.spec.ts
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+// The following is required by tsyringe
+import "reflect-metadata";
+import { it, describe } from "@jest/globals";
+import { mockClientAuthentication } from "../src/__mocks__/ClientAuthentication";
+import { Session } from "../src/Session";
+import { mockStorage } from "../../core/src/storage/__mocks__/StorageUtility";
+
+describe("Session", () => {
+  describe("constructor", () => {
+    it("accepts an empty config", async () => {
+      const mySession = new Session({});
+      expect(mySession.info.isLoggedIn).toEqual(false);
+      expect(mySession.info.sessionId).toBeDefined();
+    });
+
+    it("accepts no config", async () => {
+      const mySession = new Session();
+      expect(mySession.info.isLoggedIn).toEqual(false);
+      expect(mySession.info.sessionId).toBeDefined();
+    });
+
+    it("does not generate a session id if one is provided", () => {
+      const mySession = new Session({}, "mySession");
+      expect(mySession.info.sessionId).toEqual("mySession");
+    });
+
+    it("accepts input storage", async () => {
+      const insecureStorage = mockStorage({});
+      const secureStorage = mockStorage({});
+      const mySession = new Session({
+        insecureStorage,
+        secureStorage,
+      });
+      const clearSecureStorage = jest.spyOn(secureStorage, "delete");
+      const clearInsecureStorage = jest.spyOn(insecureStorage, "delete");
+      await mySession.logout();
+      expect(clearSecureStorage).toHaveBeenCalled();
+      expect(clearInsecureStorage).toHaveBeenCalled();
+    });
+
+    it("accepts session info", () => {
+      const mySession = new Session({
+        sessionInfo: {
+          sessionId: "mySession",
+          isLoggedIn: false,
+          webId: "https://some.webid",
+        },
+      });
+      expect(mySession.info.isLoggedIn).toEqual(false);
+      expect(mySession.info.sessionId).toEqual("mySession");
+      expect(mySession.info.webId).toEqual("https://some.webid");
+    });
+  });
+
+  describe("login", () => {
+    it("wraps up ClientAuthentication login", async () => {
+      const clientAuthentication = mockClientAuthentication();
+      const clientAuthnLogin = jest.spyOn(clientAuthentication, "login");
+      const mySession = new Session({ clientAuthentication });
+      await mySession.login({});
+      expect(clientAuthnLogin).toHaveBeenCalled();
+    });
+  });
+
+  describe("logout", () => {
+    it("wraps up ClientAuthentication logout", async () => {
+      const clientAuthentication = mockClientAuthentication();
+      const clientAuthnLogout = jest.spyOn(clientAuthentication, "logout");
+      const mySession = new Session({ clientAuthentication });
+      await mySession.logout();
+      expect(clientAuthnLogout).toHaveBeenCalled();
+    });
+  });
+
+  describe("fetch", () => {
+    it("wraps up ClientAuthentication fetch", async () => {
+      const clientAuthentication = mockClientAuthentication();
+      const clientAuthnFetch = jest.spyOn(clientAuthentication, "fetch");
+      const mySession = new Session({ clientAuthentication });
+      await mySession.fetch("https://some.url");
+      expect(clientAuthnFetch).toHaveBeenCalled();
+    });
+  });
+
+  describe("handleincomingRedirect", () => {
+    it("wraps up ClientAuthentication handleIncomingRedirect", async () => {
+      const clientAuthentication = mockClientAuthentication();
+      const clientAuthnHandle = jest.spyOn(
+        clientAuthentication,
+        "handleIncomingRedirect"
+      );
+      const mySession = new Session({ clientAuthentication });
+      await mySession.handleIncomingRedirect("https://some.url");
+      expect(clientAuthnHandle).toHaveBeenCalled();
+    });
+
+    it("updates the session's info if relevant", async () => {
+      const clientAuthentication = mockClientAuthentication();
+      clientAuthentication.handleIncomingRedirect = jest.fn(
+        async (_url: string) => {
+          return {
+            isLoggedIn: true,
+            sessionId: "a session ID",
+            webId: "https://some.webid#them",
+          };
+        }
+      );
+      const mySession = new Session({ clientAuthentication });
+      expect(mySession.info.isLoggedIn).toEqual(false);
+      await mySession.handleIncomingRedirect("https://some.url");
+      expect(mySession.info.isLoggedIn).toEqual(true);
+      expect(mySession.info.sessionId).toEqual("a session ID");
+      expect(mySession.info.webId).toEqual("https://some.webid#them");
+    });
+
+    it("leaves the session's info unchanged if no session is obtained after redirect", async () => {
+      const clientAuthentication = mockClientAuthentication();
+      clientAuthentication.handleIncomingRedirect = jest.fn(
+        async (_url: string) => undefined
+      );
+      const mySession = new Session({ clientAuthentication }, "mySession");
+      await mySession.handleIncomingRedirect("https://some.url");
+      expect(mySession.info.isLoggedIn).toEqual(false);
+      expect(mySession.info.sessionId).toEqual("mySession");
+    });
+  });
+
+  describe("onLogin", () => {
+    it("calls the registered callback on login", async (done) => {
+      const myCallback = (): void => {
+        if (done) {
+          done();
+        }
+      };
+      const mySession = new Session({
+        clientAuthentication: mockClientAuthentication(),
+      });
+      mySession.onLogin(myCallback);
+      await mySession.login({});
+    });
+  });
+
+  describe("onLogout", () => {
+    it("calls the registered callback on logout", async (done) => {
+      const myCallback = (): void => {
+        if (done) {
+          done();
+        }
+      };
+      const mySession = new Session({
+        clientAuthentication: mockClientAuthentication(),
+      });
+      mySession.onLogout(myCallback);
+      await mySession.logout();
+    });
+  });
+});

--- a/packages/browser/__tests__/Session.spec.ts
+++ b/packages/browser/__tests__/Session.spec.ts
@@ -148,7 +148,9 @@ describe("Session", () => {
 
   describe("onLogin", () => {
     it("calls the registered callback on login", async (done) => {
+      let hasBeenCalled = false;
       const myCallback = (): void => {
+        hasBeenCalled = true;
         if (done) {
           done();
         }
@@ -166,11 +168,14 @@ describe("Session", () => {
       const mySession = new Session({ clientAuthentication });
       mySession.onLogin(myCallback);
       await mySession.handleIncomingRedirect("https://some.url");
+      expect(hasBeenCalled).toEqual(true);
     });
 
     it("does not call the registered callback if login isn't successful", async () => {
       const failCallback = (): void => {
-        fail();
+        throw new Error(
+          "Should *NOT* call callback - this means test has failed!"
+        );
       };
       const clientAuthentication = mockClientAuthentication();
       clientAuthentication.handleIncomingRedirect = jest.fn(
@@ -184,7 +189,9 @@ describe("Session", () => {
       );
       const mySession = new Session({ clientAuthentication });
       mySession.onLogin(failCallback);
-      await mySession.handleIncomingRedirect("https://some.url");
+      await expect(
+        mySession.handleIncomingRedirect("https://some.url")
+      ).resolves.not.toThrow();
     });
   });
 

--- a/packages/browser/__tests__/Session.spec.ts
+++ b/packages/browser/__tests__/Session.spec.ts
@@ -40,7 +40,7 @@ describe("Session", () => {
       expect(mySession.info.sessionId).toBeDefined();
     });
 
-    it("does not generate a session id if one is provided", () => {
+    it("does not generate a session ID if one is provided", () => {
       const mySession = new Session({}, "mySession");
       expect(mySession.info.sessionId).toEqual("mySession");
     });

--- a/packages/browser/src/Session.ts
+++ b/packages/browser/src/Session.ts
@@ -93,15 +93,13 @@ export class Session extends EventEmitter {
         insecureStorage: sessionOptions.insecureStorage,
       });
     } else {
-      throw new Error(
-        "Session requires either storage options, or a client authentication instance."
-      );
+      this.clientAuthentication = getClientAuthenticationWithDependencies({});
     }
 
     if (sessionOptions.sessionInfo) {
       this.info = {
         sessionId: sessionOptions.sessionInfo.sessionId,
-        isLoggedIn: sessionOptions.sessionInfo.isLoggedIn,
+        isLoggedIn: false,
         webId: sessionOptions.sessionInfo.webId,
       };
     } else {
@@ -159,6 +157,7 @@ export class Session extends EventEmitter {
     if (sessionInfo) {
       this.info.isLoggedIn = sessionInfo.isLoggedIn;
       this.info.webId = sessionInfo.webId;
+      this.info.sessionId = sessionInfo.sessionId;
     }
     return sessionInfo;
   };

--- a/packages/browser/src/Session.ts
+++ b/packages/browser/src/Session.ts
@@ -155,6 +155,8 @@ export class Session extends EventEmitter {
     );
     if (sessionInfo) {
       if (sessionInfo.isLoggedIn) {
+        // The login event can only be triggered **after** the user has been
+        // redirected from the IdP with access and ID tokens.
         this.emit("login");
       }
       this.info.isLoggedIn = sessionInfo.isLoggedIn;

--- a/packages/browser/src/Session.ts
+++ b/packages/browser/src/Session.ts
@@ -122,7 +122,6 @@ export class Session extends EventEmitter {
     await this.clientAuthentication.login(this.info.sessionId, {
       ...options,
     });
-    this.emit("login");
   };
 
   /**
@@ -155,6 +154,9 @@ export class Session extends EventEmitter {
       url
     );
     if (sessionInfo) {
+      if (sessionInfo.isLoggedIn) {
+        this.emit("login");
+      }
       this.info.isLoggedIn = sessionInfo.isLoggedIn;
       this.info.webId = sessionInfo.webId;
       this.info.sessionId = sessionInfo.sessionId;

--- a/packages/browser/src/__mocks__/ClientAuthentication.ts
+++ b/packages/browser/src/__mocks__/ClientAuthentication.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import ClientAuthentication from "../ClientAuthentication";
+import { RedirectHandlerMock } from "../login/oidc/redirectHandler/__mocks__/RedirectHandler";
+import { LoginHandlerMock } from "../login/__mocks__/LoginHandler";
+import { LogoutHandlerMock } from "../logout/__mocks__/LogoutHandler";
+import { SessionInfoManagerMock } from "../sessionInfo/__mocks__/SessionInfoManager";
+import { EnvironmentDetectorMock } from "../util/__mocks__/EnvironmentDetector";
+import { FetcherMock } from "../util/__mocks__/Fetcher";
+
+export const mockClientAuthentication = (): ClientAuthentication =>
+  new ClientAuthentication(
+    LoginHandlerMock,
+    RedirectHandlerMock,
+    LogoutHandlerMock,
+    SessionInfoManagerMock,
+    FetcherMock,
+    EnvironmentDetectorMock
+  );

--- a/packages/browser/src/dependencies.ts
+++ b/packages/browser/src/dependencies.ts
@@ -208,7 +208,7 @@ container.register<ILogoutHandler>("logoutHandler", {
 /**
  *
  * @param dependencies
- * @deprecated This function will be removed from the external API in an upcomiong release.
+ * @deprecated This function will be removed from the external API in an upcoming release.
  */
 export function getClientAuthenticationWithDependencies(dependencies: {
   secureStorage?: IStorage;

--- a/packages/browser/src/dependencies.ts
+++ b/packages/browser/src/dependencies.ts
@@ -205,6 +205,11 @@ container.register<ILogoutHandler>("logoutHandler", {
   useClass: GeneralLogoutHandler,
 });
 
+/**
+ *
+ * @param dependencies
+ * @deprecated This function will be removed from the external API in an upcomiong release.
+ */
 export function getClientAuthenticationWithDependencies(dependencies: {
   secureStorage?: IStorage;
   insecureStorage?: IStorage;

--- a/packages/core/src/storage/__mocks__/StorageUtility.ts
+++ b/packages/core/src/storage/__mocks__/StorageUtility.ts
@@ -19,6 +19,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+import { IStorage } from "../..";
 import { default as IStorageUtility } from "../IStorageUtility";
 
 export const StorageUtilityGetResponse = "getResponse";
@@ -72,6 +73,24 @@ export const StorageUtilityMock: IStorageUtility = {
     }>
   ) => StorageUtilitySafeGetResponse,
   /* eslint-enable @typescript-eslint/no-unused-vars */
+};
+
+export const mockStorage = (
+  stored: Record<string, string | Record<string, string>>
+): IStorage => {
+  const store = stored;
+  return {
+    /* eslint-disable @typescript-eslint/no-unused-vars */
+    get: async (key: string): Promise<string | undefined> => {
+      return store[key] ? (store[key] as string) : undefined;
+    },
+    set: async (key: string, value: string): Promise<void> => {
+      store[key] = value;
+    },
+    delete: async (key: string): Promise<void> => {
+      delete store[key];
+    },
+  };
 };
 
 export const mockStorageUtility = (


### PR DESCRIPTION
Building a session no longer requires calling `buildClientAuthnWithDependencies`: the call is done internally by the Session constructor. Additionnally, tests for the Session class are created to reach 100% code coverage.

While I was at it, I also fixed a long-standing bug: the `login` event could never be emitted, since the user got redirected away from the page as part of the login method. Now, the `login` event is fired by `handleIncomingRedirect`, if and only if a session is logged in.

- [X] All acceptance criteria are met.
- [ ] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).