### PR TITLE
Simplified StorageUtility mock

### DIFF
--- a/packages/browser/__tests__/ClientAuthentication.spec.ts
+++ b/packages/browser/__tests__/ClientAuthentication.spec.ts
@@ -161,7 +161,7 @@ describe("ClientAuthentication", () => {
         sessionInfoManager: mockSessionInfoManager(
           mockStorageUtility(
             {
-              mySession: { ...sessionInfo },
+              "solidClientAuthenticationUser:mySession": { ...sessionInfo },
             },
             true
           )

--- a/packages/browser/__tests__/login/oidc/ClientRegistrar.spec.ts
+++ b/packages/browser/__tests__/login/oidc/ClientRegistrar.spec.ts
@@ -170,7 +170,7 @@ describe("ClientRegistrar", () => {
       const clientRegistrar = getClientRegistrar({
         storage: mockStorageUtility(
           {
-            mySession: {
+            "solidClientAuthenticationUser:mySession": {
               clientId: "an id",
               clientSecret: "a secret",
             },
@@ -232,7 +232,7 @@ describe("ClientRegistrar", () => {
       const clientRegistrar = getClientRegistrar({
         storage: mockStorageUtility(
           {
-            mySession: {
+            "solidClientAuthenticationUser:mySession": {
               registrationAccessToken: "some token",
             },
           },

--- a/packages/browser/__tests__/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
+++ b/packages/browser/__tests__/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
@@ -222,10 +222,10 @@ describe("AuthCodeRedirectHandler", () => {
 
     it("retrieves the code verifier from memory", async () => {
       const storage = mockStorageUtility({
-        oauth2_state_value: {
+        "solidClientAuthenticationUser:oauth2_state_value": {
           sessionId: "userId",
         },
-        userId: {
+        "solidClientAuthenticationUser:userId": {
           codeVerifier: "a",
           redirectUri: "b",
           issuer: "someIssuer",
@@ -268,7 +268,11 @@ describe("AuthCodeRedirectHandler", () => {
       >;
 
       const authCodeRedirectHandler = getAuthCodeRedirectHandler({
-        storageUtility: mockStorageUtility({}),
+        storageUtility: mockStorageUtility({
+          "solidClientAuthenticationUser:oauth2_state_value": {
+            sessionId: "mySession",
+          },
+        }),
       });
       const redirectInfo = await authCodeRedirectHandler.handle(
         "https://coolsite.com/?code=someCode&state=oauth2_state_value"
@@ -301,13 +305,14 @@ describe("AuthCodeRedirectHandler", () => {
       >;
 
       const storage = mockStorageUtility({
-        oauth2StateValue: {
+        "solidClientAuthenticationUser:oauth2StateValue": {
           sessionId: "mySession",
         },
-        mySession: {
+        "solidClientAuthenticationUser:mySession": {
           dpop: "true",
           issuer: mockIssuer().issuer.toString(),
           codeVerifier: "some code verifier",
+          redirectUri: "https://some.redirect.uri",
         },
       });
 

--- a/packages/browser/__tests__/login/oidc/refresh/TokenRefresher.spec.ts
+++ b/packages/browser/__tests__/login/oidc/refresh/TokenRefresher.spec.ts
@@ -48,7 +48,7 @@ describe("TokenRefresher", () => {
 
     const storageMock = mockStorageUtility(
       {
-        [key]: {
+        [`solidClientAuthenticationUser:${key}`]: {
           refreshToken: refreshTokenValue,
         },
       },

--- a/packages/browser/__tests__/sessionInfo/SessionInfoManager.spec.ts
+++ b/packages/browser/__tests__/sessionInfo/SessionInfoManager.spec.ts
@@ -68,7 +68,7 @@ describe("SessionInfoManager", () => {
 
       const storageMock = mockStorageUtility(
         {
-          [sessionId]: {
+          [`solidClientAuthenticationUser:${sessionId}`]: {
             webId,
             isLoggedIn: "true",
           },
@@ -115,7 +115,7 @@ describe("SessionInfoManager", () => {
     it("clears local secure storage from user data", async () => {
       const mockStorage = mockStorageUtility(
         {
-          mySession: {
+          "solidClientAuthenticationUser:mySession": {
             key: "value",
           },
         },
@@ -133,7 +133,7 @@ describe("SessionInfoManager", () => {
     it("clears local unsecure storage from user data", async () => {
       const mockStorage = mockStorageUtility(
         {
-          mySession: {
+          "solidClientAuthenticationUser:mySession": {
             key: "value",
           },
         },

--- a/packages/core/src/storage/StorageUtility.ts
+++ b/packages/core/src/storage/StorageUtility.ts
@@ -136,7 +136,14 @@ export default class StorageUtility implements IStorageUtility {
     values: Record<string, string>,
     options?: { secure?: boolean }
   ): Promise<void> {
-    const userData = await this.getUserData(userId, options?.secure);
+    let userData: Record<string, string>;
+    try {
+      userData = await this.getUserData(userId, options?.secure);
+    } catch {
+      // if reading the user data throws, the data is corrupted, and we want to write over it
+      userData = {};
+    }
+
     await this.setUserData(userId, { ...userData, ...values }, options?.secure);
   }
 

--- a/packages/node/src/ClientAuthentication.spec.ts
+++ b/packages/node/src/ClientAuthentication.spec.ts
@@ -163,7 +163,7 @@ describe("ClientAuthentication", () => {
         sessionInfoManager: mockSessionInfoManager(
           mockStorageUtility(
             {
-              mySession: { ...sessionInfo },
+              "solidClientAuthenticationUser:mySession": { ...sessionInfo },
             },
             true
           )

--- a/packages/node/src/login/oidc/ClientRegistrar.spec.ts
+++ b/packages/node/src/login/oidc/ClientRegistrar.spec.ts
@@ -80,7 +80,7 @@ describe("ClientRegistrar", () => {
       const clientRegistrar = getClientRegistrar({
         storage: mockStorageUtility(
           {
-            mySession: {
+            "solidClientAuthenticationUser:mySession": {
               clientId: "an id",
               clientSecret: "a secret",
               clientName: "my client name",
@@ -160,7 +160,7 @@ describe("ClientRegistrar", () => {
       Issuer.discover = jest.fn().mockResolvedValueOnce(mockedIssuer);
       const mockStorage = mockStorageUtility(
         {
-          mySession: {
+          "solidClientAuthenticationUser:mySession": {
             registrationAccessToken: "a token",
           },
         },

--- a/packages/node/src/login/oidc/refresh/TokenRefresher.spec.ts
+++ b/packages/node/src/login/oidc/refresh/TokenRefresher.spec.ts
@@ -48,7 +48,7 @@ describe("TokenRefresher", () => {
 
     const storageMock = mockStorageUtility(
       {
-        [key]: {
+        [`solidClientAuthenticationUser:${key}`]: {
           refreshToken: refreshTokenValue,
         },
       },

--- a/packages/node/src/sessionInfo/SessionInfoManager.spec.ts
+++ b/packages/node/src/sessionInfo/SessionInfoManager.spec.ts
@@ -60,7 +60,7 @@ describe("SessionInfoManager", () => {
 
       const storageMock = mockStorageUtility(
         {
-          [sessionId]: {
+          [`solidClientAuthenticationUser:${sessionId}`]: {
             webId,
             isLoggedIn: "true",
           },


### PR DESCRIPTION
The StorageUtility mock was basically a re-implementation, but with some features missing. Instead, this mocks up the underlying IStorage, and just returns a StorageUtility wrapping up this mocked storage.
The code is much smaller, and it uncovered a couple of bugs in the browser tests.

Note that this change is initially motivated by a feature expected in the Node module, and that was missing for the StorageUtility mocked re-implementation, which was a known issue anyways.

- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).