### PR TITLE
added github-actions to Dependabot YAML

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,13 @@
 version: 2
 updates:
+  # Enable version updates for our CI github-actions.
+  - package-ecosystem: "github-actions"
+    # For GitHub Actions, setting the directory to / will check for workflow
+    # files in .github/workflows.
+    directory: "/"
+    schedule:
+      interval: "daily"
+
   - package-ecosystem: npm
     directory: "/"
     schedule:


### PR DESCRIPTION
# Internal configuration

Added github-actions to Dependabot YAML so we can pin our CI to specific versions of those actions, and Dependabot will keep them up-to-date.