### PR TITLE
Instanciate fetch from returned token

### DIFF
--- a/packages/node/src/authenticatedFetch/fetchFactory.spec.ts
+++ b/packages/node/src/authenticatedFetch/fetchFactory.spec.ts
@@ -21,9 +21,12 @@
 
 import "reflect-metadata";
 import { describe, it } from "@jest/globals";
-import { JWK } from "jose";
-import { fetch as crossFetch } from "cross-fetch";
-import { buildBearerFetch, buildDpopFetch } from "./fetchFactory";
+import { JWK, JWT } from "jose";
+import {
+  buildBearerFetch,
+  buildDpopFetch,
+  DpopHeaderPayload,
+} from "./fetchFactory";
 
 jest.mock("cross-fetch");
 
@@ -39,67 +42,180 @@ const mockNotRedirectedResponse = (): MockedRedirectResponse => {
   };
 };
 
-const mockFetch = (response: MockedRedirectResponse): typeof crossFetch => {
-  const fetch = jest.requireMock("cross-fetch");
-  fetch.mockReturnValueOnce(
-    new Promise((resolve) => {
-      resolve(response as Response);
-    })
-  );
-  return fetch;
-};
-
-// We use ts-ignore comments here only to access mock call arguments
-/* eslint-disable @typescript-eslint/ban-ts-comment */
-
 describe("buildBearerFetch", () => {
   it("returns a fetch holding the provided token", async () => {
-    const fetch = mockFetch(mockNotRedirectedResponse());
+    const fetch = jest.requireMock("cross-fetch");
+    fetch.mockResolvedValueOnce(mockNotRedirectedResponse());
     const myFetch = buildBearerFetch("myToken", undefined);
     await myFetch("someUrl");
 
-    expect(
-      // @ts-ignore
-      fetch.mock.calls[0][1].headers.Authorization
-    ).toEqual("Bearer myToken");
+    expect(fetch.mock.calls[0][1].headers.Authorization).toEqual(
+      "Bearer myToken"
+    );
   });
 
   it("returns a fetch preserving the optional headers", async () => {
-    const fetch = mockFetch(mockNotRedirectedResponse());
+    const fetch = jest.requireMock("cross-fetch");
+    fetch.mockResolvedValueOnce(mockNotRedirectedResponse());
     const myFetch = buildBearerFetch("myToken", undefined);
     await myFetch("someUrl", { headers: { someHeader: "SomeValue" } });
 
-    expect(
-      // @ts-ignore
-      fetch.mock.calls[0][1].headers.Authorization
-    ).toEqual("Bearer myToken");
+    expect(fetch.mock.calls[0][1].headers.Authorization).toEqual(
+      "Bearer myToken"
+    );
 
-    expect(
-      // @ts-ignore
-      fetch.mock.calls[0][1].headers.someHeader
-    ).toEqual("SomeValue");
+    expect(fetch.mock.calls[0][1].headers.someHeader).toEqual("SomeValue");
   });
 
   it("returns a fetch overriding any pre-existing authorization headers", async () => {
-    const fetch = mockFetch(mockNotRedirectedResponse());
+    const fetch = jest.requireMock("cross-fetch");
+    fetch.mockResolvedValueOnce(mockNotRedirectedResponse());
     const myFetch = buildBearerFetch("myToken", undefined);
     await myFetch("someUrl", { headers: { Authorization: "some token" } });
 
-    expect(
-      // @ts-ignore
-      fetch.mock.calls[0][1].headers.Authorization
-    ).toEqual("Bearer myToken");
-  });
-});
-
-describe("buildDpopFetch", () => {
-  it("isn't implemented", async () => {
-    // TODO: buildDpopFetch isn't implemented
-    await buildDpopFetch(
-      "myToken",
-      undefined,
-      (undefined as unknown) as JWK.ECKey
+    expect(fetch.mock.calls[0][1].headers.Authorization).toEqual(
+      "Bearer myToken"
     );
   });
 });
-/* eslint-enable @typescript-eslint/ban-ts-comment */
+
+const mockJwk = (): JWK.ECKey =>
+  JWK.asKey({
+    kty: "EC",
+    kid: "oOArcXxcwvsaG21jAx_D5CHr4BgVCzCEtlfmNFQtU0s",
+    alg: "ES256",
+    crv: "P-256",
+    x: "0dGe_s-urLhD3mpqYqmSXrqUZApVV5ZNxMJXg7Vp-2A",
+    y: "-oMe9gGkpfIrnJ0aiSUHMdjqYVm5ZrGCeQmRKoIIfj8",
+    d: "yR1bCsR7m4hjFCvWo8Jw3OfNR4aiYDAFbBD9nkudJKM",
+  });
+
+describe("buildDpopFetch", () => {
+  it("returns a fetch holding the provided token and key", async () => {
+    const mockedFetch = jest.requireMock("cross-fetch");
+    mockedFetch.mockResolvedValueOnce(mockNotRedirectedResponse());
+
+    const myFetch = await buildDpopFetch("myToken", undefined, mockJwk());
+    await myFetch("http://some.url");
+
+    expect(mockedFetch.mock.calls[0][1].headers.Authorization).toEqual(
+      "DPoP myToken"
+    );
+
+    const dpopHeader = mockedFetch.mock.calls[0][1].headers.DPoP as string;
+    const decodedHeader = JWT.verify(
+      dpopHeader,
+      mockJwk()
+    ) as DpopHeaderPayload;
+    expect(decodedHeader.htu).toEqual("http://some.url/");
+    expect(decodedHeader.htm).toEqual("GET");
+  });
+
+  it("builds the appropriate DPoP header for a given HTTP verb.", async () => {
+    const mockedFetch = jest.requireMock("cross-fetch");
+    mockedFetch.mockResolvedValueOnce(mockNotRedirectedResponse());
+
+    const myFetch = await buildDpopFetch("myToken", undefined, mockJwk());
+    await myFetch("http://some.url", {
+      method: "POST",
+    });
+
+    const dpopHeader = mockedFetch.mock.calls[0][1].headers.DPoP as string;
+    const decodedHeader = JWT.verify(
+      dpopHeader,
+      mockJwk()
+    ) as DpopHeaderPayload;
+    expect(decodedHeader.htu).toEqual("http://some.url/");
+    expect(decodedHeader.htm).toEqual("POST");
+  });
+
+  it("returns a fetch preserving the provided optional headers", async () => {
+    const mockedFetch = jest.requireMock("cross-fetch");
+    mockedFetch.mockResolvedValueOnce(mockNotRedirectedResponse());
+
+    const myFetch = await buildDpopFetch("myToken", undefined, mockJwk());
+    await myFetch("http://some.url", { headers: { someHeader: "SomeValue" } });
+
+    expect(mockedFetch.mock.calls[0][1].headers.someHeader).toEqual(
+      "SomeValue"
+    );
+  });
+
+  it("returns a fetch overriding any pre-existing Authorization or DPoP headers", async () => {
+    const mockedFetch = jest.requireMock("cross-fetch");
+    mockedFetch.mockResolvedValueOnce(mockNotRedirectedResponse());
+
+    const myFetch = await buildDpopFetch("myToken", undefined, mockJwk());
+    await myFetch("http://some.url", {
+      headers: {
+        Authorization: "some token",
+        DPoP: "some header",
+      },
+    });
+
+    expect(mockedFetch.mock.calls[0][1].headers.Authorization).toEqual(
+      "DPoP myToken"
+    );
+  });
+
+  it("returns a fetch that rebuilds the DPoP token if redirected", async () => {
+    const mockedFetch = jest.requireMock("cross-fetch");
+
+    // Redirects once
+    mockedFetch
+      .mockResolvedValueOnce({
+        url: "https://my.pod/container/",
+        status: 403,
+        ok: false,
+      } as Response)
+      .mockResolvedValueOnce({
+        url: "https://my.pod/container/",
+        ok: true,
+        status: 200,
+      } as Response);
+
+    const myFetch = await buildDpopFetch("myToken", undefined, mockJwk());
+    await myFetch("https://my.pod/container");
+
+    expect(mockedFetch.mock.calls[1][0]).toEqual("https://my.pod/container/");
+    const dpopHeader = mockedFetch.mock.calls[1][1].headers.DPoP as string;
+    const decodedHeader = JWT.verify(
+      dpopHeader,
+      mockJwk()
+    ) as DpopHeaderPayload;
+    expect(decodedHeader.htu).toEqual("https://my.pod/container/");
+  });
+
+  it("does not retry a redirected fetch if the error is not auth-related", async () => {
+    const mockedFetch = jest.requireMock("cross-fetch");
+
+    // Mimics a redirect that lead to a non-auth error.
+    mockedFetch.mockResolvedValueOnce({
+      url: "https://my.pod/container/",
+      status: 400,
+      ok: false,
+    } as Response);
+
+    const myFetch = await buildDpopFetch("myToken", undefined, mockJwk());
+    const response = await myFetch("https://my.pod/container");
+
+    expect(mockedFetch.mock.calls).toHaveLength(1);
+    expect(response.status).toEqual(400);
+  });
+
+  it("does not retry a **not** redirected fetch if there was an auth-related issue", async () => {
+    const mockedFetch = jest.requireMock("cross-fetch");
+    // Mimics a redirect that lead to a non-auth error.
+    mockedFetch.mockResolvedValueOnce({
+      url: "https://my.pod/resource",
+      status: 403,
+      ok: false,
+    } as Response);
+
+    const myFetch = await buildDpopFetch("myToken", undefined, mockJwk());
+    const response = await myFetch("https://my.pod/resource");
+
+    expect(mockedFetch.mock.calls).toHaveLength(1);
+    expect(response.status).toEqual(403);
+  });
+});


### PR DESCRIPTION
This uses the DPoP token returned by the IdP to instanciate a fetch function. This authenticated fetch also follows redirects to rebuild a DPoP token if necessary.
This also completes the tests of handleRedirect by checking that the obtained fetch is authenticated.

Note: this replaces https://github.com/inrupt/solid-client-authn-js/pull/621 to resolve merge conflicts by cherrypicking one commit after the other have been merged.

# Checklist

- [X] All acceptance criteria are met.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).