### PR TITLE
Bearer-authenticated fetch supports the refresh token flow

### DIFF
--- a/packages/node/src/authenticatedFetch/fetchFactory.spec.ts
+++ b/packages/node/src/authenticatedFetch/fetchFactory.spec.ts
@@ -116,7 +116,7 @@ describe("buildBearerFetch", () => {
     expect(fetch.mock.calls[0][1].headers.someHeader).toEqual("SomeValue");
   });
 
-  it("rotates the refresh tokens if a new one is issued", async () => {
+  it("rotates the refresh token if a new one is issued", async () => {
     const fetch = jest.requireMock("cross-fetch");
     fetch.mockResolvedValue({ status: 401 });
     const tokenSet = mockDefaultTokenSet();

--- a/packages/node/src/authenticatedFetch/fetchFactory.spec.ts
+++ b/packages/node/src/authenticatedFetch/fetchFactory.spec.ts
@@ -47,16 +47,6 @@ const mockNotRedirectedResponse = (): MockedRedirectResponse => {
   };
 };
 
-type MockedStatusResponse = {
-  status: number;
-};
-
-const mockStatusResponse = (status: number): MockedStatusResponse => {
-  return {
-    status,
-  };
-};
-
 describe("buildBearerFetch", () => {
   it("returns a fetch holding the provided token", async () => {
     const fetch = jest.requireMock("cross-fetch");
@@ -95,7 +85,7 @@ describe("buildBearerFetch", () => {
 
   it("returns a fetch that refreshes the token on 401", async () => {
     const fetch = jest.requireMock("cross-fetch");
-    fetch.mockResolvedValueOnce(mockStatusResponse(401));
+    fetch.mockResolvedValueOnce({ status: 401 });
     const myFetch = buildBearerFetch("myToken", {
       refreshToken: "some refresh token",
       sessionId: "mySession",
@@ -111,7 +101,7 @@ describe("buildBearerFetch", () => {
 
   it("returns a fetch preserving the optional headers even after refresh", async () => {
     const fetch = jest.requireMock("cross-fetch");
-    fetch.mockResolvedValueOnce(mockStatusResponse(401));
+    fetch.mockResolvedValueOnce({ status: 401 });
     const myFetch = buildBearerFetch("myToken", {
       refreshToken: "some refresh token",
       sessionId: "mySession",
@@ -128,7 +118,7 @@ describe("buildBearerFetch", () => {
 
   it("rotates the refresh tokens if a new one is issued", async () => {
     const fetch = jest.requireMock("cross-fetch");
-    fetch.mockResolvedValue(mockStatusResponse(401));
+    fetch.mockResolvedValue({ status: 401 });
     const tokenSet = mockDefaultTokenSet();
     tokenSet.refresh_token = "some refreshed refresh token";
     const mockedFreshener = mockTokenRefresher(tokenSet);
@@ -149,7 +139,7 @@ describe("buildBearerFetch", () => {
 
   it("does not try to refresh on a non-auth error", async () => {
     const fetch = jest.requireMock("cross-fetch");
-    fetch.mockResolvedValue(mockStatusResponse(418));
+    fetch.mockResolvedValue({ status: 418 });
     const mockedRefresher = mockDefaultTokenRefresher();
     const refreshCall = jest.spyOn(mockedRefresher, "refresh");
 
@@ -164,7 +154,7 @@ describe("buildBearerFetch", () => {
 
   it("returns the initial response when the refresh flow fails", async () => {
     const fetch = jest.requireMock("cross-fetch");
-    fetch.mockResolvedValueOnce(mockStatusResponse(401));
+    fetch.mockResolvedValueOnce({ status: 401 });
     const myFetch = buildBearerFetch("myToken", {
       refreshToken: "some refresh token",
       sessionId: "mySession",

--- a/packages/node/src/authenticatedFetch/fetchFactory.ts
+++ b/packages/node/src/authenticatedFetch/fetchFactory.ts
@@ -24,11 +24,6 @@ import { fetch } from "cross-fetch";
 import { v4 } from "uuid";
 import { ITokenRefresher } from "../login/oidc/refresh/TokenRefresher";
 
-// node-fetch fetch has an additional property (isRedirect) which prevents using
-// `typeof fetch`.
-// export type fetchType = (info: RequestInfo, init?: RequestInit) => Promise<Response>;
-export type fetchType = typeof fetch;
-
 export type RefreshOptions = {
   sessionId: string;
   refreshToken: string;
@@ -52,7 +47,7 @@ function isExpectedAuthError(statusCode: number): boolean {
 export function buildBearerFetch(
   accessToken: string,
   refreshOptions?: RefreshOptions
-): fetchType {
+): typeof fetch {
   // currentAccessToken and currentRefreshOptions are initialized with the provided
   // parameters, but they may be mutated in the authenticated fetch closure.
   let currentAccessToken = accessToken;
@@ -193,8 +188,8 @@ export async function buildDpopFetch(
   //  so dependent on that wrapper existing first!
   _refreshToken: string | undefined,
   dpopKey: JWK.ECKey
-): Promise<fetchType> {
-  return async (url, options): Promise<Response> => {
+): Promise<typeof fetch> {
+  return async (url: RequestInfo, options?: RequestInit): Promise<Response> => {
     const response = await fetch(
       url,
       await buildDpopFetchOptions(url.toString(), authToken, dpopKey, options)

--- a/packages/node/src/authenticatedFetch/fetchFactory.ts
+++ b/packages/node/src/authenticatedFetch/fetchFactory.ts
@@ -48,8 +48,8 @@ export function buildBearerFetch(
   accessToken: string,
   refreshOptions?: RefreshOptions
 ): typeof fetch {
-  // currentAccessToken and currentRefreshOptions are initialized with the provided
-  // parameters, but they may be mutated in the authenticated fetch closure.
+  // These local copies of the the provided parameters may be mutated in the
+  // authenticated fetch closure.
   let currentAccessToken = accessToken;
   const currentRefreshOptions: RefreshOptions | undefined = refreshOptions
     ? { ...refreshOptions }
@@ -81,7 +81,7 @@ export function buildBearerFetch(
       currentAccessToken = tokenSet.access_token;
       if (tokenSet.refresh_token) {
         // If the refresh token is rotated, update it in the closure.
-        // TODO: Plug this in an external storage if one is provided.
+        // TODO: Plug this into external storage, if one is provided.
         currentRefreshOptions.refreshToken = tokenSet.refresh_token;
       }
       // Once the token has been refreshed, re-issue the authenticated request.

--- a/packages/node/src/authenticatedFetch/fetchFactory.ts
+++ b/packages/node/src/authenticatedFetch/fetchFactory.ts
@@ -22,33 +22,89 @@
 import { JWK, JWT } from "jose";
 import { fetch } from "cross-fetch";
 import { v4 } from "uuid";
+import { ITokenRefresher } from "../login/oidc/refresh/TokenRefresher";
 
 // node-fetch fetch has an additional property (isRedirect) which prevents using
 // `typeof fetch`.
 // export type fetchType = (info: RequestInfo, init?: RequestInit) => Promise<Response>;
 export type fetchType = typeof fetch;
 
+export type RefreshOptions = {
+  sessionId: string;
+  refreshToken: string;
+  tokenRefresher: ITokenRefresher;
+};
+
+function isExpectedAuthError(statusCode: number): boolean {
+  // As per https://tools.ietf.org/html/rfc7235#section-3.1 and https://tools.ietf.org/html/rfc7235#section-3.1,
+  // a response failing because the provided credentials aren't accepted by the
+  // server can get a 401 or a 403 response.
+  return [401, 403].includes(statusCode);
+}
+
 /**
- * @param authToken A bearer token.
- * @param _refreshToken An optional refresh token.
+ * @param accessToken A bearer token.
+ * @param refreshToken An optional refresh token.
  * @returns A fetch function that adds an Authorization header with the provided
  * bearer token.
  * @hidden
  */
 export function buildBearerFetch(
-  authToken: string,
-  // TODO: We need to push this refresh token into a wrapper around the fetch,
-  //  so dependent on that wrapper existing first!
-  _refreshToken: string | undefined
+  accessToken: string,
+  refreshOptions?: RefreshOptions
 ): fetchType {
-  return (init: RequestInfo, options?: RequestInit): Promise<Response> => {
-    return fetch(init, {
+  // currentAccessToken and currentRefreshOptions are initialized with the provided
+  // parameters, but they may be mutated in the authenticated fetch closure.
+  let currentAccessToken = accessToken;
+  const currentRefreshOptions: RefreshOptions | undefined = refreshOptions
+    ? { ...refreshOptions }
+    : undefined;
+  return async (
+    init: RequestInfo,
+    options?: RequestInit
+  ): Promise<Response> => {
+    const response = await fetch(init, {
       ...options,
       headers: {
         ...options?.headers,
-        Authorization: `Bearer ${authToken}`,
+        Authorization: `Bearer ${currentAccessToken}`,
       },
     });
+    if (
+      !isExpectedAuthError(response.status) ||
+      currentRefreshOptions === undefined
+    ) {
+      // Either the request succeeded, or its failure isn't auth-related, or
+      // no refresh token has been provided.
+      return response;
+    }
+    try {
+      const tokenSet = await currentRefreshOptions.tokenRefresher.refresh(
+        currentRefreshOptions.sessionId,
+        currentRefreshOptions.refreshToken
+      );
+      currentAccessToken = tokenSet.access_token;
+      if (tokenSet.refresh_token) {
+        // If the refresh token is rotated, update it in the closure.
+        // TODO: Plug this in an external storage if one is provided.
+        currentRefreshOptions.refreshToken = tokenSet.refresh_token;
+      }
+      // Once the token has been refreshed, re-issue the authenticated request.
+      // If it has an auth failure again, the user legitimately doesn't have access
+      // to the target resource.
+      return fetch(init, {
+        ...options,
+        headers: {
+          ...options?.headers,
+          Authorization: `Bearer ${currentAccessToken}`,
+        },
+      });
+    } catch (e) {
+      // If we used a log framework, the error could be logged at the `debug` level,
+      // but otherwise the failure of the refresh flow should not blow up in the user's
+      // face, and returning the original authentication error is better.
+      return response;
+    }
   };
 }
 
@@ -122,13 +178,6 @@ async function buildDpopFetchOptions(
       ),
     },
   };
-}
-
-function isExpectedAuthError(statusCode: number): boolean {
-  // As per https://tools.ietf.org/html/rfc7235#section-3.1 and https://tools.ietf.org/html/rfc7235#section-3.1,
-  // a response failing because the provided credentials aren't accepted by the
-  // server can get a 401 or a 403 response.
-  return [401, 403].includes(statusCode);
 }
 
 /**

--- a/packages/node/src/login/oidc/redirectHandler/AggregateRedirectHandler.ts
+++ b/packages/node/src/login/oidc/redirectHandler/AggregateRedirectHandler.ts
@@ -33,14 +33,13 @@ import {
   ISessionInfo,
   AggregateHandler,
 } from "@inrupt/solid-client-authn-core";
-import { fetchType } from "../../../authenticatedFetch/fetchFactory";
 
 /**
  * @hidden
  */
 @injectable()
 export default class AggregateRedirectHandler
-  extends AggregateHandler<[string], ISessionInfo & { fetch: fetchType }>
+  extends AggregateHandler<[string], ISessionInfo & { fetch: typeof fetch }>
   implements IRedirectHandler {
   constructor(
     @injectAll("redirectHandlers") redirectHandlers: IRedirectHandler[]

--- a/packages/node/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
+++ b/packages/node/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
@@ -37,6 +37,7 @@ import {
   mockDefaultIssuerConfig,
 } from "../__mocks__/IssuerConfigFetcher";
 import { mockDefaultClientRegistrar } from "../__mocks__/ClientRegistrar";
+import { mockDefaultTokenRefresher } from "../refresh/__mocks__/TokenRefresher";
 
 jest.mock("openid-client");
 jest.mock("cross-fetch");
@@ -119,6 +120,7 @@ const defaultMocks = {
   sessionInfoManager: mockSessionInfoManager(mockStorageUtility({})),
   clientRegistrar: mockDefaultClientRegistrar(),
   issuerConfigFetcher: mockIssuerConfigFetcher(mockDefaultIssuerConfig()),
+  tokenRefresher: mockDefaultTokenRefresher(),
 };
 
 function getAuthCodeRedirectHandler(
@@ -128,7 +130,8 @@ function getAuthCodeRedirectHandler(
     mocks.storageUtility ?? defaultMocks.storageUtility,
     mocks.sessionInfoManager ?? defaultMocks.sessionInfoManager,
     mocks.issuerConfigFetcher ?? defaultMocks.issuerConfigFetcher,
-    mocks.clientRegistrar ?? defaultMocks.clientRegistrar
+    mocks.clientRegistrar ?? defaultMocks.clientRegistrar,
+    mocks.tokenRefresher ?? defaultMocks.tokenRefresher
   );
 }
 

--- a/packages/node/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
+++ b/packages/node/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
@@ -44,7 +44,6 @@ import { configToIssuerMetadata } from "../IssuerConfigFetcher";
 import {
   buildBearerFetch,
   buildDpopFetch,
-  fetchType,
   RefreshOptions,
 } from "../../../authenticatedFetch/fetchFactory";
 import { ITokenRefresher } from "../refresh/TokenRefresher";
@@ -104,7 +103,7 @@ export class AuthCodeRedirectHandler implements IRedirectHandler {
 
   async handle(
     redirectUrl: string
-  ): Promise<ISessionInfo & { fetch: fetchType }> {
+  ): Promise<ISessionInfo & { fetch: typeof fetch }> {
     if (!(await this.canHandle(redirectUrl))) {
       throw new Error(
         `AuthCodeRedirectHandler cannot handle [${redirectUrl}]: it is missing one of [code, state].`

--- a/packages/node/src/login/oidc/redirectHandler/FallbackRedirectHandler.ts
+++ b/packages/node/src/login/oidc/redirectHandler/FallbackRedirectHandler.ts
@@ -32,7 +32,6 @@ import {
 import { URL } from "url";
 
 import { getUnauthenticatedSession } from "../../../sessionInfo/SessionInfoManager";
-import { fetchType } from "../../../authenticatedFetch/fetchFactory";
 
 /**
  * This class handles redirect IRIs without any query params, and returns an unauthenticated
@@ -58,7 +57,7 @@ export class FallbackRedirectHandler implements IRedirectHandler {
   async handle(
     // The argument is ignored, but must be present to implement the interface
     _redirectUrl: string
-  ): Promise<ISessionInfo & { fetch: fetchType }> {
+  ): Promise<ISessionInfo & { fetch: typeof fetch }> {
     return getUnauthenticatedSession();
   }
 }

--- a/packages/node/src/login/oidc/refresh/TokenRefresher.ts
+++ b/packages/node/src/login/oidc/refresh/TokenRefresher.ts
@@ -36,7 +36,8 @@ import { Issuer, TokenSet } from "openid-client";
 import { JWK } from "jose";
 import { configToIssuerMetadata } from "../IssuerConfigFetcher";
 
-// Some identifiers are in camelcase on purpose.
+// Some identifiers are not in camelcase on purpose, as they are named using the
+// official names from the OIDC/OAuth2 specifications.
 /* eslint-disable camelcase */
 
 /**

--- a/packages/node/src/login/oidc/refresh/TokenRefresher.ts
+++ b/packages/node/src/login/oidc/refresh/TokenRefresher.ts
@@ -36,11 +36,17 @@ import { Issuer, TokenSet } from "openid-client";
 import { JWK } from "jose";
 import { configToIssuerMetadata } from "../IssuerConfigFetcher";
 
+// Some identifiers are in camelcase on purpose.
+/* eslint-disable camelcase */
+
 /**
  * @hidden
  */
 export interface ITokenRefresher {
-  refresh(localUserId: string, refreshToken?: string): Promise<TokenSet>;
+  refresh(
+    localUserId: string,
+    refreshToken?: string
+  ): Promise<TokenSet & { access_token: string }>;
 }
 
 /**
@@ -59,7 +65,7 @@ export default class TokenRefresher implements ITokenRefresher {
     sessionId: string,
     refreshToken?: string,
     dpopKey?: JWK.ECKey
-  ): Promise<TokenSet> {
+  ): Promise<TokenSet & { access_token: string }> {
     const oidcContext = await loadOidcContextFromStorage(
       sessionId,
       this.storageUtility,
@@ -108,7 +114,7 @@ export default class TokenRefresher implements ITokenRefresher {
         { secure: true }
       );
     }
-
-    return tokenSet;
+    // The type assertion is fine, since we throw on undefined access_token
+    return tokenSet as TokenSet & { access_token: string };
   }
 }

--- a/packages/node/src/login/oidc/refresh/__mocks__/TokenRefresher.ts
+++ b/packages/node/src/login/oidc/refresh/__mocks__/TokenRefresher.ts
@@ -19,10 +19,37 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { ITokenRequester } from "../TokenRequester";
+import { IdTokenClaims, TokenSet } from "openid-client";
+import { ITokenRefresher } from "../TokenRefresher";
 
-export const TokenRequesterMock: jest.Mocked<ITokenRequester> = {
-  request: jest.fn((_localUserId: string, _body: Record<string, string>) => {
-    return Promise.resolve();
-  }),
+// Some identifiers are in camelcase on purpose.
+/* eslint-disable camelcase */
+
+export const mockTokenRefresher = (
+  tokenSet: TokenSet & { access_token: string }
+): ITokenRefresher => {
+  return {
+    refresh: async () => tokenSet,
+  };
 };
+
+const mockIdTokenPayload = (): IdTokenClaims => {
+  return {
+    sub: "https://my.webid",
+    iss: "https://my.idp/",
+    aud: "https://resource.example.org",
+    exp: 1662266216,
+    iat: 1462266216,
+  };
+};
+
+export const mockDefaultTokenSet = (): TokenSet & { access_token: string } => {
+  return {
+    access_token: "some refreshed access token",
+    expired: () => false,
+    claims: mockIdTokenPayload,
+  };
+};
+
+export const mockDefaultTokenRefresher = (): ITokenRefresher =>
+  mockTokenRefresher(mockDefaultTokenSet());

--- a/packages/node/src/sessionInfo/SessionInfoManager.ts
+++ b/packages/node/src/sessionInfo/SessionInfoManager.ts
@@ -33,10 +33,9 @@ import {
 } from "@inrupt/solid-client-authn-core";
 import { v4 } from "uuid";
 import { fetch } from "cross-fetch";
-import { fetchType } from "../authenticatedFetch/fetchFactory";
 
 export function getUnauthenticatedSession(): ISessionInfo & {
-  fetch: fetchType;
+  fetch: typeof fetch;
 } {
   return {
     isLoggedIn: false,


### PR DESCRIPTION
This ensures that the authenticated fetch built after having received a Bearer token supports the refresh token flow. On auth failure, the fetch function tries to update its current access token, and retries the request. The refresh token is also rotated if a new token is sent by the issuer.

The DPoP fetch will incorporate a similar logic in an upcoming PR.

- [x] All acceptance criteria are met.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).