### PR TITLE
Dynamic client registration with openid-client

### DIFF
--- a/packages/core/src/login/oidc/IClient.ts
+++ b/packages/core/src/login/oidc/IClient.ts
@@ -30,4 +30,5 @@
 export interface IClient {
   clientId: string;
   clientSecret?: string;
+  clientName?: string;
 }

--- a/packages/node/src/login/oidc/ClientRegistrar.ts
+++ b/packages/node/src/login/oidc/ClientRegistrar.ts
@@ -52,25 +52,23 @@ export default class ClientRegistrar implements IClientRegistrar {
     const [
       storedClientId,
       storedClientSecret,
-      // storedClientName,
+      storedClientName,
     ] = await Promise.all([
       this.storageUtility.getForUser(options.sessionId, "clientId", {
-        // FIXME: figure out how to persist secure storage at reload
         secure: false,
       }),
       this.storageUtility.getForUser(options.sessionId, "clientSecret", {
-        // FIXME: figure out how to persist secure storage at reload
         secure: false,
       }),
-      // this.storageUtility.getForUser(options.sessionId, "clientName", {
-      //   // FIXME: figure out how to persist secure storage at reload
-      //   secure: false,
-      // }),
+      this.storageUtility.getForUser(options.sessionId, "clientName", {
+        secure: false,
+      }),
     ]);
     if (storedClientId) {
       return {
         clientId: storedClientId,
         clientSecret: storedClientSecret,
+        clientName: storedClientName as string | undefined,
       };
     }
     const extendedOptions = { ...options };
@@ -122,6 +120,7 @@ export default class ClientRegistrar implements IClientRegistrar {
     return {
       clientId: registeredClient.metadata.client_id,
       clientSecret: registeredClient.metadata.client_secret,
+      clientName: registeredClient.metadata.client_name as string | undefined,
     };
   }
 }

--- a/packages/node/src/login/oidc/ClientRegistrar.ts
+++ b/packages/node/src/login/oidc/ClientRegistrar.ts
@@ -31,8 +31,9 @@ import {
   IIssuerConfig,
   IClient,
   IClientRegistrarOptions,
-  NotImplementedError,
+  ConfigurationError,
 } from "@inrupt/solid-client-authn-core";
+import { Client, Issuer } from "openid-client";
 
 /**
  * @hidden
@@ -45,7 +46,7 @@ export default class ClientRegistrar implements IClientRegistrar {
 
   async getClient(
     options: IClientRegistrarOptions,
-    _issuerConfig: IIssuerConfig
+    issuerConfig: IIssuerConfig
   ): Promise<IClient> {
     // If client secret and/or client id are stored in storage, use those.
     const [
@@ -80,6 +81,47 @@ export default class ClientRegistrar implements IClientRegistrar {
         options.sessionId,
         "registrationAccessToken"
       ));
-    throw new NotImplementedError("getClient not implemented for Node");
+
+    // TODO: It would be more efficient to only issue a single request (see IssuerConfigFetcher)
+    const issuer = await Issuer.discover(issuerConfig.issuer);
+
+    if (issuer.metadata.registration_endpoint === undefined) {
+      throw new ConfigurationError(
+        `Dynamic client registration cannot be performed, because issuer does not have a registration endpoint: ${JSON.stringify(
+          issuer.metadata
+        )}`
+      );
+    }
+
+    // The following is compliant with the example code, but seems to mismatch the
+    // type annotations.
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    const registeredClient: Client = await issuer.Client.register(
+      {
+        redirect_uris: [options.redirectUrl],
+        client_name: options.clientName,
+      },
+      {
+        initialAccessToken: extendedOptions.registrationAccessToken,
+      }
+    );
+    const infoToSave: Record<string, string> = {
+      clientId: registeredClient.metadata.client_id,
+    };
+    if (registeredClient.metadata.client_secret) {
+      infoToSave.clientSecret = registeredClient.metadata.client_secret;
+    }
+    await this.storageUtility.setForUser(
+      extendedOptions.sessionId,
+      infoToSave,
+      {
+        secure: true,
+      }
+    );
+    return {
+      clientId: registeredClient.metadata.client_id,
+      clientSecret: registeredClient.metadata.client_secret,
+    };
   }
 }

--- a/packages/node/src/login/oidc/IssuerConfigFetcher.spec.ts
+++ b/packages/node/src/login/oidc/IssuerConfigFetcher.spec.ts
@@ -21,30 +21,13 @@
 
 import "reflect-metadata";
 import { mockStorageUtility } from "@inrupt/solid-client-authn-core";
-import { IssuerMetadata } from "openid-client";
 import IssuerConfigFetcher from "./IssuerConfigFetcher";
+import {
+  mockDefaultIssuerConfig,
+  mockIssuerConfig,
+} from "./__mocks__/IssuerConfigFetcher";
 
 jest.mock("openid-client");
-
-const mockDefaultIssuerConfig = (): IssuerMetadata => {
-  return {
-    issuer: "https://my.idp/",
-    authorization_endpoint: "https://my.idp/auth",
-    token_endpoint: "https://my.idp/token",
-    jwks_uri: "https://my.idp/jwks",
-    claims_supported: ["sub"],
-    subject_types_supported: ["public", "pairwise"],
-  };
-};
-
-const mockIssuerConfig = (
-  config: Record<string, string | undefined>
-): IssuerMetadata => {
-  return {
-    ...mockDefaultIssuerConfig(),
-    ...config,
-  };
-};
 
 /**
  * Test for IssuerConfigFetcher

--- a/packages/node/src/login/oidc/OidcLoginHandler.ts
+++ b/packages/node/src/login/oidc/OidcLoginHandler.ts
@@ -96,8 +96,8 @@ export default class OidcLoginHandler implements ILoginHandler {
         clientSecret: options.clientSecret,
       };
     } else {
-      // If client id and secret aren't specified in the options, performe dynamic
-      // client registration.
+      // If 'client_id' and 'client_secret' aren't specified in the options,
+      // perform dynamic client registration.
       clientInfo = await this.clientRegistrar.getClient(options, issuerConfig);
     }
 

--- a/packages/node/src/login/oidc/__mocks__/ClientRegistrar.ts
+++ b/packages/node/src/login/oidc/__mocks__/ClientRegistrar.ts
@@ -25,6 +25,7 @@ import {
   IClientRegistrarOptions,
   IIssuerConfig,
 } from "@inrupt/solid-client-authn-core";
+import { ClientMetadata } from "openid-client";
 
 export const ClientRegistrarResponse: IClient = {
   clientId: "abcde",
@@ -49,4 +50,41 @@ export const PublicClientRegistrarMock: jest.Mocked<IClientRegistrar> = {
     (options: IClientRegistrarOptions, issuerConfig: IIssuerConfig) =>
       Promise.resolve(PublicClientRegistrarResponse)
   ),
+};
+
+export const mockDefaultClientConfig = (): ClientMetadata => {
+  return {
+    client_id: "some client",
+    client_secret: "some secret",
+    redirect_uris: ["https://my.app/redirect"],
+    response_types: ["code"],
+  };
+};
+
+export const mockClientConfig = (
+  config: Record<string, string | undefined>
+): ClientMetadata => {
+  return {
+    ...mockDefaultClientConfig(),
+    ...config,
+  };
+};
+
+export const mockDefaultClient = (): IClient => {
+  return {
+    clientId: "a client id",
+    clientSecret: "a client secret",
+  };
+};
+
+export const mockDefaultClientRegistrar = (): IClientRegistrar => {
+  return {
+    getClient: async () => mockDefaultClient(),
+  };
+};
+
+export const mockClientRegistrar = (client: IClient): IClientRegistrar => {
+  return {
+    getClient: async () => client,
+  };
 };

--- a/packages/node/src/login/oidc/__mocks__/IssuerConfigFetcher.ts
+++ b/packages/node/src/login/oidc/__mocks__/IssuerConfigFetcher.ts
@@ -23,6 +23,7 @@ import {
   IIssuerConfig,
   IIssuerConfigFetcher,
 } from "@inrupt/solid-client-authn-core";
+import { IssuerMetadata } from "openid-client";
 
 export const IssuerConfigFetcherFetchConfigResponse: IIssuerConfig = {
   issuer: "https://idp.com",
@@ -39,4 +40,25 @@ export const IssuerConfigFetcherMock: jest.Mocked<IIssuerConfigFetcher> = {
   fetchConfig: jest.fn((_issuer: string) =>
     Promise.resolve(IssuerConfigFetcherFetchConfigResponse)
   ),
+};
+
+export const mockDefaultIssuerConfig = (): IssuerMetadata => {
+  return {
+    issuer: "https://my.idp/",
+    authorization_endpoint: "https://my.idp/auth",
+    token_endpoint: "https://my.idp/token",
+    registration_endpoint: "https://my.idp/register",
+    jwks_uri: "https://my.idp/jwks",
+    claims_supported: ["sub"],
+    subject_types_supported: ["public", "pairwise"],
+  };
+};
+
+export const mockIssuerConfig = (
+  config: Record<string, string | undefined>
+): IssuerMetadata => {
+  return {
+    ...mockDefaultIssuerConfig(),
+    ...config,
+  };
 };


### PR DESCRIPTION
This implements DCR using "openid-client". With the code in this commit, the login process progresses all the way to the point where the client can redirect the user to the IdP.

Two main files are updated: 
- `OidcLoginHandler`, which depending on the options decides whether to go dynamically register the client or not
- `ClientRegistrar`, which handles the client registration.

- [X] All acceptance criteria are met.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).