### PR TITLE
Gracefully handle redirect for DPoP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 - If `handleLogin` is called twice, the token endpoint is only hit once, because it might reject replay of the authorization code.
 
+### Non-breaking changes
+
+- It is now possible to build a `Session` without calling `getClientAuthenticationWithDependencies`, which results in simpler code.
+
+### Bugfixes
+
+- A DPoP-authenticated request now follow redirects (in particular, forgetting the trailing `/` for a container no longer returns 401).
+
 ## [0.2.2]
 
 ### Automated test suite
@@ -24,10 +32,6 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### Security patches
 
 - The support for DPoP was re-implemented in @inrupt/oidc-client-dpop-browser, such that the DPoP JWK is never stored, and only kept inside the closure of the authenticated fetch.
-
-### Non-breaking changes
-
-- It is now possible to build a `Session` without calling `getClientAuthenticationWithDependencies`, which results in simpler code.
 
 ### Bugfixes
 

--- a/e2e/browser/test-suite.json
+++ b/e2e/browser/test-suite.json
@@ -26,37 +26,54 @@
       "envTestUserPassword": "E2E_NSS_PASSWORD",
       "brokeredIdp": "nss",
       "authorizeClientAppMechanism": "nss"
-    } ],
+    }
+  ],
 
   "testList": [
     {
       "name": "Public resource in my Pod - not logged in",
       "performLogin": false,
       "resourceToGet": "<POD ROOT>public/",
-      "expectResponseContainsAnyOf": [ "ldp:BasicContainer" ]
+      "expectResponseContainsAnyOf": ["ldp:BasicContainer"]
+    },
+    {
+      "name": "Public resource in my Pod, redirected - not logged in",
+      "performLogin": false,
+      "resourceToGet": "<POD ROOT>public",
+      "expectResponseContainsAnyOf": ["ldp:BasicContainer"]
     },
     {
       "name": "Private resource in my Pod - not logged in",
       "performLogin": false,
       "resourceToGet": "<POD ROOT>private/",
-      "expectResponseContainsAnyOf": [ "\"Unauthorized\"", "requires you to log" ]
+      "expectResponseContainsAnyOf": ["\"Unauthorized\"", "requires you to log"]
     },
     {
       "name": "Private resource in my Pod - logged in",
       "performLogin": true,
       "resourceToGet": "<POD ROOT>private/",
-      "expectResponseContainsAnyOf": [ "ldp:BasicContainer" ]
+      "expectResponseContainsAnyOf": ["ldp:BasicContainer"]
+    },
+    {
+      "name": "Private resource in my Pod, redirected - logged in",
+      "performLogin": true,
+      "resourceToGet": "<POD ROOT>private",
+      "expectResponseContainsAnyOf": ["ldp:BasicContainer"]
     },
     {
       "name": "Public resource in my Pod - logged in",
       "performLogin": true,
       "resourceToGet": "<POD ROOT>public/",
-      "expectResponseContainsAnyOf": [ "ldp:BasicContainer" ]
+      "expectResponseContainsAnyOf": ["ldp:BasicContainer"]
     },
     {
       "name": "Private resource that doesn't exist - logged in",
       "performLogin": true,
       "resourceToGet": "<POD ROOT>private/resource-that-does-not-exist.ttl",
-      "expectResponseContainsAnyOf": [ "\"Not Found\"", "Can't find file requested" ]
-    } ]
+      "expectResponseContainsAnyOf": [
+        "\"Not Found\"",
+        "Can't find file requested"
+      ]
+    }
+  ]
 }

--- a/packages/browser/__tests__/authenticatedFetch/fetchFactory.spec.ts
+++ b/packages/browser/__tests__/authenticatedFetch/fetchFactory.spec.ts
@@ -112,7 +112,7 @@ describe("buildDpopFetch", () => {
   it("builds the appropriate DPoP header for a given HTTP verb.", async () => {
     mockFetch(mockNotRedirectedResponse());
     const key = await generateJwkForDpop();
-    const myFetch = await buildDpopFetch("myToken", undefined,  key);
+    const myFetch = await buildDpopFetch("myToken", undefined, key);
     await myFetch("http://some.url", {
       method: "POST",
     });
@@ -222,7 +222,7 @@ describe("buildDpopFetch", () => {
     );
 
     const key = await generateJwkForDpop();
-    const myFetch = await buildDpopFetch("myToken", key);
+    const myFetch = await buildDpopFetch("myToken", undefined, key);
     const response = await myFetch("https://my.pod/container");
 
     expect(
@@ -245,7 +245,7 @@ describe("buildDpopFetch", () => {
     );
 
     const key = await generateJwkForDpop();
-    const myFetch = await buildDpopFetch("myToken", key);
+    const myFetch = await buildDpopFetch("myToken", undefined, key);
     const response = await myFetch("https://my.pod/resource");
 
     expect(

--- a/packages/browser/__tests__/authenticatedFetch/fetchFactory.spec.ts
+++ b/packages/browser/__tests__/authenticatedFetch/fetchFactory.spec.ts
@@ -42,7 +42,7 @@ const mockRedirectedResponse = (): MockedRedirectResponse => {
 const mockNotRedirectedResponse = (): MockedRedirectResponse => {
   return {
     redirected: false,
-    url: "https://my.pod/container/",
+    url: "http://some.url",
   };
 };
 
@@ -195,6 +195,10 @@ describe("buildDpopFetch", () => {
       // @ts-ignore
       fetch.fetch.mock.calls[1][0]
     ).toEqual("https://my.pod/container/");
+    // @ts-ignore
+    const dpopHeader = fetch.fetch.mock.calls[1][1].headers["DPoP"] as string;
+    const decodedHeader = await decodeJwt(dpopHeader, key);
+    expect(decodedHeader["htu"]).toEqual("https://my.pod/container/");
   });
 });
 /* eslint-enable @typescript-eslint/ban-ts-ignore */

--- a/packages/browser/__tests__/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
+++ b/packages/browser/__tests__/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
@@ -277,7 +277,6 @@ describe("AuthCodeRedirectHandler", () => {
     });
 
     it("returns an authenticated dpop fetch if requested", async () => {
-<<<<<<< HEAD
       window.fetch = jest.fn().mockReturnValueOnce(
         new Promise((resolve) => {
           resolve({
@@ -289,22 +288,6 @@ describe("AuthCodeRedirectHandler", () => {
         ReturnType<typeof window.fetch>,
         [RequestInfo, RequestInit?]
       >;
-=======
-      const fetch = jest.requireMock("cross-fetch") as {
-        fetch: jest.Mock<
-          ReturnType<typeof window.fetch>,
-          [RequestInfo, RequestInit?]
-        >;
-      };
-      fetch.fetch = jest.fn().mockReturnValueOnce(
-        new Promise((resolve) => {
-          resolve({
-            redirected: true,
-            url: "https://my.pod/container/",
-          } as Response);
-        })
-      );
->>>>>>> DPoP-authenticated fetch manages redirection
 
       const storage = mockStorageUtility({
         oauth2StateValue: {

--- a/packages/browser/__tests__/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
+++ b/packages/browser/__tests__/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
@@ -277,10 +277,34 @@ describe("AuthCodeRedirectHandler", () => {
     });
 
     it("returns an authenticated dpop fetch if requested", async () => {
-      window.fetch = jest.fn() as jest.Mock<
+<<<<<<< HEAD
+      window.fetch = jest.fn().mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolve({
+            redirected: true,
+            url: "https://my.pod/container/",
+          } as Response);
+        })
+      ) as jest.Mock<
         ReturnType<typeof window.fetch>,
         [RequestInfo, RequestInit?]
       >;
+=======
+      const fetch = jest.requireMock("cross-fetch") as {
+        fetch: jest.Mock<
+          ReturnType<typeof window.fetch>,
+          [RequestInfo, RequestInit?]
+        >;
+      };
+      fetch.fetch = jest.fn().mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolve({
+            redirected: true,
+            url: "https://my.pod/container/",
+          } as Response);
+        })
+      );
+>>>>>>> DPoP-authenticated fetch manages redirection
 
       const storage = mockStorageUtility({
         oauth2StateValue: {

--- a/packages/browser/examples/single/bundle/src/App.js
+++ b/packages/browser/examples/single/bundle/src/App.js
@@ -37,12 +37,10 @@ export default function App() {
   // is redirected to the page after logging in the identity provider.
   useEffect(() => {
     // After redirect, the current URL contains login information.
-    session
-      .handleIncomingRedirect(new URL(window.location.href))
-      .then((info) => {
-        setResource(info.webId);
-        setWebId(info.webId);
-      });
+    session.handleIncomingRedirect(window.location.href).then((info) => {
+      setResource(info.webId);
+      setWebId(info.webId);
+    });
   }, [session]);
 
   const handleLogin = (e) => {
@@ -52,8 +50,8 @@ export default function App() {
     // Login will redirect the user away so that they can log in the OIDC issuer,
     // and back to the provided redirect URL (which should be controlled by your app).
     session.login({
-      redirectUrl: new URL(REDIRECT_URL),
-      oidcIssuer: new URL(issuer),
+      redirectUrl: REDIRECT_URL,
+      oidcIssuer: issuer,
     });
   };
 

--- a/packages/browser/src/authenticatedFetch/fetchFactory.ts
+++ b/packages/browser/src/authenticatedFetch/fetchFactory.ts
@@ -67,6 +67,9 @@ async function buildDpopFetchOptions(
 }
 
 function isExpectedAuthError(statusCode: number): boolean {
+  // As per https://tools.ietf.org/html/rfc7235#section-3.1 and https://tools.ietf.org/html/rfc7235#section-3.1,
+  // a response failing because the provided credentials aren't accepted by the
+  // server can get a 401 or a 403 response.
   return [401, 403].includes(statusCode);
 }
 

--- a/packages/browser/src/authenticatedFetch/fetchFactory.ts
+++ b/packages/browser/src/authenticatedFetch/fetchFactory.ts
@@ -61,7 +61,7 @@ export async function buildDpopFetch(
   dpopKey: JSONWebKey
 ): Promise<typeof fetch> {
   return async (init, options): Promise<Response> => {
-    return fetch(init, {
+    const fetchOptions: RequestInit = {
       ...options,
       headers: {
         ...options?.headers,
@@ -72,6 +72,12 @@ export async function buildDpopFetch(
           dpopKey
         ),
       },
-    });
+      redirect: "manual",
+    };
+    const response = await fetch(init, fetchOptions);
+    if (!response.redirected) {
+      return response;
+    }
+    return fetch(response.url, fetchOptions);
   };
 }

--- a/packages/browser/src/authenticatedFetch/fetchFactory.ts
+++ b/packages/browser/src/authenticatedFetch/fetchFactory.ts
@@ -63,11 +63,10 @@ async function buildDpopFetchOptions(
         dpopKey
       ),
     },
-    redirect: "manual",
   };
 }
 
-function isAuthError(statusCode: number): boolean {
+function isExpectedAuthError(statusCode: number): boolean {
   return [401, 403].includes(statusCode);
 }
 
@@ -90,9 +89,10 @@ export async function buildDpopFetch(
       url,
       await buildDpopFetchOptions(url.toString(), authToken, dpopKey, options)
     );
-    const nonAuthNotOk = !response.ok && !isAuthError(response.status);
+    const failedButNotExpectedAuthError =
+      !response.ok && !isExpectedAuthError(response.status);
     const hasBeenRedirected = response.url !== url;
-    if (response.ok || nonAuthNotOk || !hasBeenRedirected) {
+    if (response.ok || failedButNotExpectedAuthError || !hasBeenRedirected) {
       // If there hasn't been a redirection, or if there has been a non-auth related
       // issue, it should be handled at the application level
       return response;


### PR DESCRIPTION
Since a DPoP header is scoped to one target IRI, if the request is redirected, the DPoP header is invalid, which results in a 401 unauthenticated. To fix the issue, the fetch must capture the redirection, and replay the request to the actual target IRI.

This is particularly useful when requests target a container, but omit to include the trailing `/`.

Fixes #89.

# Checklist

- [X] All acceptance criteria are met.
- [x] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).