### PR TITLE
Moved AggregateHandler pattern from browser to core module

### DIFF
--- a/packages/browser/__tests__/login/AggregateLoginHandler.spec.ts
+++ b/packages/browser/__tests__/login/AggregateLoginHandler.spec.ts
@@ -21,11 +21,13 @@
 
 // Required by TSyringe:
 import "reflect-metadata";
-import { ILoginHandler } from "@inrupt/solid-client-authn-core";
+import {
+  ILoginHandler,
+  AggregateHandler,
+} from "@inrupt/solid-client-authn-core";
 import AggregateLoginHandler from "../../src/login/AggregateLoginHandler";
-import AggregateHandler from "../../src/util/handlerPattern/AggregateHandler";
 
-jest.mock("../../src/util/handlerPattern/AggregateHandler");
+jest.mock("@inrupt/solid-client-authn-core");
 
 describe("AggregateLoginHandler", () => {
   it("should pass injected handlers to its superclass", () => {

--- a/packages/browser/__tests__/login/oidc/AggregateOidcHandler.spec.ts
+++ b/packages/browser/__tests__/login/oidc/AggregateOidcHandler.spec.ts
@@ -21,11 +21,13 @@
 
 // Required by TSyringe:
 import "reflect-metadata";
-import { IOidcHandler } from "@inrupt/solid-client-authn-core";
+import {
+  IOidcHandler,
+  AggregateHandler,
+} from "@inrupt/solid-client-authn-core";
 import AggregateOidcHandler from "../../../src/login/oidc/AggregateOidcHandler";
-import AggregateHandler from "../../../src/util/handlerPattern/AggregateHandler";
 
-jest.mock("../../../src/util/handlerPattern/AggregateHandler");
+jest.mock("@inrupt/solid-client-authn-core");
 
 describe("AggregateOidcHandler", () => {
   it("should pass injected handlers to its superclass", () => {

--- a/packages/browser/src/login/AggregateLoginHandler.ts
+++ b/packages/browser/src/login/AggregateLoginHandler.ts
@@ -28,8 +28,11 @@
  * Responsible for decided which Login Handler should be used given the Login Options
  */
 import { injectable, injectAll } from "tsyringe";
-import { ILoginHandler, ILoginOptions } from "@inrupt/solid-client-authn-core";
-import AggregateHandler from "../util/handlerPattern/AggregateHandler";
+import {
+  ILoginHandler,
+  ILoginOptions,
+  AggregateHandler,
+} from "@inrupt/solid-client-authn-core";
 
 /**
  * @hidden

--- a/packages/browser/src/login/oidc/AggregateOidcHandler.ts
+++ b/packages/browser/src/login/oidc/AggregateOidcHandler.ts
@@ -28,8 +28,11 @@
  * Responsible for selecting the correct OidcHandler to handle the provided OIDC Options
  */
 import { injectable, injectAll } from "tsyringe";
-import { IOidcHandler, IOidcOptions } from "@inrupt/solid-client-authn-core";
-import AggregateHandler from "../../util/handlerPattern/AggregateHandler";
+import {
+  IOidcHandler,
+  IOidcOptions,
+  AggregateHandler,
+} from "@inrupt/solid-client-authn-core";
 
 /**
  * @hidden

--- a/packages/browser/src/login/oidc/redirectHandler/AggregateRedirectHandler.ts
+++ b/packages/browser/src/login/oidc/redirectHandler/AggregateRedirectHandler.ts
@@ -31,8 +31,8 @@ import { injectable, injectAll } from "tsyringe";
 import {
   IRedirectHandler,
   ISessionInfo,
+  AggregateHandler,
 } from "@inrupt/solid-client-authn-core";
-import AggregateHandler from "../../../util/handlerPattern/AggregateHandler";
 
 /**
  * @hidden

--- a/packages/browser/src/login/popUp/AggregatePostPopUpLoginHandler.ts
+++ b/packages/browser/src/login/popUp/AggregatePostPopUpLoginHandler.ts
@@ -28,8 +28,11 @@
  * Responsible for deciding which Login Handler should be used inside a popup window
  */
 import { injectable, injectAll } from "tsyringe";
-import { ILoginOptions, ILoginHandler } from "@inrupt/solid-client-authn-core";
-import AggregateHandler from "../../util/handlerPattern/AggregateHandler";
+import {
+  ILoginOptions,
+  ILoginHandler,
+  AggregateHandler,
+} from "@inrupt/solid-client-authn-core";
 
 /**
  * @hidden

--- a/packages/core/__tests__/util/handlerPattern/AggregateHandler.spec.ts
+++ b/packages/core/__tests__/util/handlerPattern/AggregateHandler.spec.ts
@@ -20,7 +20,7 @@
  */
 
 import "reflect-metadata";
-import { IHandleable } from "@inrupt/solid-client-authn-core";
+import IHandleable from "../../../src/util/handlerPattern/IHandleable";
 import AggregateHandler from "../../../src/util/handlerPattern/AggregateHandler";
 
 describe("AggregateHandler", () => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -27,6 +27,7 @@ export { default as ILoginOptions } from "./login/ILoginOptions";
 export { default as ILogoutHandler } from "./logout/ILogoutHandler";
 
 export { default as IHandleable } from "./util/handlerPattern/IHandleable";
+export { default as AggregateHandler } from "./util/handlerPattern/AggregateHandler";
 
 export { default as IAuthenticatedFetcher } from "./authenticatedFetch/IAuthenticatedFetcher";
 export { default as IRequestCredentials } from "./authenticatedFetch/IRequestCredentials";

--- a/packages/core/src/util/handlerPattern/AggregateHandler.ts
+++ b/packages/core/src/util/handlerPattern/AggregateHandler.ts
@@ -27,10 +27,8 @@
 /**
  * An abstract class that will select the first handler that can handle certain parameters
  */
-import {
-  IHandleable,
-  HandlerNotFoundError,
-} from "@inrupt/solid-client-authn-core";
+import IHandleable from "./IHandleable";
+import HandlerNotFoundError from "../../errors/HandlerNotFoundError";
 
 /**
  * @hidden


### PR DESCRIPTION
The handler pattern is not environment-specific, and should be located in the core module to avoid code duplication.

Note: in this case, the class is supposed to be internal, and is not re-exported from the browser on purpose.

- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).