### PR TITLE
Implemented authenticated e2e tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,11 @@ jobs:
       - run: npm run bootstrap -- --ci
       - run: npm run build
       - run: npm run test
+      - run: npm run e2e-test
+        env: 
+          REFRESH_TOKEN: ${{ secrets.REFRESH_TOKEN }}
+          CLIENT_ID: ${{ secrets.CLIENT_ID }}
+          CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
       - run: npx prettier --check "{packages/*/src,packages/*/__tests__}/**"
       - run: npm audit --audit-level=moderate
       - name: Archive code coverage results

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,6 +6,11 @@ module.exports = {
     "^.+\\.(ts|tsx)?$": "ts-jest",
   },
   modulePathIgnorePatterns: ["dist/"],
+  testPathIgnorePatterns: [
+    "/node_modules/",
+    // By default we only run unit tests:
+    "e2e/*",
+  ],
   collectCoverageFrom: [
     "**/src/**/*.ts",
     "!**/node_modules/**",

--- a/jest.e2e.config.js
+++ b/jest.e2e.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+  roots: ["<rootDir>"],
+  clearMocks: true,
+  // Because we're making HTTP requests that can take a while,
+  // tests should be given a little longer to complete:
+  testTimeout: 10000,
+  testMatch: ["**/src/e2e/?(*.)+(spec|test).+(ts|tsx|js)"],
+  transform: {
+    "^.+\\.(ts|tsx)?$": "ts-jest",
+  },
+};

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "audit": "lerna-audit",
     "demo-app": "cd packages/browser; npm run demo-app",
     "bootstrap": "lerna bootstrap",
+    "e2e-test": "jest --config jest.e2e.config.js",
     "build": "lerna run build",
     "clean": "rm --recursive --force packages/*/dist/ packages/*/node_modules/ packages/*/coverage/ packages/*/umd/",
     "build-api-docs": "lerna run build-api-docs",

--- a/packages/node/jest.e2e.config.js
+++ b/packages/node/jest.e2e.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  ...require("../../jest.e2e.config"),
+  testEnvironment: "node",
+};

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "prepublishOnly": "npm run build",
     "clean": "rm -rf ./dist && rm -rf ./coverage",
+    "e2e-test": "jest --config jest.e2e.config.js",
     "build": "tsc -p tsconfig.json",
     "lint": "eslint \"src/**/*.ts\"",
     "lint-fix": "eslint --fix \"src/**\"",

--- a/packages/node/src/e2e/e2e-test.spec.ts
+++ b/packages/node/src/e2e/e2e-test.spec.ts
@@ -85,9 +85,6 @@ describe("Authenticated fetch", () => {
       "https://ldp.demo-ess.inrupt.com/105177326598249077653/"
     );
     expect(response.status).toEqual(200);
-    await expect(response.text()).resolves.toContain(
-      "foaf:PersonalProfileDocument"
-    );
 
     await session.logout();
     response = await session.fetch(

--- a/packages/node/src/e2e/e2e-test.spec.ts
+++ b/packages/node/src/e2e/e2e-test.spec.ts
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { it, describe } from "@jest/globals";
+import { Session } from "../Session";
+
+const OIDC_ISSUER = "https://broker.demo-ess.inrupt.com/";
+
+// This first test just saves the trouble of looking for a library failure when
+// the environment wasn't properly set.
+describe("Environment", () => {
+  it("contains the expected environment variables", () => {
+    expect(process.env.REFRESH_TOKEN).not.toBeUndefined();
+    expect(process.env.CLIENT_ID).not.toBeUndefined();
+    expect(process.env.CLIENT_SECRET).not.toBeUndefined();
+  });
+});
+
+describe("Authenticated fetch", () => {
+  it("can fetch a public resource when logged in", async () => {
+    const session = new Session();
+    await session.login({
+      clientId: process.env.CLIENT_ID,
+      clientSecret: process.env.CLIENT_SECRET,
+      refreshToken: process.env.REFRESH_TOKEN,
+      oidcIssuer: OIDC_ISSUER,
+    });
+    const response = await session.fetch(
+      "https://ldp.demo-ess.inrupt.com/105177326598249077653/profile/card#me"
+    );
+    expect(response.status).toEqual(200);
+    await expect(response.text()).resolves.toContain(
+      "foaf:PersonalProfileDocument"
+    );
+  });
+
+  it("can fetch a private resource when logged in", async () => {
+    const session = new Session();
+    await session.login({
+      clientId: process.env.CLIENT_ID,
+      clientSecret: process.env.CLIENT_SECRET,
+      refreshToken: process.env.REFRESH_TOKEN,
+      oidcIssuer: OIDC_ISSUER,
+    });
+    const response = await session.fetch(
+      "https://ldp.demo-ess.inrupt.com/105177326598249077653/"
+    );
+    expect(response.status).toEqual(200);
+    await expect(response.text()).resolves.toContain("ldp:BasicContainer");
+  });
+});
+
+describe("Unauthenticated fetch", () => {
+  it("can fetch a public resource when not logged in", async () => {
+    const session = new Session();
+    const response = await session.fetch(
+      "https://ldp.demo-ess.inrupt.com/105177326598249077653/profile/card#me"
+    );
+    expect(response.status).toEqual(200);
+    await expect(response.text()).resolves.toContain(
+      "foaf:PersonalProfileDocument"
+    );
+  });
+
+  it("cannot fetch a private resource when not logged in", async () => {
+    const session = new Session();
+    const response = await session.fetch(
+      "https://ldp.demo-ess.inrupt.com/105177326598249077653/"
+    );
+    expect(response.status).toEqual(401);
+  });
+});
+
+describe("Post-logout fetch", () => {
+  it("can fetch a public resource after logging out", async () => {
+    const session = new Session();
+    await session.login({
+      clientId: process.env.CLIENT_ID,
+      clientSecret: process.env.CLIENT_SECRET,
+      refreshToken: process.env.REFRESH_TOKEN,
+      oidcIssuer: OIDC_ISSUER,
+    });
+    await session.logout();
+    const response = await session.fetch(
+      "https://ldp.demo-ess.inrupt.com/105177326598249077653/profile/card#me"
+    );
+    expect(response.status).toEqual(200);
+    await expect(response.text()).resolves.toContain(
+      "foaf:PersonalProfileDocument"
+    );
+  });
+
+  it("cannot fetch a private resource after logging out", async () => {
+    const session = new Session();
+    await session.login({
+      clientId: process.env.CLIENT_ID,
+      clientSecret: process.env.CLIENT_SECRET,
+      refreshToken: process.env.REFRESH_TOKEN,
+      oidcIssuer: OIDC_ISSUER,
+    });
+    await session.logout();
+    const response = await session.fetch(
+      "https://ldp.demo-ess.inrupt.com/105177326598249077653/"
+    );
+    expect(response.status).toEqual(401);
+  });
+});


### PR DESCRIPTION
This runs authenticated e2e tests based on secrets stored in the environment. Note that this required to use the "bootstrap" app in `packages/node/demo/bootstrappedApp/` in order to log in with the demo account into the identity provider, get the credentials, and store them in GH secrets.

- [X] All acceptance criteria are met.
- [X] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).