### PR TITLE
Prepared CHANGELOG for release 1.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,12 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Bugfix
 
+The following sections document changes that have been released already:
+
+## 1.2.4 - 2020-12-17
+
 - `ajv` was imported through a dependency instead of being explicitly declared as
 a direct dependency of `solid-client-authn-core`
-
-The following sections document changes that have been released already:
 
 ## 1.2.3 - 2020-12-17
 

--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
   "packages": ["packages/*"],
-  "version": "1.2.3"
+  "version": "1.2.4"
 }

--- a/packages/browser/package-lock.json
+++ b/packages/browser/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/solid-client-authn-browser",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/solid-client-authn-browser",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "license": "MIT",
   "types": "dist/index",
   "browser": "dist/index.js",
@@ -64,8 +64,8 @@
     "webpack-merge": "^5.4.0"
   },
   "dependencies": {
-    "@inrupt/oidc-client-ext": "^1.2.3",
-    "@inrupt/solid-client-authn-core": "^1.2.3",
+    "@inrupt/oidc-client-ext": "^1.2.4",
+    "@inrupt/solid-client-authn-core": "^1.2.4",
     "@types/form-urlencoded": "^2.0.1",
     "@types/lodash.clonedeep": "^4.5.6",
     "@types/node": "^14.14.14",

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/solid-client-authn-core",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/solid-client-authn-core",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index",

--- a/packages/node/package-lock.json
+++ b/packages/node/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/solid-client-authn-node",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/solid-client-authn-node",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index",
@@ -30,7 +30,7 @@
     "typescript": "^4.0.5"
   },
   "dependencies": {
-    "@inrupt/solid-client-authn-core": "^1.2.3",
+    "@inrupt/solid-client-authn-core": "^1.2.4",
     "@types/node": "^14.14.14",
     "@types/uuid": "^8.3.0",
     "cross-fetch": "^3.0.6",

--- a/packages/oidc/package-lock.json
+++ b/packages/oidc/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/oidc-client-ext",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/oidc/package.json
+++ b/packages/oidc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/oidc-client-ext",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "A module extending oidc-client-js with new features, such as dynamic client registration and DPoP support.",
   "homepage": "https://github.com/inrupt/solid-client-authn-js/tree/master/packages/oidc/",
   "bugs": "https://github.com/inrupt/solid-client-authn-js/issues",


### PR DESCRIPTION
This PR bumps the version to 1.2.4

# Checklist

- [X] I used `lerna version <major|minor|patch> --no-push` to update the version number, first inspecting the CHANGELOG to determine if the release was major, minor or patch.
- [X] The CHANGELOG has been updated to show version and release date - https://keepachangelog.com/en/1.0.0/.
- [X] The **only** commits in this PR are:
  - the CHANGELOG update.
  - the version update.
- [ ] I will make sure **not** to squash these commits, but **rebase** instead.
- [ ] Once this PR is merged, I will push the tag created by `lerna version ...` (e.g. `git push origin vX.X.X`).
