### PR TITLE
WIP Workaround to get a cleaner doc output

### DIFF
--- a/packages/browser/src/ClientAuthentication.ts
+++ b/packages/browser/src/ClientAuthentication.ts
@@ -30,10 +30,10 @@ import {
   ILoginHandler,
   ILogoutHandler,
   IRedirectHandler,
-  ISessionInfo,
   ISessionInfoManager,
 } from "@inrupt/solid-client-authn-core";
 import { removeOidcQueryParam } from "@inrupt/oidc-client-ext";
+import { ISessionInfo } from ".";
 
 /**
  * @hidden

--- a/packages/browser/src/Session.ts
+++ b/packages/browser/src/Session.ts
@@ -23,14 +23,11 @@
  * @hidden
  */
 import { EventEmitter } from "events";
-import {
-  ILoginInputOptions,
-  ISessionInfo,
-  IStorage,
-} from "@inrupt/solid-client-authn-core";
+import { IStorage } from "@inrupt/solid-client-authn-core";
 import { v4 } from "uuid";
 import ClientAuthentication from "./ClientAuthentication";
 import { getClientAuthenticationWithDependencies } from "./dependencies";
+import { ILoginInputOptions, ISessionInfo } from ".";
 
 export interface ISessionOptions {
   /**

--- a/packages/browser/src/SessionManager.ts
+++ b/packages/browser/src/SessionManager.ts
@@ -20,11 +20,12 @@
  */
 
 import { EventEmitter } from "events";
-import { ISessionInfo, IStorage } from "@inrupt/solid-client-authn-core";
+import { IStorage } from "@inrupt/solid-client-authn-core";
 import { injectable } from "tsyringe";
 import { Session } from "./Session";
 import ClientAuthentication from "./ClientAuthentication";
 import { getClientAuthenticationWithDependencies } from "./dependencies";
+import { ISessionInfo } from ".";
 
 export interface ISessionManagerOptions {
   secureStorage?: IStorage;

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -19,29 +19,16 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-// The following "empty" extensions ensure self-containment of the "browser" module
-// documentation. Type annotations are available on the core interface at compile
-// time, which ensures they are properly referenced in the documentation.
-// Additionnally, users don't need to import anything from the "core" module.
-
-import {
-  ILoginInputOptions as ILoginInputOptionsCore,
-  ISessionInfo as ISessionInfoCore,
-  IStorage as IStorageCore,
-} from "@inrupt/solid-client-authn-core";
-
 export { Session, ISessionOptions } from "./Session";
 
 export { SessionManager, ISessionManagerOptions } from "./SessionManager";
 export { getClientAuthenticationWithDependencies } from "./dependencies";
 
-// Re-export of types defined in the core module and produced/consumed by our API
-
-export {
+export type {
+  ILoginInputOptions,
+  ISessionInfo,
+  IStorage,
   NotImplementedError,
   ConfigurationError,
   InMemoryStorage,
 } from "@inrupt/solid-client-authn-core";
-export type ILoginInputOptions = ILoginInputOptionsCore;
-export type ISessionInfo = ISessionInfoCore;
-export type IStorage = IStorageCore;

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -19,6 +19,17 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+// The following "empty" extensions ensure self-containment of the "browser" module
+// documentation. Type annotations are available on the core interface at compile
+// time, which ensures they are properly referenced in the documentation.
+// Additionnally, users don't need to import anything from the "core" module.
+
+import {
+  ILoginInputOptions as ILoginInputOptionsCore,
+  ISessionInfo as ISessionInfoCore,
+  IStorage as IStorageCore,
+} from "@inrupt/solid-client-authn-core";
+
 export { Session, ISessionOptions } from "./Session";
 
 export { SessionManager, ISessionManagerOptions } from "./SessionManager";
@@ -27,10 +38,10 @@ export { getClientAuthenticationWithDependencies } from "./dependencies";
 // Re-export of types defined in the core module and produced/consumed by our API
 
 export {
-  ILoginInputOptions,
-  ISessionInfo,
-  IStorage,
   NotImplementedError,
   ConfigurationError,
   InMemoryStorage,
 } from "@inrupt/solid-client-authn-core";
+export type ILoginInputOptions = ILoginInputOptionsCore;
+export type ISessionInfo = ISessionInfoCore;
+export type IStorage = IStorageCore;

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -27,7 +27,7 @@ export { SessionManager, ISessionManagerOptions } from "./SessionManager";
 
 // Re-export of types defined in the core module and produced/consumed by our API
 
-export {
+export type {
   ILoginInputOptions,
   ISessionInfo,
   IStorage,


### PR DESCRIPTION
This adds documentation for types exported by the core module directly in the browser/node module.