### PR TITLE
Disabled ESS e2e tests until Cognito is supported

### DIFF
--- a/e2e/browser/test-suite-disabled.json
+++ b/e2e/browser/test-suite-disabled.json
@@ -1,0 +1,22 @@
+{
+  "podServerList": [
+    {
+      "description": "ESS Prod - Gluu (default)",
+      "podResourceServer": "https://ldp.pod.inrupt.com/<TEST USER NAME>/",
+      "identityProvider": "https://broker.pod.inrupt.com",
+      "envTestUserName": "E2E_ESS_USERNAME",
+      "envTestUserPassword": "E2E_ESS_PASSWORD",
+      "brokeredIdp": "Gluu",
+      "authorizeClientAppMechanism": "ess"
+    },
+    {
+      "description": "ESS Dev - select: Gluu",
+      "podResourceServer": "https://ldp.dev-ess.inrupt.com/<TEST USER NAME>/",
+      "identityProvider": "https://broker.dev-ess.inrupt.com",
+      "envTestUserName": "E2E_ESS_DEV_USERNAME",
+      "envTestUserPassword": "E2E_ESS_DEV_PASSWORD",
+      "brokeredIdp": "Gluu",
+      "authorizeClientAppMechanism": "ess"
+    }
+  ]
+}

--- a/e2e/browser/test-suite.json
+++ b/e2e/browser/test-suite.json
@@ -1,24 +1,6 @@
 {
   "podServerList": [
     {
-      "description": "ESS Prod - Gluu (default)",
-      "podResourceServer": "https://ldp.pod.inrupt.com/<TEST USER NAME>/",
-      "identityProvider": "https://broker.pod.inrupt.com",
-      "envTestUserName": "E2E_ESS_USERNAME",
-      "envTestUserPassword": "E2E_ESS_PASSWORD",
-      "brokeredIdp": "Gluu",
-      "authorizeClientAppMechanism": "ess"
-    },
-    {
-      "description": "ESS Dev - select: Gluu",
-      "podResourceServer": "https://ldp.dev-ess.inrupt.com/<TEST USER NAME>/",
-      "identityProvider": "https://broker.dev-ess.inrupt.com",
-      "envTestUserName": "E2E_ESS_DEV_USERNAME",
-      "envTestUserPassword": "E2E_ESS_DEV_PASSWORD",
-      "brokeredIdp": "Gluu",
-      "authorizeClientAppMechanism": "ess"
-    },
-    {
       "description": "NSS",
       "podResourceServer": "https://<TEST USER NAME>.inrupt.net/",
       "identityProvider": "https://inrupt.net",


### PR DESCRIPTION
Testcafé seems not to play nicely with Cognito, so while we figure it out, ESS e2e tests are disabled.