### PR TITLE
Attach WebID to session when logging in a script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased
 
-### New feature
+### Bugfix
+
+- The WebID is now REALLY set on the session when logging in a script. The initial 
+fix introduced in 1.2.1 did compute the WebID from the identity provider response,
+but did not set it properly on the session.
+
+The following sections document changes that have been released already:
 
 ## 1.2.1 - 2020-12-16
 

--- a/packages/node/src/ClientAuthentication.spec.ts
+++ b/packages/node/src/ClientAuthentication.spec.ts
@@ -85,6 +85,7 @@ describe("ClientAuthentication", () => {
         handle: jest.fn((_options: ILoginOptions) =>
           Promise.resolve(({
             fetch: mockedAuthFetch,
+            webId: "https://my.webid/",
           } as unknown) as LoginResult)
         ),
       };
@@ -97,6 +98,7 @@ describe("ClientAuthentication", () => {
         clientSecret: "some client secret",
       });
       expect(loginResult).not.toBeUndefined();
+      expect(loginResult?.webId).toEqual("https://my.webid/");
       expect(clientAuthn.fetch).toBe(mockedAuthFetch);
     });
 

--- a/packages/node/src/ClientAuthentication.ts
+++ b/packages/node/src/ClientAuthentication.ts
@@ -84,6 +84,7 @@ export default class ClientAuthentication {
       return {
         isLoggedIn: true,
         sessionId,
+        webId: loginReturn.webId,
       };
     }
     // undefined is returned in the case when the login must be completed

--- a/packages/node/src/Session.spec.ts
+++ b/packages/node/src/Session.spec.ts
@@ -90,11 +90,13 @@ describe("Session", () => {
       clientAuthentication.login = jest.fn().mockResolvedValueOnce({
         isLoggedIn: true,
         sessionId: "mySession",
+        webId: "https://my.webid/",
       });
       const mySession = new Session({ clientAuthentication });
       await mySession.login({});
       expect(mySession.info.isLoggedIn).toEqual(true);
       expect(mySession.info.sessionId).toEqual("mySession");
+      expect(mySession.info.webId).toEqual("https://my.webid/");
     });
   });
 

--- a/packages/node/src/Session.ts
+++ b/packages/node/src/Session.ts
@@ -131,6 +131,7 @@ export class Session extends EventEmitter {
     if (loginInfo !== undefined) {
       this.info.isLoggedIn = loginInfo.isLoggedIn;
       this.info.sessionId = loginInfo.sessionId;
+      this.info.webId = loginInfo.webId;
     }
   };
 

--- a/packages/node/src/e2e/e2e-test.spec.ts
+++ b/packages/node/src/e2e/e2e-test.spec.ts
@@ -35,6 +35,19 @@ describe("Environment", () => {
 });
 
 describe("Authenticated fetch", () => {
+  it("properly sets up session information", async () => {
+    const session = new Session();
+    await session.login({
+      clientId: process.env.CLIENT_ID,
+      clientSecret: process.env.CLIENT_SECRET,
+      refreshToken: process.env.REFRESH_TOKEN,
+      oidcIssuer: OIDC_ISSUER,
+    });
+    expect(session.info.isLoggedIn).toEqual(true);
+    expect(session.info.sessionId).not.toBeUndefined();
+    expect(session.info.webId).not.toBeUndefined();
+  });
+
   it("can fetch a public resource when logged in", async () => {
     const session = new Session();
     await session.login({

--- a/packages/node/src/login/oidc/oidcHandlers/RefreshTokenOidcHandler.spec.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/RefreshTokenOidcHandler.spec.ts
@@ -149,6 +149,7 @@ describe("RefreshTokenOidcHandler", () => {
         })
       );
       expect(result).not.toBeUndefined();
+      expect(result?.webId).toEqual("https://my.webid/");
 
       const mockedFetch = jest.requireMock("cross-fetch");
       mockedFetch.mockResolvedValue({


### PR DESCRIPTION
This fixes a bug where the WebID was not bubbled up from the login
handler to the session that called said handler, resulting in the WebID
being computed from the ID token, but never actually set on the session.

- [X] I've added a unit test to test for potential regressions of this bug.
- [X] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).