### PR TITLE
Upgraded jose to jose@3.x

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -39,5 +39,10 @@ module.exports = {
     "import/prefer-default-export": "off",
     // The following rule should be re-enabled after a refactoring of the handler pattern
     "class-methods-use-this": "off",
+    // The following rule prevents issues with jose@3.x
+    "import/no-unresolved": "off",
+    // Each usage of @ts-ignore is documented. This rule only leads to
+    // add an additional comment on top of each TS command.
+    "@typescript-eslint/ban-ts-comment": "off",
   },
 };

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         # Available OS's: https://help.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners
         os: [ubuntu-20.04, windows-2019]
-        node-version: [12.x, 10.x]
+        node-version: [12.x]
     steps:
       - uses: actions/checkout@v2.3.4
       - name: Use Node.js ${{ matrix.node-version }}

--- a/jest.config.js
+++ b/jest.config.js
@@ -19,4 +19,8 @@ module.exports = {
     "!**/src/index.ts",
     "!**/dist/**",
   ],
+  moduleNameMapper: {
+    // Here, the OIDC package is used, but any package depending on jose@3.x would do.
+    "^jose/(.*)$": "<rootDir>/packages/node/node_modules/jose/dist/node/cjs/$1",
+  },
 };

--- a/jest.e2e.config.js
+++ b/jest.e2e.config.js
@@ -8,4 +8,8 @@ module.exports = {
   transform: {
     "^.+\\.(ts|tsx)?$": "ts-jest",
   },
+  moduleNameMapper: {
+    // Here, the OIDC package is used, but any package depending on jose@3.x would do.
+    "^jose/(.*)$": "<rootDir>/packages/node/node_modules/jose/dist/node/cjs/$1",
+  },
 };

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "audit": "lerna-audit",
     "demo-app": "cd packages/browser; npm run demo-app",
     "bootstrap": "lerna bootstrap",
-    "e2e-test": "jest --config jest.e2e.config.js",
+    "e2e-test": "lerna run e2e-test",
     "build": "lerna run build",
     "clean": "rm --recursive --force packages/*/dist/ packages/*/node_modules/ packages/*/coverage/ packages/*/umd/",
     "build-api-docs": "lerna run build-api-docs",

--- a/packages/node/jest.config.js
+++ b/packages/node/jest.config.js
@@ -1,4 +1,8 @@
 module.exports = {
   ...require("../../jest.config"),
   testEnvironment: "node",
+  moduleNameMapper: {
+    // Here, the OIDC package is used, but any package depending on jose@3.x would do.
+    "^jose/(.*)$": "<rootDir>/node_modules/jose/dist/node/cjs/$1",
+  },
 };

--- a/packages/node/jest.e2e.config.js
+++ b/packages/node/jest.e2e.config.js
@@ -1,4 +1,8 @@
 module.exports = {
   ...require("../../jest.e2e.config"),
   testEnvironment: "node",
+  moduleNameMapper: {
+    // Here, the OIDC package is used, but any package depending on jose@3.x would do.
+    "^jose/(.*)$": "<rootDir>/node_modules/jose/dist/node/cjs/$1",
+  },
 };

--- a/packages/node/package-lock.json
+++ b/packages/node/package-lock.json
@@ -442,30 +442,6 @@
         }
       }
     },
-    "@inrupt/solid-client-authn-core": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-core/-/solid-client-authn-core-1.2.0.tgz",
-      "integrity": "sha512-1UxrtKQNGgxKhKatv9aWX7cXd/5wpbJX66ZBh/tlTaD8OxGnUrAdJW8Nohfv0ST34KdJd27purySID18YYLmhw==",
-      "requires": {
-        "@inrupt/solid-common-vocab": "^0.5.1",
-        "@types/lodash.clonedeep": "^4.5.6",
-        "@types/n3": "^1.4.4",
-        "@types/uuid": "^8.3.0",
-        "cross-fetch": "^3.0.6",
-        "lodash.clonedeep": "^4.5.0",
-        "n3": "^1.6.4",
-        "uuid": "^8.3.1"
-      }
-    },
-    "@inrupt/solid-common-vocab": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-common-vocab/-/solid-common-vocab-0.5.2.tgz",
-      "integrity": "sha512-377npDMn5s/8+vyl3mhCK8YNvxBAbo4nbr2v3NbutzGdggYiV2OkfYhE3hRPdPaeg13xI3quHlulkno+zZ4HTg==",
-      "requires": {
-        "@rdfjs/data-model": "1.2.0",
-        "@types/rdf-js": "4.0.0"
-      }
-    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -682,14 +658,6 @@
       "resolved": "https://registry.npmjs.org/@panva/asn1.js/-/asn1.js-1.0.0.tgz",
       "integrity": "sha512-UdkG3mLEqXgnlKsWanWcgb6dOjUzJ+XC5f+aWw30qrtjxeNUSfKX1cd5FBzOaXQumoe9nIqeZUvrRJS03HCCtw=="
     },
-    "@rdfjs/data-model": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@rdfjs/data-model/-/data-model-1.2.0.tgz",
-      "integrity": "sha512-6ITWcu2sr9zJqXUPDm1XJ8DRpea7PotWBIkTzuO1MCSruLOWH2ICoQOAtlJy30cT+GqH9oAQKPR+CHXejsdizA==",
-      "requires": {
-        "@types/rdf-js": "*"
-      }
-    },
     "@sindresorhus/is": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.0.0.tgz",
@@ -829,28 +797,6 @@
         "@types/node": "*"
       }
     },
-    "@types/lodash": {
-      "version": "4.14.165",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.165.tgz",
-      "integrity": "sha512-tjSSOTHhI5mCHTy/OOXYIhi2Wt1qcbHmuXD1Ha7q70CgI/I71afO4XtLb/cVexki1oVYchpul/TOuu3Arcdxrg=="
-    },
-    "@types/lodash.clonedeep": {
-      "version": "4.5.6",
-      "resolved": "https://registry.npmjs.org/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.6.tgz",
-      "integrity": "sha512-cE1jYr2dEg1wBImvXlNtp0xDoS79rfEdGozQVgliDZj1uERH4k+rmEMTudP9b4VQ8O6nRb5gPqft0QzEQGMQgA==",
-      "requires": {
-        "@types/lodash": "*"
-      }
-    },
-    "@types/n3": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@types/n3/-/n3-1.4.4.tgz",
-      "integrity": "sha512-xsWfwyDh0uAH0CXvwqe9vb2UEDafMjRez/pB7yZwbWpd9Olw2wdxaL32FtdHjmmFE6b9i+j249JfRyZnvWkoqg==",
-      "requires": {
-        "@types/node": "*",
-        "@types/rdf-js": "*"
-      }
-    },
     "@types/node": {
       "version": "14.14.11",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.11.tgz",
@@ -867,14 +813,6 @@
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.1.5.tgz",
       "integrity": "sha512-UEyp8LwZ4Dg30kVU2Q3amHHyTn1jEdhCIE59ANed76GaT1Vp76DD3ZWSAxgCrw6wJ0TqeoBpqmfUHiUDPs//HQ==",
       "dev": true
-    },
-    "@types/rdf-js": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/rdf-js/-/rdf-js-4.0.0.tgz",
-      "integrity": "sha512-2uaR7ks0380MqzUWGOPOOk9yZIr/6MOaCcaj3ntKgd2PqNocgi8j5kSHIJTDe+5ABtTHqKMSE0v0UqrsT8ibgQ==",
-      "requires": {
-        "@types/node": "*"
-      }
     },
     "@types/responselike": {
       "version": "1.0.0",
@@ -2737,7 +2675,8 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "interpret": {
       "version": "1.4.0",
@@ -3530,12 +3469,9 @@
       }
     },
     "jose": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-2.0.3.tgz",
-      "integrity": "sha512-L+RlDgjO0Tk+Ki6/5IXCSEnmJCV8iMFZoBuEgu2vPQJJ4zfG/k3CAqZUMKDYNRHIDyy0QidJpOvX0NgpsAqFlw==",
-      "requires": {
-        "@panva/asn1.js": "^1.0.0"
-      }
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-3.3.1.tgz",
+      "integrity": "sha512-dMVfVKnyJyl2d9OBkwu/nvheGh9fbS1khhkJdvbGnINNe8IUfSJ/U+BXJOQvk65BCIJ58lp7xQKJTGQQ5dxrZA=="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -3815,11 +3751,6 @@
       "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
       "dev": true
     },
-    "lodash.clonedeep": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
-    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -3995,15 +3926,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
-    },
-    "n3": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/n3/-/n3-1.6.4.tgz",
-      "integrity": "sha512-qiiBhW2nJ59cfQzi0nvZs5tSXkXgDXedIy3zNNuKjTwE8Bcvv95DTFJpOY9geg6of5T7z6cg+ZWcaHIij3svrA==",
-      "requires": {
-        "queue-microtask": "^1.1.2",
-        "readable-stream": "^3.6.0"
-      }
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -4240,6 +4162,16 @@
         "object-hash": "^2.0.1",
         "oidc-token-hash": "^5.0.0",
         "p-any": "^3.0.0"
+      },
+      "dependencies": {
+        "jose": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/jose/-/jose-2.0.3.tgz",
+          "integrity": "sha512-L+RlDgjO0Tk+Ki6/5IXCSEnmJCV8iMFZoBuEgu2vPQJJ4zfG/k3CAqZUMKDYNRHIDyy0QidJpOvX0NgpsAqFlw==",
+          "requires": {
+            "@panva/asn1.js": "^1.0.0"
+          }
+        }
       }
     },
     "optionator": {
@@ -4499,11 +4431,6 @@
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
     },
-    "queue-microtask": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.2.tgz",
-      "integrity": "sha512-dB15eXv3p2jDlbOiNLyMabYg1/sXvppd8DP2J3EOCQ0AkuSXCW2tP7mnVouVLJKgUMY6yP0kcQDVpLCN13h4Xg=="
-    },
     "quick-lru": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
@@ -4579,16 +4506,6 @@
         "find-up": "^4.1.0",
         "read-pkg": "^5.2.0",
         "type-fest": "^0.8.1"
-      }
-    },
-    "readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "requires": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
       }
     },
     "readdir-scoped-modules": {
@@ -5432,21 +5349,6 @@
         "strip-ansi": "^6.0.0"
       }
     },
-    "string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "requires": {
-        "safe-buffer": "~5.2.0"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-        }
-      }
-    },
     "strip-ansi": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
@@ -5947,11 +5849,6 @@
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
-    },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "util-extend": {
       "version": "1.0.3",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -15,7 +15,7 @@
     "lint": "eslint \"src/**/*.ts\"",
     "lint-fix": "eslint --fix \"src/**\"",
     "licenses": "license-checker --production --out license.csv --failOn \"AGPL-1.0-only; AGPL-1.0-or-later; AGPL-3.0-only; AGPL-3.0-or-later; Beerware; CC-BY-NC-1.0; CC-BY-NC-2.0; CC-BY-NC-2.5; CC-BY-NC-3.0; CC-BY-NC-4.0; CC-BY-NC-ND-1.0; CC-BY-NC-ND-2.0; CC-BY-NC-ND-2.5; CC-BY-NC-ND-3.0; CC-BY-NC-ND-4.0; CC-BY-NC-SA-1.0; CC-BY-NC-SA-2.0; CC-BY-NC-SA-2.5; CC-BY-NC-SA-3.0; CC-BY-NC-SA-4.0; CPAL-1.0; EUPL-1.0; EUPL-1.1; EUPL-1.1;  GPL-1.0-only; GPL-1.0-or-later; GPL-2.0-only;  GPL-2.0-or-later; GPL-3.0; GPL-3.0-only; GPL-3.0-or-later; SISSL;  SISSL-1.2; WTFPL\"",
-    "test": "npm run lint-fix && npm run licenses && jest --coverage --verbose --passWithNoTests",
+    "test": "npm run lint-fix && npm run licenses && jest --coverage --verbose",
     "build-api-docs": "npx typedoc --out docs/api/source/api --readme none",
     "build-docs-preview-site": "npm run build-api-docs; cd docs/api; make html"
   },
@@ -34,7 +34,7 @@
     "@types/node": "^14.14.11",
     "@types/uuid": "^8.3.0",
     "cross-fetch": "^3.0.6",
-    "jose": "^2.0.3",
+    "jose": "^3.3.1",
     "openid-client": "^4.2.2",
     "reflect-metadata": "^0.1.13",
     "tsyringe": "^4.4.0",

--- a/packages/node/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
+++ b/packages/node/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
@@ -25,7 +25,7 @@ import {
   mockStorageUtility,
 } from "@inrupt/solid-client-authn-core";
 import { IdTokenClaims, TokenSet } from "openid-client";
-import { JWK } from "jose";
+import { JWK } from "jose/types";
 import {
   AuthCodeRedirectHandler,
   getWebidFromTokenPayload,
@@ -42,8 +42,8 @@ import { mockDefaultTokenRefresher } from "../refresh/__mocks__/TokenRefresher";
 jest.mock("openid-client");
 jest.mock("cross-fetch");
 
-const mockJwk = (): JWK.ECKey =>
-  JWK.asKey({
+const mockJwk = (): JWK => {
+  return {
     kty: "EC",
     kid: "oOArcXxcwvsaG21jAx_D5CHr4BgVCzCEtlfmNFQtU0s",
     alg: "ES256",
@@ -51,7 +51,8 @@ const mockJwk = (): JWK.ECKey =>
     x: "0dGe_s-urLhD3mpqYqmSXrqUZApVV5ZNxMJXg7Vp-2A",
     y: "-oMe9gGkpfIrnJ0aiSUHMdjqYVm5ZrGCeQmRKoIIfj8",
     d: "yR1bCsR7m4hjFCvWo8Jw3OfNR4aiYDAFbBD9nkudJKM",
-  });
+  };
+};
 
 const mockWebId = (): string => "https://my.webid/";
 
@@ -79,7 +80,7 @@ type AccessJwt = {
   };
 };
 
-const mockKeyBoundToken = (): AccessJwt => {
+const mockKeyBoundToken = async (): Promise<AccessJwt> => {
   return {
     sub: mockWebId(),
     iss: mockDefaultIssuerConfig().issuer.toString(),

--- a/packages/node/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
+++ b/packages/node/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
@@ -39,7 +39,10 @@ import {
 } from "@inrupt/solid-client-authn-core";
 import { URL } from "url";
 import { IdTokenClaims, Issuer, TokenSet } from "openid-client";
-import { JWK } from "jose";
+import { JWK } from "jose/types";
+import generateKeyPair from "jose/util/generate_key_pair";
+import fromKeyLike from "jose/jwk/from_key_like";
+
 import { configToIssuerMetadata } from "../IssuerConfigFetcher";
 import {
   buildBearerFetch,
@@ -148,17 +151,23 @@ export class AuthCodeRedirectHandler implements IRedirectHandler {
 
     const params = client.callbackParams(redirectUrl);
 
-    let dpopKey: JWK.ECKey;
+    let dpopKey: JWK;
     let tokenSet: TokenSet;
     let authFetch: typeof fetch;
 
     if (dpop) {
-      dpopKey = await JWK.generate("EC", "P-256");
+      dpopKey = await fromKeyLike((await generateKeyPair("ES256")).privateKey);
+      // The alg property isn't set by fromKeyLike, so set it manually.
+      dpopKey.alg = "ES256";
       tokenSet = await client.callback(
         redirectUri,
         params,
         { code_verifier: codeVerifier, state: oauthState },
-        { DPoP: dpopKey.toJWK(true) }
+        // openid-client does not support yet jose@3.x, and expects
+        // type definitions that are no longer present. However, the JWK
+        // type that we pass here is compatible with the API.
+        // @ts-ignore
+        { DPoP: dpopKey }
       );
     } else {
       tokenSet = await client.callback(redirectUri, params, {

--- a/packages/node/src/login/oidc/refresh/TokenRefresher.spec.ts
+++ b/packages/node/src/login/oidc/refresh/TokenRefresher.spec.ts
@@ -24,7 +24,7 @@ import {
   mockStorageUtility,
   StorageUtilityMock,
 } from "@inrupt/solid-client-authn-core";
-import { JWK } from "jose";
+import { JWK } from "jose/types";
 import { IdTokenClaims, TokenSet } from "openid-client";
 import TokenRefresher from "./TokenRefresher";
 import { mockDefaultClientRegistrar } from "../__mocks__/ClientRegistrar";
@@ -35,8 +35,8 @@ import {
 
 jest.mock("openid-client");
 
-const mockJwk = (): JWK.ECKey =>
-  JWK.asKey({
+const mockJwk = (): JWK => {
+  return {
     kty: "EC",
     kid: "oOArcXxcwvsaG21jAx_D5CHr4BgVCzCEtlfmNFQtU0s",
     alg: "ES256",
@@ -44,7 +44,8 @@ const mockJwk = (): JWK.ECKey =>
     x: "0dGe_s-urLhD3mpqYqmSXrqUZApVV5ZNxMJXg7Vp-2A",
     y: "-oMe9gGkpfIrnJ0aiSUHMdjqYVm5ZrGCeQmRKoIIfj8",
     d: "yR1bCsR7m4hjFCvWo8Jw3OfNR4aiYDAFbBD9nkudJKM",
-  });
+  };
+};
 
 const mockIdToken = (): string =>
   "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJodHRwczovL215LndlYmlkIiwiaXNzIjoiaHR0cHM6Ly9teS5pZHAvIiwiYXVkIjoiaHR0cHM6Ly9yZXNvdXJjZS5leGFtcGxlLm9yZyIsImV4cCI6MTY2MjI2NjIxNiwiaWF0IjoxNDYyMjY2MjE2fQ.IwumuwJtQw5kUBMMHAaDPJBppfBpRHbiXZw_HlKe6GNVUWUlyQRYV7W7r9OQtHmMsi6GVwOckelA3ErmhrTGVw";

--- a/packages/node/src/login/oidc/refresh/TokenRefresher.ts
+++ b/packages/node/src/login/oidc/refresh/TokenRefresher.ts
@@ -33,7 +33,7 @@ import {
   loadOidcContextFromStorage,
 } from "@inrupt/solid-client-authn-core";
 import { Issuer, TokenSet } from "openid-client";
-import { JWK } from "jose";
+import { JWK } from "jose/types";
 import { configToIssuerMetadata } from "../IssuerConfigFetcher";
 
 // Some identifiers are not in camelcase on purpose, as they are named using the
@@ -47,7 +47,7 @@ export interface ITokenRefresher {
   refresh(
     localUserId: string,
     refreshToken?: string,
-    dpopKey?: JWK.ECKey
+    dpopKey?: JWK
   ): Promise<TokenSet & { access_token: string }>;
 }
 
@@ -66,7 +66,7 @@ export default class TokenRefresher implements ITokenRefresher {
   async refresh(
     sessionId: string,
     refreshToken?: string,
-    dpopKey?: JWK.ECKey
+    dpopKey?: JWK
   ): Promise<TokenSet & { access_token: string }> {
     const oidcContext = await loadOidcContextFromStorage(
       sessionId,
@@ -99,7 +99,11 @@ export default class TokenRefresher implements ITokenRefresher {
     }
 
     const tokenSet = await client.refresh(refreshToken, {
-      DPoP: dpopKey?.toJWK(true),
+      // openid-client does not support yet jose@3.x, and expects
+      // type definitions that are no longer present. However, the JWK
+      // type that we pass here is compatible with the API.
+      // @ts-ignore
+      DPoP: dpopKey,
     });
 
     if (tokenSet.access_token === undefined) {


### PR DESCRIPTION
This updates the jose dependency to the latsest majoer version, and
adapts the code to the subsequent interface changes. Notice that the
testing/linting config also had to be changed, because jose@3.x uses
modern JS practices that aren't yet fully supported by jest.

- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).