### PR TITLE
Only use one storage in NodeJS

### DIFF
--- a/packages/core/src/storage/StorageUtility.spec.ts
+++ b/packages/core/src/storage/StorageUtility.spec.ts
@@ -575,13 +575,13 @@ describe("saveSessionInfoToStorage", () => {
     );
 
     await expect(
-      mockedStorage.getForUser("some session", "idToken", { secure: true })
+      mockedStorage.getForUser("some session", "idToken")
     ).resolves.toEqual("an ID token");
     await expect(
-      mockedStorage.getForUser("some session", "webId", { secure: true })
+      mockedStorage.getForUser("some session", "webId")
     ).resolves.toEqual("https://my.webid");
     await expect(
-      mockedStorage.getForUser("some session", "isLoggedIn", { secure: true })
+      mockedStorage.getForUser("some session", "isLoggedIn")
     ).resolves.toEqual("true");
   });
 
@@ -593,7 +593,8 @@ describe("saveSessionInfoToStorage", () => {
       "an ID token",
       "https://my.webid",
       "true",
-      "a refresh token"
+      "a refresh token",
+      true
     );
 
     await expect(

--- a/packages/core/src/storage/StorageUtility.ts
+++ b/packages/core/src/storage/StorageUtility.ts
@@ -101,7 +101,8 @@ export async function saveSessionInfoToStorage(
   idToken: string,
   webId: string,
   isLoggedIn: string,
-  refreshToken?: string
+  refreshToken?: string,
+  secure?: boolean
 ): Promise<void> {
   if (refreshToken !== undefined) {
     await storageUtility.setForUser(
@@ -109,7 +110,7 @@ export async function saveSessionInfoToStorage(
       {
         refreshToken,
       },
-      { secure: true }
+      { secure }
     );
   }
   await storageUtility.setForUser(
@@ -119,7 +120,7 @@ export async function saveSessionInfoToStorage(
       webId,
       isLoggedIn,
     },
-    { secure: true }
+    { secure }
   );
 }
 

--- a/packages/node/src/ClientAuthentication.spec.ts
+++ b/packages/node/src/ClientAuthentication.spec.ts
@@ -161,12 +161,9 @@ describe("ClientAuthentication", () => {
       };
       const clientAuthn = getClientAuthentication({
         sessionInfoManager: mockSessionInfoManager(
-          mockStorageUtility(
-            {
-              "solidClientAuthenticationUser:mySession": { ...sessionInfo },
-            },
-            true
-          )
+          mockStorageUtility({
+            "solidClientAuthenticationUser:mySession": { ...sessionInfo },
+          })
         ),
       });
       const session = await clientAuthn.getSessionInfo("mySession");

--- a/packages/node/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
+++ b/packages/node/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
@@ -252,10 +252,10 @@ describe("AuthCodeRedirectHandler", () => {
 
       // Check that the session information is stored in the provided storage
       await expect(
-        mockedStorage.getForUser("mySession", "webId", { secure: true })
+        mockedStorage.getForUser("mySession", "webId")
       ).resolves.toEqual(mockWebId());
       await expect(
-        mockedStorage.getForUser("mySession", "isLoggedIn", { secure: true })
+        mockedStorage.getForUser("mySession", "isLoggedIn")
       ).resolves.toEqual("true");
 
       // Check that the returned fetch function is authenticated
@@ -339,7 +339,7 @@ describe("AuthCodeRedirectHandler", () => {
 
       // Check that the session information is stored in the provided storage
       await expect(
-        mockedStorage.getForUser("mySession", "refreshToken", { secure: true })
+        mockedStorage.getForUser("mySession", "refreshToken")
       ).resolves.toEqual("some refresh token");
     });
 

--- a/packages/node/src/login/oidc/refresh/TokenRefresher.spec.ts
+++ b/packages/node/src/login/oidc/refresh/TokenRefresher.spec.ts
@@ -267,7 +267,7 @@ describe("TokenRefresher", () => {
 
     // Check that the session information is stored in the provided storage
     await expect(
-      mockedStorage.getForUser("mySession", "refreshToken", { secure: true })
+      mockedStorage.getForUser("mySession", "refreshToken")
     ).resolves.toEqual("some new refresh token");
   });
 

--- a/packages/node/src/login/oidc/refresh/TokenRefresher.ts
+++ b/packages/node/src/login/oidc/refresh/TokenRefresher.ts
@@ -109,11 +109,9 @@ export default class TokenRefresher implements ITokenRefresher {
     }
 
     if (tokenSet.refresh_token !== undefined) {
-      await this.storageUtility.setForUser(
-        sessionId,
-        { refreshToken: tokenSet.refresh_token },
-        { secure: true }
-      );
+      await this.storageUtility.setForUser(sessionId, {
+        refreshToken: tokenSet.refresh_token,
+      });
     }
     // The type assertion is fine, since we throw on undefined access_token
     return tokenSet as TokenSet & { access_token: string };

--- a/packages/node/src/sessionInfo/SessionInfoManager.spec.ts
+++ b/packages/node/src/sessionInfo/SessionInfoManager.spec.ts
@@ -58,15 +58,12 @@ describe("SessionInfoManager", () => {
 
       const webId = "https://zoomies.com/commanderCool#me";
 
-      const storageMock = mockStorageUtility(
-        {
-          [`solidClientAuthenticationUser:${sessionId}`]: {
-            webId,
-            isLoggedIn: "true",
-          },
+      const storageMock = mockStorageUtility({
+        [`solidClientAuthenticationUser:${sessionId}`]: {
+          webId,
+          isLoggedIn: "true",
         },
-        true
-      );
+      });
 
       // const storageUtility = defaultMocks.storageUtility;
       // storageUtility.getForUser
@@ -88,7 +85,7 @@ describe("SessionInfoManager", () => {
 
     it("returns undefined if the specified storage does not contain the user", async () => {
       const sessionManager = getSessionInfoManager({
-        storageUtility: mockStorageUtility({}, true),
+        storageUtility: mockStorageUtility({}),
       });
       const session = await sessionManager.get("commanderCool");
       expect(session).toBeUndefined();

--- a/packages/node/src/sessionInfo/SessionInfoManager.ts
+++ b/packages/node/src/sessionInfo/SessionInfoManager.ts
@@ -112,15 +112,10 @@ export class SessionInfoManager implements ISessionInfoManager {
   }
 
   async get(sessionId: string): Promise<ISessionInfo | undefined> {
-    const webId = await this.storageUtility.getForUser(sessionId, "webId", {
-      secure: true,
-    });
+    const webId = await this.storageUtility.getForUser(sessionId, "webId");
     const isLoggedIn = await this.storageUtility.getForUser(
       sessionId,
-      "isLoggedIn",
-      {
-        secure: true,
-      }
+      "isLoggedIn"
     );
     if (isLoggedIn !== undefined) {
       return {


### PR DESCRIPTION
Using two storages is a requirement in the browser, because we want to expose as little information as possible in the local storage.
In NodeJS, this constraint does not apply, and it's more convenient to store everything in one storage, since the problem of persistent/non-persistent
storage that forces to use the local storage in the browser does not exist on the server side.

- [X] All acceptance criteria are met.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).