### PR TITLE
Docs: Remove Beta banner

### DIFF
--- a/packages/browser/docs/api/conf.py
+++ b/packages/browser/docs/api/conf.py
@@ -84,8 +84,8 @@ html_title = 'Inrupt {0} API Documentation'.format(name)
 
 html_theme_options = {
     'project_title': 'Inrupt {0} API Documentation'.format(name),
-    'banner': True,
-    'banner_msg': 'This is a Beta (i.e. in progress) version of the manual. Content and features are subject to change.',
+    'banner': False,
+    'banner_msg': '',
     'robots_index': True,
     'github_editable': False,
     'github_org': 'inrupt',

--- a/packages/core/docs/api/conf.py
+++ b/packages/core/docs/api/conf.py
@@ -84,8 +84,8 @@ html_title = 'Inrupt {0} API Documentation'.format(name)
 
 html_theme_options = {
     'project_title': 'Inrupt {0} API Documentation'.format(name),
-    'banner': True,
-    'banner_msg': 'This is a Beta (i.e. in progress) version of the manual. Content and features are subject to change.',
+    'banner': False,
+    'banner_msg': '',
     'robots_index': True,
     'github_editable': False,
     'github_org': 'inrupt',


### PR DESCRIPTION
Update docs configuration to remove Beta from the API docs.

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

