### PR TITLE
Enforces exact version match in prereleases

### DIFF
--- a/.github/workflows/cd-preview.yml
+++ b/.github/workflows/cd-preview.yml
@@ -28,7 +28,7 @@ jobs:
           git config user.name $GITHUB_ACTOR
           git config user.email gh-actions-${GITHUB_ACTOR}@github.com
           # Make sure the prerelease is tagged with the branch name, and that they are sorted by build:
-          npm run version -- prerelease --preid=$TAG_SLUG-$GITHUB_RUN_ID-$GITHUB_RUN_NUMBER --yes --no-push
+          npm run version -- prerelease --preid=$TAG_SLUG-$GITHUB_RUN_ID-$GITHUB_RUN_NUMBER --yes --no-push --exact
       - run: npm run build
       - run: npm run publish-preview -- --dist-tag "$TAG_SLUG" --yes
         env:


### PR DESCRIPTION
In some cases, semver matching prevents from using the most up-to-date dependencies, which makes it much harder to test the behaviour of a preview branch.

- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).