### PR TITLE
Stores static clients when logging in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Bugfix
 
+- Credentials for statically registered clients weren't stored, which failed the token exchange.
+
 The following sections document changes that have been released already:
 
 ## 1.2.4 - 2020-12-17

--- a/packages/node/src/login/oidc/OidcLoginHandler.ts
+++ b/packages/node/src/login/oidc/OidcLoginHandler.ts
@@ -97,7 +97,21 @@ export default class OidcLoginHandler implements ILoginHandler {
       clientInfo = {
         clientId: options.clientId,
         clientSecret: options.clientSecret,
+        clientName: options.clientName,
       };
+      await this._storageUtility.setForUser(options.sessionId, {
+        clientId: options.clientId,
+      });
+      if (options.clientSecret) {
+        await this._storageUtility.setForUser(options.sessionId, {
+          clientSecret: options.clientSecret,
+        });
+      }
+      if (options.clientName) {
+        await this._storageUtility.setForUser(options.sessionId, {
+          clientName: options.clientName,
+        });
+      }
     } else {
       // If 'client_id' and 'client_secret' aren't specified in the options,
       // perform dynamic client registration.

--- a/packages/node/src/login/oidc/OidcLoginHandler.ts
+++ b/packages/node/src/login/oidc/OidcLoginHandler.ts
@@ -61,7 +61,7 @@ function hasIssuer(
 @injectable()
 export default class OidcLoginHandler implements ILoginHandler {
   constructor(
-    @inject("storageUtility") private _storageUtility: IStorageUtility,
+    @inject("storageUtility") private storageUtility: IStorageUtility,
     @inject("oidcHandler") private oidcHandler: IOidcHandler,
     @inject("issuerConfigFetcher")
     private issuerConfigFetcher: IIssuerConfigFetcher,
@@ -99,16 +99,16 @@ export default class OidcLoginHandler implements ILoginHandler {
         clientSecret: options.clientSecret,
         clientName: options.clientName,
       };
-      await this._storageUtility.setForUser(options.sessionId, {
+      await this.storageUtility.setForUser(options.sessionId, {
         clientId: options.clientId,
       });
       if (options.clientSecret) {
-        await this._storageUtility.setForUser(options.sessionId, {
+        await this.storageUtility.setForUser(options.sessionId, {
           clientSecret: options.clientSecret,
         });
       }
       if (options.clientName) {
-        await this._storageUtility.setForUser(options.sessionId, {
+        await this.storageUtility.setForUser(options.sessionId, {
           clientName: options.clientName,
         });
       }


### PR DESCRIPTION
Dynamically registering clients gets them stored in localStorage, ready
to be reused after redirection. It was not the case for statically
registered client credentials, which prevented the token exchange to
complete successfully. This resolves the issue, making it possible to
use statically registered clients.

- [X] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
