### PR TITLE
DPoP-authenticated fetch uses the refresh flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### New features
 
+- NodeJS support: a new NPM package, `@inrupt/solid-client-authn-node`, is now available to use authentication in a server environment. 
+- In addition to the features supported by the browser version, `@inrupt/solid-client-authn-node` supports the refresh token grant, which 
+makes it possible to maintain long-lived sessions without re-involving the user.
+
 ### Bugfixes
 
 - Deriving the WebID from the ID token did not accept some valid IRIs in the subject claim, i.e. issued by a local instance of Node Solid Server.

--- a/packages/node/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
+++ b/packages/node/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
@@ -175,17 +175,24 @@ export class AuthCodeRedirectHandler implements IRedirectHandler {
         `The Identity Provider [${issuer.metadata.issuer}] did not return the expected tokens: missing at least one of 'access_token', 'id_token.`
       );
     }
+    let refreshOptions: RefreshOptions | undefined;
+    if (tokenSet.refresh_token !== undefined) {
+      refreshOptions = {
+        refreshToken: tokenSet.refresh_token,
+        sessionId,
+        tokenRefresher: this.tokenRefresher,
+      };
+    }
     if (dpop) {
       authFetch = await buildDpopFetch(
         tokenSet.access_token,
-        tokenSet.refresh_token,
         // TS thinks dpopKey isn't initialized, when it is.
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
-        dpopKey as any
+        dpopKey as any,
+        refreshOptions
       );
     } else {
-      let refreshOptions: RefreshOptions | undefined;
       if (tokenSet.refresh_token !== undefined) {
         refreshOptions = {
           refreshToken: tokenSet.refresh_token,


### PR DESCRIPTION
This enables refreshing a DPoP access token on authentication failure. Redirection is handled at a higher priority than refresh, so that a redirected request may trigger the refresh flow.
Refreshed access and refresh tokens are then kept in the fetch closure to be reused.

This completes the support for the refresh token flow.

- [X] All acceptance criteria are met.
- [x] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).