### PR TITLE
Docs top navbar

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "ts-loader": "^8.0.3",
     "tsc-watch": "^4.2.9",
     "typedoc": "^0.20.13",
-    "typedoc-plugin-markdown": "^3.0.7",
     "typescript": "^4.0.5",
     "webpack": "^5.3.2",
     "webpack-cli": "^4.1.0",

--- a/packages/browser/docs/api/_static/css/inrupt.css
+++ b/packages/browser/docs/api/_static/css/inrupt.css
@@ -205,8 +205,8 @@ p.topic-title {
 }
 
 .social-icon {
-  padding-left: 0.12rem;
-  padding-right: 0.12rem;
+  padding-left: 0.4rem;
+  padding-right: 0.4rem;
 }
 
 @media (min-width: 992px) {

--- a/packages/browser/docs/api/_static/css/inrupt.css
+++ b/packages/browser/docs/api/_static/css/inrupt.css
@@ -204,6 +204,11 @@ p.topic-title {
    color: #222222;
 }
 
+.social-icon {
+  padding-left: 0.12rem;
+  padding-right: 0.12rem;
+}
+
 @media (min-width: 992px) {
    .navbar-expand-lg .navbar-nav .nav-link {
       padding-right: 1rem;

--- a/packages/browser/docs/api/_templates/docs-navbar.html
+++ b/packages/browser/docs/api/_templates/docs-navbar.html
@@ -41,9 +41,9 @@
       {% endif %}
 
       <div class="social">
-         <a class="social-icon" href="https://twitter.com/inrupt" target="_blank" title="Twitter"><i class="fab fa-twitter-square" ></i></a>
-         <a class="social-icon" href="https://www.linkedin.com/company/inrupt/" target="_blank" title="LinkedIn"><i class="fab fa-linkedin" ></i></a>
-         <a class="social-icon" href="https://forum.solidproject.org/" target="_blank" title="Solid Forum"> <i class="fas fa-users"></i></a>
+         <a class="social-icon" href="https://twitter.com/inrupt" target="_blank" title="Inrupt on Twitter" aria-label="Inrupt on Twitter"><i class="fab fa-twitter-square" aria-hidden="true"></i></a>
+         <a class="social-icon" href="https://www.linkedin.com/company/inrupt/" target="_blank" title="Inrupt on LinkedIn" aria-label="Inrupt on LinkedIn"><i class="fab fa-linkedin" aria-hidden="true"></i></a>
+         <a class="social-icon" href="https://forum.solidproject.org/" target="_blank" title="Solid Forum" aria-label="Solid forum"> <i class="fas fa-users" aria-hidden="true"></i></a>
       </div>
 
     </div>

--- a/packages/browser/docs/api/_templates/docs-navbar.html
+++ b/packages/browser/docs/api/_templates/docs-navbar.html
@@ -12,6 +12,9 @@
     <div id="navbar-menu" class="col-lg-9 collapse navbar-collapse">
       <ul id="navbar-main-elements" class="navbar-nav mr-auto">
           <li class="nav-item">
+            <a class="nav-link" href="https://docs.inrupt.com/">Docs Home</a>
+          </li>
+          <li class="nav-item">
              <a class="nav-link" href="{{theme_ess_docs}}">Enterprise Solid Server</a>
           </li>
           <li class="nav-item"><a class="nav-link" href="#">Developer Tools</a>

--- a/packages/browser/docs/api/_templates/docs-navbar.html
+++ b/packages/browser/docs/api/_templates/docs-navbar.html
@@ -40,6 +40,11 @@
         {%- include "search-field.html" %}
       {% endif %}
 
-      
+      <div class="social">
+         <a class="social-icon" href="https://twitter.com/inrupt" target="_blank" title="Twitter"><i class="fab fa-twitter-square" ></i></a>
+         <a class="social-icon" href="https://www.linkedin.com/company/inrupt/" target="_blank" title="LinkedIn"><i class="fab fa-linkedin" ></i></a>
+         <a class="social-icon" href="https://forum.solidproject.org/" target="_blank" title="Solid Forum"> <i class="fas fa-users"></i></a>
+      </div>
+
     </div>
 </div>

--- a/packages/core/docs/api/_static/css/inrupt.css
+++ b/packages/core/docs/api/_static/css/inrupt.css
@@ -205,8 +205,8 @@ p.topic-title {
 }
 
 .social-icon {
-  padding-left: 0.12rem;
-  padding-right: 0.12rem;
+  padding-left: 0.4rem;
+  padding-right: 0.4rem;
 }
 
 @media (min-width: 992px) {

--- a/packages/core/docs/api/_static/css/inrupt.css
+++ b/packages/core/docs/api/_static/css/inrupt.css
@@ -204,6 +204,11 @@ p.topic-title {
    color: #222222;
 }
 
+.social-icon {
+  padding-left: 0.12rem;
+  padding-right: 0.12rem;
+}
+
 @media (min-width: 992px) {
    .navbar-expand-lg .navbar-nav .nav-link {
       padding-right: 1rem;

--- a/packages/core/docs/api/_templates/docs-navbar.html
+++ b/packages/core/docs/api/_templates/docs-navbar.html
@@ -41,9 +41,9 @@
       {% endif %}
 
       <div class="social">
-         <a class="social-icon" href="https://twitter.com/inrupt" target="_blank" title="Twitter"><i class="fab fa-twitter-square" ></i></a>
-         <a class="social-icon" href="https://www.linkedin.com/company/inrupt/" target="_blank" title="LinkedIn"><i class="fab fa-linkedin" ></i></a>
-         <a class="social-icon" href="https://forum.solidproject.org/" target="_blank" title="Solid Forum"> <i class="fas fa-users"></i></a>
+         <a class="social-icon" href="https://twitter.com/inrupt" target="_blank" title="Inrupt on Twitter" aria-label="Inrupt on Twitter"><i class="fab fa-twitter-square" aria-hidden="true"></i></a>
+         <a class="social-icon" href="https://www.linkedin.com/company/inrupt/" target="_blank" title="Inrupt on LinkedIn" aria-label="Inrupt on LinkedIn"><i class="fab fa-linkedin" aria-hidden="true"></i></a>
+         <a class="social-icon" href="https://forum.solidproject.org/" target="_blank" title="Solid Forum" aria-label="Solid forum"> <i class="fas fa-users" aria-hidden="true"></i></a>
       </div>
 
     </div>

--- a/packages/core/docs/api/_templates/docs-navbar.html
+++ b/packages/core/docs/api/_templates/docs-navbar.html
@@ -12,6 +12,9 @@
     <div id="navbar-menu" class="col-lg-9 collapse navbar-collapse">
       <ul id="navbar-main-elements" class="navbar-nav mr-auto">
           <li class="nav-item">
+            <a class="nav-link" href="https://docs.inrupt.com/">Docs Home</a>
+          </li>
+          <li class="nav-item">
              <a class="nav-link" href="{{theme_ess_docs}}">Enterprise Solid Server</a>
           </li>
           <li class="nav-item"><a class="nav-link" href="#">Developer Tools</a>

--- a/packages/core/docs/api/_templates/docs-navbar.html
+++ b/packages/core/docs/api/_templates/docs-navbar.html
@@ -40,6 +40,11 @@
         {%- include "search-field.html" %}
       {% endif %}
 
-      
+      <div class="social">
+         <a class="social-icon" href="https://twitter.com/inrupt" target="_blank" title="Twitter"><i class="fab fa-twitter-square" ></i></a>
+         <a class="social-icon" href="https://www.linkedin.com/company/inrupt/" target="_blank" title="LinkedIn"><i class="fab fa-linkedin" ></i></a>
+         <a class="social-icon" href="https://forum.solidproject.org/" target="_blank" title="Solid Forum"> <i class="fas fa-users"></i></a>
+      </div>
+
     </div>
 </div>

--- a/packages/node/docs/api/_static/css/inrupt.css
+++ b/packages/node/docs/api/_static/css/inrupt.css
@@ -205,8 +205,8 @@ p.topic-title {
 }
 
 .social-icon {
-  padding-left: 0.12rem;
-  padding-right: 0.12rem;
+  padding-left: 0.4rem;
+  padding-right: 0.4rem;
 }
 
 @media (min-width: 992px) {

--- a/packages/node/docs/api/_static/css/inrupt.css
+++ b/packages/node/docs/api/_static/css/inrupt.css
@@ -204,6 +204,11 @@ p.topic-title {
    color: #222222;
 }
 
+.social-icon {
+  padding-left: 0.12rem;
+  padding-right: 0.12rem;
+}
+
 @media (min-width: 992px) {
    .navbar-expand-lg .navbar-nav .nav-link {
       padding-right: 1rem;

--- a/packages/node/docs/api/_templates/docs-navbar.html
+++ b/packages/node/docs/api/_templates/docs-navbar.html
@@ -41,9 +41,9 @@
       {% endif %}
 
       <div class="social">
-         <a class="social-icon" href="https://twitter.com/inrupt" target="_blank" title="Twitter"><i class="fab fa-twitter-square" ></i></a>
-         <a class="social-icon" href="https://www.linkedin.com/company/inrupt/" target="_blank" title="LinkedIn"><i class="fab fa-linkedin" ></i></a>
-         <a class="social-icon" href="https://forum.solidproject.org/" target="_blank" title="Solid Forum"> <i class="fas fa-users"></i></a>
+         <a class="social-icon" href="https://twitter.com/inrupt" target="_blank" title="Inrupt on Twitter" aria-label="Inrupt on Twitter"><i class="fab fa-twitter-square" aria-hidden="true"></i></a>
+         <a class="social-icon" href="https://www.linkedin.com/company/inrupt/" target="_blank" title="Inrupt on LinkedIn" aria-label="Inrupt on LinkedIn"><i class="fab fa-linkedin" aria-hidden="true"></i></a>
+         <a class="social-icon" href="https://forum.solidproject.org/" target="_blank" title="Solid Forum" aria-label="Solid forum"> <i class="fas fa-users" aria-hidden="true"></i></a>
       </div>
       
     </div>

--- a/packages/node/docs/api/_templates/docs-navbar.html
+++ b/packages/node/docs/api/_templates/docs-navbar.html
@@ -12,6 +12,9 @@
     <div id="navbar-menu" class="col-lg-9 collapse navbar-collapse">
       <ul id="navbar-main-elements" class="navbar-nav mr-auto">
           <li class="nav-item">
+            <a class="nav-link" href="https://docs.inrupt.com/">Docs Home</a>
+          </li>
+          <li class="nav-item">
              <a class="nav-link" href="{{theme_ess_docs}}">Enterprise Solid Server</a>
           </li>
           <li class="nav-item"><a class="nav-link" href="#">Developer Tools</a>

--- a/packages/node/docs/api/_templates/docs-navbar.html
+++ b/packages/node/docs/api/_templates/docs-navbar.html
@@ -40,6 +40,11 @@
         {%- include "search-field.html" %}
       {% endif %}
 
+      <div class="social">
+         <a class="social-icon" href="https://twitter.com/inrupt" target="_blank" title="Twitter"><i class="fab fa-twitter-square" ></i></a>
+         <a class="social-icon" href="https://www.linkedin.com/company/inrupt/" target="_blank" title="LinkedIn"><i class="fab fa-linkedin" ></i></a>
+         <a class="social-icon" href="https://forum.solidproject.org/" target="_blank" title="Solid Forum"> <i class="fas fa-users"></i></a>
+      </div>
       
     </div>
 </div>


### PR DESCRIPTION
- Commit 1: Adds link to docs home on top nav bar
- Commit 2: Adds social icon links to top nav bar
- Commit 3: rm typedoc-plugin-markdown from top-level packages.json. Its version ("^3.0.7") conflicted with that in the packages.json in the core|browser|node directories ("^3.1.0") and caused typedoc to error).

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
