### PR TITLE
Add "browser" tag to package.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased
 
+## Bugfix
+
+- Addressed part of issue https://github.com/inrupt/solid-client-authn-js/issues/684,
+by providing a `browser` entry in the `package.json` file. The ES modules export will
+be adressed in a different PR. 
+
 ## New feature
 
 ## 1.2.0 - 2020-12-04
@@ -31,7 +37,7 @@ from being possible, and now after a login that does not require a redirect, the
 
 ### Bugfixes
 
-- issue #685 fixed by removing all URL query params.
+- issue #685 fixed by removing all URL query params after login, which prevents from crashing when reloading a page.
 
 ### Patches
 

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -4,6 +4,7 @@
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index",
+  "browser": "dist/solid-client-authn.bundle.js",
   "repository": {
     "url": "https://github.com/inrupt/solid-client-authn"
   },

--- a/packages/browser/webpack.browser.js
+++ b/packages/browser/webpack.browser.js
@@ -1,4 +1,5 @@
 const { merge } = require("webpack-merge");
+const path = require("path");
 
 const commonConfig = require("./webpack.common.js");
 
@@ -9,6 +10,8 @@ module.exports = () => {
     output: {
       libraryTarget: "var",
       library: "solidClientAuthentication",
+      filename: "solid-client-authn.bundle.js",
+      path: path.resolve(__dirname, "dist"),
     },
   };
 

--- a/packages/browser/webpack.common.js
+++ b/packages/browser/webpack.common.js
@@ -1,5 +1,3 @@
-const path = require("path");
-
 module.exports = {
   entry: "./src/index.browser.ts",
   module: {
@@ -26,10 +24,5 @@ module.exports = {
       util: require.resolve("util/"),
       buffer: require.resolve("buffer/"),
     },
-  },
-  output: {
-    filename: "solid-client-authn.bundle.js",
-    path: path.resolve(__dirname, "browserDist"),
-    libraryTarget: "commonjs",
   },
 };


### PR DESCRIPTION
Resolves #684 (in part)

We use webpack to output a browser bundle, so it should be advertized in the package.json.

Note that this does not add the ES module build. For consistency, I'd like to switch the whole build system to rollup, so I'll make sure the an ES module build is generated and exported after the migration.

- [X] All acceptance criteria are met.
- [ ] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).