### PR TITLE
Reads WebID from ID token in refresh flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - Addressed part of issue https://github.com/inrupt/solid-client-authn-js/issues/684,
 by providing a `browser` entry in the `package.json` file. The ES modules export will
 be adressed in a different PR. 
+- The WebID is now set on the session when logging in a script.
 
 ## New feature
 

--- a/packages/node/src/ClientAuthentication.ts
+++ b/packages/node/src/ClientAuthentication.ts
@@ -66,7 +66,6 @@ export default class ClientAuthentication {
     // could return to a previous redirect URL that contains OIDC params that
     // are now longer valid - so just to be safe, strip relevant params now.
     const { redirectUrl } = options;
-
     const loginReturn = await this.loginHandler.handle({
       sessionId,
       oidcIssuer: options.oidcIssuer,

--- a/packages/node/src/authenticatedFetch/fetchFactory.ts
+++ b/packages/node/src/authenticatedFetch/fetchFactory.ts
@@ -162,17 +162,11 @@ async function buildDpopFetchOptions(
   defaultOptions?: RequestInit
 ): Promise<RequestInit> {
   const options: RequestInit = { ...defaultOptions };
-  if (authToken !== "") {
-    options.headers = {
-      ...defaultOptions?.headers,
-      Authorization: `DPoP ${authToken}`,
-      DPoP: createDpopHeader(
-        targetUrl,
-        defaultOptions?.method ?? "get",
-        dpopKey
-      ),
-    };
-  }
+  options.headers = {
+    ...defaultOptions?.headers,
+    Authorization: `DPoP ${authToken}`,
+    DPoP: createDpopHeader(targetUrl, defaultOptions?.method ?? "get", dpopKey),
+  };
   return options;
 }
 

--- a/packages/node/src/login/oidc/oidcHandlers/RefreshTokenOidcHandler.spec.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/RefreshTokenOidcHandler.spec.ts
@@ -26,12 +26,17 @@
 
 import "reflect-metadata";
 import { mockStorageUtility } from "@inrupt/solid-client-authn-core";
+import { IdTokenClaims } from "openid-client";
 import {
   mockDefaultOidcOptions,
   mockOidcOptions,
 } from "../__mocks__/IOidcOptions";
 import RefreshTokenOidcHandler from "./RefreshTokenOidcHandler";
-import { mockDefaultTokenRefresher } from "../refresh/__mocks__/TokenRefresher";
+import {
+  mockDefaultTokenRefresher,
+  mockDefaultTokenSet,
+  mockTokenRefresher,
+} from "../refresh/__mocks__/TokenRefresher";
 
 jest.mock("cross-fetch");
 
@@ -114,7 +119,7 @@ describe("RefreshTokenOidcHandler", () => {
           },
         })
       );
-      expect(result).not.toBeUndefined();
+      expect(result?.webId).toEqual("https://my.webid/");
 
       const mockedFetch = jest.requireMock("cross-fetch");
       mockedFetch.mockResolvedValue({
@@ -245,5 +250,65 @@ describe("RefreshTokenOidcHandler", () => {
       })
     );
     expect(result).not.toBeUndefined();
+  });
+
+  it("throws if the IdP does not return an ID token", async () => {
+    // This builds the fetch function holding the refresh token...
+    const refreshTokenOidcHandler = new RefreshTokenOidcHandler(
+      mockTokenRefresher({
+        access_token: "some access token",
+        expired: () => false,
+        claims: () => (null as unknown) as IdTokenClaims,
+      }),
+      mockStorageUtility({})
+    );
+    const result = refreshTokenOidcHandler.handle(
+      mockOidcOptions({
+        refreshToken: "some refresh token",
+        client: {
+          clientId: "some client id",
+          clientSecret: "some client secret",
+        },
+      })
+    );
+    await expect(result).rejects.toThrow(
+      "The Identity Provider did not return an ID token on refresh, which prevents from getting the user's WebID."
+    );
+  });
+
+  it("uses the rotated refresh token to build the authenticated fetch if applicable", async () => {
+    const tokenSet = mockDefaultTokenSet();
+    tokenSet.refresh_token = "some rotated refresh token";
+    const mockedTokenRefresher = mockTokenRefresher(tokenSet);
+    const mockedRefreshFunction = jest.spyOn(mockedTokenRefresher, "refresh");
+
+    // This builds the fetch function holding the refresh token...
+    const refreshTokenOidcHandler = new RefreshTokenOidcHandler(
+      mockedTokenRefresher,
+      mockStorageUtility({})
+    );
+    const result = await refreshTokenOidcHandler.handle(
+      mockOidcOptions({
+        refreshToken: "some refresh token",
+        client: {
+          clientId: "some client id",
+          clientSecret: "some client secret",
+        },
+      })
+    );
+    expect(result?.webId).toEqual("https://my.webid/");
+
+    const mockedFetch = jest.requireMock("cross-fetch");
+    mockedFetch.mockResolvedValue({
+      status: 401,
+      url: "https://my.pod/resource",
+    });
+    if (result !== undefined) {
+      // ... and this should trigger the refresh flow.
+      await result.fetch("https://some.pod/resource");
+    }
+    expect(mockedRefreshFunction.mock.calls[1]).toContain(
+      "some rotated refresh token"
+    );
   });
 });

--- a/packages/node/src/login/oidc/oidcHandlers/RefreshTokenOidcHandler.spec.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/RefreshTokenOidcHandler.spec.ts
@@ -311,4 +311,27 @@ describe("RefreshTokenOidcHandler", () => {
       "some rotated refresh token"
     );
   });
+
+  it("throws if the credentials are incorrect", async () => {
+    const tokenRefresher = mockTokenRefresher({
+      access_token: "some access token",
+      expired: () => false,
+      claims: () => (null as unknown) as IdTokenClaims,
+    });
+    tokenRefresher.refresh = jest.fn().mockRejectedValue("Invalid credentials");
+    const refreshTokenOidcHandler = new RefreshTokenOidcHandler(
+      tokenRefresher,
+      mockStorageUtility({})
+    );
+    const result = refreshTokenOidcHandler.handle(
+      mockOidcOptions({
+        refreshToken: "some refresh token",
+        client: {
+          clientId: "some client id",
+          clientSecret: "some client secret",
+        },
+      })
+    );
+    await expect(result).rejects.toThrow("Invalid credentials");
+  });
 });

--- a/packages/node/src/login/oidc/oidcHandlers/RefreshTokenOidcHandler.spec.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/RefreshTokenOidcHandler.spec.ts
@@ -272,7 +272,7 @@ describe("RefreshTokenOidcHandler", () => {
       })
     );
     await expect(result).rejects.toThrow(
-      "The Identity Provider [https://example.com] did not return an ID token on refresh, which prevents from getting the user's WebID."
+      "The Identity Provider [https://example.com] did not return an ID token on refresh, which prevents us from getting the user's WebID."
     );
   });
 

--- a/packages/node/src/login/oidc/oidcHandlers/RefreshTokenOidcHandler.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/RefreshTokenOidcHandler.ts
@@ -130,6 +130,15 @@ export default class RefreshTokenOidcHandler implements IOidcHandler {
       tokenRefresher: this.tokenRefresher,
     };
 
+    // This information must be in storage for the refresh flow to succeed.
+    await this.storageUtility.setForUser(oidcLoginOptions.sessionId, {
+      issuer: oidcLoginOptions.issuer,
+      dpop: oidcLoginOptions.dpop ? "true" : "false",
+      clientId: oidcLoginOptions.client.clientId,
+      // Note: We assume here that a client secret is present, which is checked for when validating the options.
+      clientSecret: oidcLoginOptions.client.clientSecret as string,
+    });
+
     const accessInfo = await refreshAccess(
       refreshOptions,
       oidcLoginOptions.dpop
@@ -155,11 +164,13 @@ export default class RefreshTokenOidcHandler implements IOidcHandler {
       "true",
       accessInfo.refresh_token ?? refreshOptions.refreshToken
     );
+
     await this.storageUtility.setForUser(oidcLoginOptions.sessionId, {
       issuer: oidcLoginOptions.issuer,
       dpop: oidcLoginOptions.dpop ? "true" : "false",
       clientId: oidcLoginOptions.client.clientId,
     });
+
     if (oidcLoginOptions.client.clientSecret) {
       await this.storageUtility.setForUser(oidcLoginOptions.sessionId, {
         clientSecret: oidcLoginOptions.client.clientSecret,

--- a/packages/node/src/login/oidc/oidcHandlers/RefreshTokenOidcHandler.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/RefreshTokenOidcHandler.ts
@@ -159,7 +159,7 @@ export default class RefreshTokenOidcHandler implements IOidcHandler {
 
     if (accessInfo.id_token === undefined) {
       throw new Error(
-        `The Identity Provider [${oidcLoginOptions.issuer}] did not return an ID token on refresh, which prevents from getting the user's WebID.`
+        `The Identity Provider [${oidcLoginOptions.issuer}] did not return an ID token on refresh, which prevents us from getting the user's WebID.`
       );
     }
     sessionInfo.webId = await getWebidFromTokenPayload(accessInfo.claims());

--- a/packages/node/src/login/oidc/oidcHandlers/RefreshTokenOidcHandler.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/RefreshTokenOidcHandler.ts
@@ -66,19 +66,24 @@ async function refreshAccess(
   // eslint-disable-next-line camelcase
   let tokens: TokenSet & { access_token: string };
   let dpopKey: JWK.ECKey;
-  if (dpop) {
-    dpopKey = await JWK.generate("EC", "P-256");
-    tokens = await refreshOptions.tokenRefresher.refresh(
-      refreshOptions.sessionId,
-      refreshOptions.refreshToken,
-      dpopKey
-    );
-  } else {
-    tokens = await refreshOptions.tokenRefresher.refresh(
-      refreshOptions.sessionId,
-      refreshOptions.refreshToken
-    );
+  try {
+    if (dpop) {
+      dpopKey = await JWK.generate("EC", "P-256");
+      tokens = await refreshOptions.tokenRefresher.refresh(
+        refreshOptions.sessionId,
+        refreshOptions.refreshToken,
+        dpopKey
+      );
+    } else {
+      tokens = await refreshOptions.tokenRefresher.refresh(
+        refreshOptions.sessionId,
+        refreshOptions.refreshToken
+      );
+    }
+  } catch (e) {
+    throw new Error(`Invalid refresh credentials: ${e.toString()}`);
   }
+
   // Rotate the refresh token if applicable
   const rotatedRefreshOptions = {
     ...refreshOptions,

--- a/packages/node/src/login/oidc/refresh/__mocks__/TokenRefresher.ts
+++ b/packages/node/src/login/oidc/refresh/__mocks__/TokenRefresher.ts
@@ -46,6 +46,7 @@ const mockIdTokenPayload = (): IdTokenClaims => {
 export const mockDefaultTokenSet = (): TokenSet & { access_token: string } => {
   return {
     access_token: "some refreshed access token",
+    id_token: JSON.stringify(mockIdTokenPayload()),
     expired: () => false,
     claims: mockIdTokenPayload,
   };


### PR DESCRIPTION
Instead of manually refreshing the token upfront, a lazy evaluation approach was previously implemented: the fetch function was provided an empty access token when logging in a script, additionnally to the refresh token and client credentials. On the first fetch, the absence of credentials returned 401, which triggered a regular refresh flow. Now, instead but instead of pretending we have an access token initially that will be discarded on the first use in order to get a proper access token, we just go through the refresh flow when logging in, which gets us both the access token that we give to the fetch, but also the ID token that gets us the WebID. Note that the access token isn't used in the refresh flow. The empty string was perviously just used to send a fetch that looks authenticated but gets rejected, and from then trigger the refresh flow.

This change is completely transparent to the user: in any case, you'll just call session.login . The fact that the access token is obtained at this point or on the first session.fetch is an implementation detail
The limitation of the previous approach was that the refresh flow only ever happened in the fetch closure, which prevented us from getting the WebID and attaching it to the session


- [X] All acceptance criteria are met.
- [x] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
