### PR TITLE
Fix/browser/parcel support

### DIFF
--- a/.codesandbox/sandbox/src/App.js
+++ b/.codesandbox/sandbox/src/App.js
@@ -1,21 +1,11 @@
 import React, { useState, useEffect } from "react";
-import {
-  Session as AuthSession,
-  getClientAuthenticationWithDependencies
-} from "@inrupt/solid-client-authn-browser";
+import { Session as AuthSession } from "@inrupt/solid-client-authn-browser";
 
 const REDIRECT_URL = window.location;
 
 export default function Home() {
   // eslint-disable-next-line
-  const [session, setSession] = useState(
-    new AuthSession(
-      {
-        clientAuthentication: getClientAuthenticationWithDependencies({})
-      },
-      "mySession"
-    )
-  );
+  const [session, _setSession] = useState(new AuthSession({}));
   const [issuer, setIssuer] = useState("https://broker.demo-ess.inrupt.com/");
   const [resource, setResource] = useState(session.info.webId);
   const [data, setData] = useState(null);
@@ -24,11 +14,9 @@ export default function Home() {
     const authCode = new URL(window.location.href).searchParams.get("code");
     if (authCode) {
       console.log("Being redirected from the IdP");
-      session
-        .handleIncomingRedirect(window.location.href)
-        .then((info) => {
-          setResource(info.webId);
-        });
+      session.handleIncomingRedirect(window.location.href).then((info) => {
+        setResource(info.webId);
+      });
     }
   }, [session]);
 
@@ -38,7 +26,7 @@ export default function Home() {
     e.preventDefault();
     session.login({
       redirectUrl: REDIRECT_URL,
-      oidcIssuer: issuer
+      oidcIssuer: issuer,
     });
   };
 

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -4,7 +4,8 @@
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index",
-  "browser": "dist/solid-client-authn.bundle.js",
+  "browser": "dist/index.js",
+  "bundle": "dist/solid-client-authn.bundle.js",
   "repository": {
     "url": "https://github.com/inrupt/solid-client-authn"
   },

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -4,6 +4,7 @@
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index",
+  "browser": "dist/solid-client-authn.bundle.js",
   "repository": {
     "url": "https://github.com/inrupt/solid-client-authn"
   },

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -4,7 +4,6 @@
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index",
-  "browser": "dist/solid-client-authn.bundle.js",
   "repository": {
     "url": "https://github.com/inrupt/solid-client-authn"
   },

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -2,7 +2,6 @@
   "name": "@inrupt/solid-client-authn-browser",
   "version": "1.2.2",
   "license": "MIT",
-  "main": "dist/index.js",
   "types": "dist/index",
   "browser": "dist/index.js",
   "bundle": "dist/solid-client-authn.bundle.js",


### PR DESCRIPTION
This PR tries to make sure Parcel can still deploy an app using solid-client-authn-browser.

- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).