### PR TITLE
Disabled MacOS environment from the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         # Available OS's: https://help.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners
-        os: [ubuntu-20.04, windows-2019, macos-10.15]
+        os: [ubuntu-20.04, windows-2019]
         node-version: [12.x, 10.x]
     steps:
       - uses: actions/checkout@v2.1.0


### PR DESCRIPTION
The MacOS environment is unstable, often stalls the CI, and given that our tests run on ubuntu, which is another unix-based environment, it's not a big issue not to run them on MacOS as well.