### PR TITLE
Bootstrap : add menu of IDPs; emit token as JSON

### DIFF
--- a/packages/node/example/bootstrappedApp/README.md
+++ b/packages/node/example/bootstrappedApp/README.md
@@ -33,3 +33,7 @@ request. It expects a number of arguments:
 ```
 node app.js --clientId <the client id> --clientSecret <the client secret>  --refreshToken <the refresh token> --oidcIssuer <the issuer that issued the token> --resource <the private resource you want to access>
 ```
+Within a script, you may simply paste the credentials obtained in the getting-a-token step, as arguments to login.  For example;
+```javascript
+    login( <JSON returned from getting a cookie goes here> )
+```

--- a/packages/node/example/bootstrappedApp/package-lock.json
+++ b/packages/node/example/bootstrappedApp/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@inrupt/demo-app-authn-node",
+  "name": "@inrupt/demo-authn-node-script",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -462,6 +462,11 @@
         "string_decoder": "^1.1.1",
         "util-deprecate": "^1.0.1"
       }
+    },
+    "readline-sync": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/readline-sync/-/readline-sync-1.4.10.tgz",
+      "integrity": "sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw=="
     },
     "require-directory": {
       "version": "2.1.1",

--- a/packages/node/example/bootstrappedApp/package.json
+++ b/packages/node/example/bootstrappedApp/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@inrupt/solid-client-authn-core": "^1.1.0",
     "express": "^4.17.1",
+    "readline-sync": "^1.4.10",
     "yargs": "^16.1.1"
   }
 }


### PR DESCRIPTION
This replaces the command-line arguments in the bootstrap script with a menu/prompt interface and a menu of IDPs.  It presents the returned token as a JSON string which can be plugged directly into the login arguments of a script.  Eventually, the initial prompts might ask for a file path and the script could end by writing (encrypted?) JSON to that file for easy retrieval by scripts, 