### PR TITLE
Read data from a JSON file

### DIFF
--- a/packages/node/src/storage/FileSystemStorage.spec.ts
+++ b/packages/node/src/storage/FileSystemStorage.spec.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { it, describe } from "@jest/globals";
+import { get } from "./FileSystemStorage";
+
+jest.mock("fs/promises");
+
+describe("FileSystemStorage", () => {
+  describe("get", () => {
+    it("retrieves an element from a JSON file", async () => {
+      const data = { someKey: "some value" };
+      const mockedFs = jest.requireMock("fs/promises");
+      mockedFs.readFile = jest.fn().mockResolvedValueOnce(JSON.stringify(data));
+      await expect(get("some file", "someKey")).resolves.toEqual("some value");
+    });
+  });
+});

--- a/packages/node/src/storage/FileSystemStorage.spec.ts
+++ b/packages/node/src/storage/FileSystemStorage.spec.ts
@@ -22,14 +22,16 @@
 import { it, describe } from "@jest/globals";
 import { get } from "./FileSystemStorage";
 
-jest.mock("fs/promises");
+jest.mock("fs");
 
 describe("FileSystemStorage", () => {
   describe("get", () => {
     it("retrieves an element from a JSON file", async () => {
       const data = { someKey: "some value" };
-      const mockedFs = jest.requireMock("fs/promises");
-      mockedFs.readFile = jest.fn().mockResolvedValueOnce(JSON.stringify(data));
+      const mockedFs = jest.requireMock("fs");
+      mockedFs.promises = {
+        readFile: jest.fn().mockResolvedValue(JSON.stringify(data)),
+      };
       await expect(get("some file", "someKey")).resolves.toEqual("some value");
     });
   });

--- a/packages/node/src/storage/FileSystemStorage.ts
+++ b/packages/node/src/storage/FileSystemStorage.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * @hidden
+ * @packageDocumentation
+ */
+
+import { IStorage, NotImplementedError } from "@inrupt/solid-client-authn-core";
+import { readFile } from "fs/promises";
+import { existsSync, writeFileSync } from "fs";
+
+export const get = async (
+  path: string,
+  key: string
+): Promise<string | undefined> => {
+  try {
+    const rawData = await readFile(path, {
+      encoding: "utf-8",
+    });
+    const parsedData = JSON.parse(rawData);
+    return parsedData[key] || undefined;
+  } catch (e) {
+    throw new Error(
+      `An error happened while parsing JSON content of ${path}: ${e}`
+    );
+  }
+};
+
+/**
+ * Simple persistent storage solution that uses a file on the host filesystem to store data
+ * @hidden
+ */
+export default class FileSystemStorage implements IStorage {
+  private map: Record<string, string> = {};
+
+  constructor(private path: string) {
+    // If the file does not exist, create it
+    if (!existsSync(path)) {
+      writeFileSync(path, "");
+    }
+  }
+
+  get = (key: string): Promise<string | undefined> => get(this.path, key);
+
+  async set(key: string, value: string): Promise<void> {
+    throw new NotImplementedError("FileSystemStorage.set not implemented yet");
+  }
+
+  async delete(key: string): Promise<void> {
+    throw new NotImplementedError(
+      "FileSystemStorage.delete not implemented yet"
+    );
+  }
+}

--- a/packages/node/src/storage/FileSystemStorage.ts
+++ b/packages/node/src/storage/FileSystemStorage.ts
@@ -42,7 +42,7 @@ export const get = async (
     return parsedData[key] || undefined;
   } catch (e) {
     throw new Error(
-      `An error happened while parsing JSON content of ${path}: ${e}`
+      `An error happened while parsing JSON content of [${path}]: ${e}`
     );
   }
 };
@@ -63,13 +63,11 @@ export default class FileSystemStorage implements IStorage {
 
   get = (key: string): Promise<string | undefined> => get(this.path, key);
 
-  async set(_key: string, _value: string): Promise<void> {
-    throw new NotImplementedError("FileSystemStorage.set not implemented yet");
-  }
+  set = async (_key: string, _value: string): Promise<void> => {
+    throw new NotImplementedError("FileSystemStorage.set");
+  };
 
-  async delete(_key: string): Promise<void> {
-    throw new NotImplementedError(
-      "FileSystemStorage.delete not implemented yet"
-    );
-  }
+  delete = async (_key: string): Promise<void> => {
+    throw new NotImplementedError("FileSystemStorage.delete");
+  };
 }

--- a/packages/node/src/storage/FileSystemStorage.ts
+++ b/packages/node/src/storage/FileSystemStorage.ts
@@ -25,15 +25,17 @@
  */
 
 import { IStorage, NotImplementedError } from "@inrupt/solid-client-authn-core";
-import { readFile } from "fs/promises";
-import { existsSync, writeFileSync } from "fs";
+// Note that currently, the jest runner doesn't support ES modules, so the following
+// does not work, and the "promise" import on the line after that is required instead.
+// import { readFile } from "fs/promises";
+import { existsSync, writeFileSync, promises } from "fs";
 
 export const get = async (
   path: string,
   key: string
 ): Promise<string | undefined> => {
   try {
-    const rawData = await readFile(path, {
+    const rawData = await promises.readFile(path, {
       encoding: "utf-8",
     });
     const parsedData = JSON.parse(rawData);

--- a/packages/node/src/storage/FileSystemStorage.ts
+++ b/packages/node/src/storage/FileSystemStorage.ts
@@ -63,11 +63,11 @@ export default class FileSystemStorage implements IStorage {
 
   get = (key: string): Promise<string | undefined> => get(this.path, key);
 
-  async set(key: string, value: string): Promise<void> {
+  async set(_key: string, _value: string): Promise<void> {
     throw new NotImplementedError("FileSystemStorage.set not implemented yet");
   }
 
-  async delete(key: string): Promise<void> {
+  async delete(_key: string): Promise<void> {
     throw new NotImplementedError(
       "FileSystemStorage.delete not implemented yet"
     );


### PR DESCRIPTION
This introduces a new `IStorage` implementation, `FileSystemStorage`, which uses a JSON file on the filesystem as storage. The purpose is to be able to test easily the support for externally-stored tokens (i.e. this isn't intended to be used in a production system). It will also be a good exemple of extension if one wants to support their own storage solution for user credentials.

This only implements the read feature, write and delete will be implemented in separate PRs.

- [x] All acceptance criteria are met.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).