### PR TITLE
Remove depdendency on existing data in e2e tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,11 +31,11 @@ jobs:
       - run: npm run test
       - run: npm run e2e-test
         env: 
-          REFRESH_TOKEN: ${{ secrets.REFRESH_TOKEN }}
-          CLIENT_ID: ${{ secrets.CLIENT_ID }}
-          CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
-          OIDC_ISSUER: ${{ secrets.OIDC_ISSUER }}
-          POD_ROOT: ${{ secrets.POD_ROOT }}
+          E2E_TEST_REFRESH_TOKEN: ${{ secrets.E2E_TEST_REFRESH_TOKEN }}
+          E2E_TEST_CLIENT_ID: ${{ secrets.E2E_TEST_CLIENT_ID }}
+          E2E_TEST_CLIENT_SECRET: ${{ secrets.E2E_TEST_CLIENT_SECRET }}
+          E2E_TEST_IDP_URL: ${{ secrets.E2E_TEST_IDP_URL }}
+          E2E_TEST_ESS_POD: ${{ secrets.E2E_TEST_ESS_POD }}
       - run: npx prettier --check "{packages/*/src,packages/*/__tests__}/**"
       - run: npm audit --audit-level=moderate
       - name: Archive code coverage results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,8 @@ jobs:
           REFRESH_TOKEN: ${{ secrets.REFRESH_TOKEN }}
           CLIENT_ID: ${{ secrets.CLIENT_ID }}
           CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
+          OIDC_ISSUER: ${{ secrets.OIDC_ISSUER }}
+          POD_ROOT: ${{ secrets.POD_ROOT }}
       - run: npx prettier --check "{packages/*/src,packages/*/__tests__}/**"
       - run: npm audit --audit-level=moderate
       - name: Archive code coverage results

--- a/packages/node/src/e2e/e2e-test.spec.ts
+++ b/packages/node/src/e2e/e2e-test.spec.ts
@@ -22,15 +22,14 @@
 import { it, describe } from "@jest/globals";
 import { Session } from "../Session";
 
-const OIDC_ISSUER = "https://broker.demo-ess.inrupt.com/";
-
 // This first test just saves the trouble of looking for a library failure when
 // the environment wasn't properly set.
 describe("Environment", () => {
   it("contains the expected environment variables", () => {
-    expect(process.env.REFRESH_TOKEN).not.toBeUndefined();
-    expect(process.env.CLIENT_ID).not.toBeUndefined();
-    expect(process.env.CLIENT_SECRET).not.toBeUndefined();
+    expect(process.env.E2E_TEST_REFRESH_TOKEN).not.toBeUndefined();
+    expect(process.env.E2E_TEST_CLIENT_ID).not.toBeUndefined();
+    expect(process.env.E2E_TEST_CLIENT_SECRET).not.toBeUndefined();
+    expect(process.env.E2E_TEST_IDP_URL).not.toBeUndefined();
   });
 });
 
@@ -38,10 +37,10 @@ describe("Authenticated fetch", () => {
   it("properly sets up session information", async () => {
     const session = new Session();
     await session.login({
-      clientId: process.env.CLIENT_ID,
-      clientSecret: process.env.CLIENT_SECRET,
-      refreshToken: process.env.REFRESH_TOKEN,
-      oidcIssuer: OIDC_ISSUER,
+      clientId: process.env.E2E_TEST_CLIENT_ID,
+      clientSecret: process.env.E2E_TEST_CLIENT_SECRET,
+      refreshToken: process.env.E2E_TEST_REFRESH_TOKEN,
+      oidcIssuer: process.env.E2E_TEST_IDP_URL,
     });
     expect(session.info.isLoggedIn).toEqual(true);
     expect(session.info.sessionId).not.toBeUndefined();
@@ -51,10 +50,10 @@ describe("Authenticated fetch", () => {
   it("can fetch a public resource when logged in", async () => {
     const session = new Session();
     await session.login({
-      clientId: process.env.CLIENT_ID,
-      clientSecret: process.env.CLIENT_SECRET,
-      refreshToken: process.env.REFRESH_TOKEN,
-      oidcIssuer: OIDC_ISSUER,
+      clientId: process.env.E2E_TEST_CLIENT_ID,
+      clientSecret: process.env.E2E_TEST_CLIENT_SECRET,
+      refreshToken: process.env.E2E_TEST_REFRESH_TOKEN,
+      oidcIssuer: process.env.E2E_TEST_IDP_URL,
     });
     const publicResourceUrl = session.info.webId!;
     const response = await session.fetch(publicResourceUrl);
@@ -67,12 +66,12 @@ describe("Authenticated fetch", () => {
   it("can fetch a private resource when logged in", async () => {
     const session = new Session();
     await session.login({
-      clientId: process.env.CLIENT_ID,
-      clientSecret: process.env.CLIENT_SECRET,
-      refreshToken: process.env.REFRESH_TOKEN,
-      oidcIssuer: OIDC_ISSUER,
+      clientId: process.env.E2E_TEST_CLIENT_ID,
+      clientSecret: process.env.E2E_TEST_CLIENT_SECRET,
+      refreshToken: process.env.E2E_TEST_REFRESH_TOKEN,
+      oidcIssuer: process.env.E2E_TEST_IDP_URL,
     });
-    const privateResourceUrl = process.env.POD_ROOT!;
+    const privateResourceUrl = process.env.E2E_TEST_ESS_POD!;
     const response = await session.fetch(privateResourceUrl);
     expect(response.status).toEqual(200);
     await expect(response.text()).resolves.toContain("ldp:BasicContainer");
@@ -80,15 +79,15 @@ describe("Authenticated fetch", () => {
 
   it("can fetch a private resource when logged in after the same fetch failed", async () => {
     const session = new Session();
-    const privateResourceUrl = process.env.POD_ROOT!;
+    const privateResourceUrl = process.env.E2E_TEST_ESS_POD!;
     let response = await session.fetch(privateResourceUrl);
     expect(response.status).toEqual(401);
 
     await session.login({
-      clientId: process.env.CLIENT_ID,
-      clientSecret: process.env.CLIENT_SECRET,
-      refreshToken: process.env.REFRESH_TOKEN,
-      oidcIssuer: OIDC_ISSUER,
+      clientId: process.env.E2E_TEST_CLIENT_ID,
+      clientSecret: process.env.E2E_TEST_CLIENT_SECRET,
+      refreshToken: process.env.E2E_TEST_REFRESH_TOKEN,
+      oidcIssuer: process.env.E2E_TEST_IDP_URL,
     });
 
     response = await session.fetch(privateResourceUrl);
@@ -101,13 +100,13 @@ describe("Authenticated fetch", () => {
 
   it("only logs in the requested session", async () => {
     const authenticatedSession = new Session();
-    const privateResourceUrl = process.env.POD_ROOT!;
+    const privateResourceUrl = process.env.E2E_TEST_ESS_POD!;
 
     await authenticatedSession.login({
-      clientId: process.env.CLIENT_ID,
-      clientSecret: process.env.CLIENT_SECRET,
-      refreshToken: process.env.REFRESH_TOKEN,
-      oidcIssuer: OIDC_ISSUER,
+      clientId: process.env.E2E_TEST_CLIENT_ID,
+      clientSecret: process.env.E2E_TEST_CLIENT_SECRET,
+      refreshToken: process.env.E2E_TEST_REFRESH_TOKEN,
+      oidcIssuer: process.env.E2E_TEST_IDP_URL,
     });
 
     let response = await authenticatedSession.fetch(privateResourceUrl);
@@ -123,10 +122,10 @@ describe("Unauthenticated fetch", () => {
   it("can fetch a public resource when not logged in", async () => {
     const authenticatedSession = new Session();
     await authenticatedSession.login({
-      clientId: process.env.CLIENT_ID,
-      clientSecret: process.env.CLIENT_SECRET,
-      refreshToken: process.env.REFRESH_TOKEN,
-      oidcIssuer: process.env.OIDC_ISSUER,
+      clientId: process.env.E2E_TEST_CLIENT_ID,
+      clientSecret: process.env.E2E_TEST_CLIENT_SECRET,
+      refreshToken: process.env.E2E_TEST_REFRESH_TOKEN,
+      oidcIssuer: process.env.E2E_TEST_IDP_URL,
     });
     const publicResourceUrl = authenticatedSession.info.webId!;
 
@@ -140,7 +139,7 @@ describe("Unauthenticated fetch", () => {
 
   it("cannot fetch a private resource when not logged in", async () => {
     const session = new Session();
-    const privateResourceUrl = process.env.POD_ROOT!;
+    const privateResourceUrl = process.env.E2E_TEST_ESS_POD!;
     const response = await session.fetch(privateResourceUrl);
     expect(response.status).toEqual(401);
   });
@@ -150,10 +149,10 @@ describe("Post-logout fetch", () => {
   it("can fetch a public resource after logging out", async () => {
     const session = new Session();
     await session.login({
-      clientId: process.env.CLIENT_ID,
-      clientSecret: process.env.CLIENT_SECRET,
-      refreshToken: process.env.REFRESH_TOKEN,
-      oidcIssuer: OIDC_ISSUER,
+      clientId: process.env.E2E_TEST_CLIENT_ID,
+      clientSecret: process.env.E2E_TEST_CLIENT_SECRET,
+      refreshToken: process.env.E2E_TEST_REFRESH_TOKEN,
+      oidcIssuer: process.env.E2E_TEST_IDP_URL,
     });
     const publicResourceUrl = session.info.webId!;
     await session.logout();
@@ -166,12 +165,12 @@ describe("Post-logout fetch", () => {
 
   it("cannot fetch a private resource after logging out", async () => {
     const session = new Session();
-    const privateResourceUrl = process.env.POD_ROOT!;
+    const privateResourceUrl = process.env.E2E_TEST_ESS_POD!;
     await session.login({
-      clientId: process.env.CLIENT_ID,
-      clientSecret: process.env.CLIENT_SECRET,
-      refreshToken: process.env.REFRESH_TOKEN,
-      oidcIssuer: OIDC_ISSUER,
+      clientId: process.env.E2E_TEST_CLIENT_ID,
+      clientSecret: process.env.E2E_TEST_CLIENT_SECRET,
+      refreshToken: process.env.E2E_TEST_REFRESH_TOKEN,
+      oidcIssuer: process.env.E2E_TEST_IDP_URL,
     });
     await session.logout();
     const response = await session.fetch(privateResourceUrl);


### PR DESCRIPTION
The end-to-end tests attempt to fetch both public and private
Resources, and depended on a Pod being pre-initialised with known
access permissions.

To make the tests work with any Pod for which the credentials are
provided, we now use the Pod's WebID document as a public resource
(as that is required by the Solid spec to be public), and the Pod
root as a private resource (as that will always exist and usually
not be initialised to be public).

With that, the tests now also run against the production instance of ESS. I've currently used the same credentials as used for the solid-client end-to-end tests, but those can be changed at any time in the environment variables.

I've also aligned the names of the environment variables with those in solid-client. I'll remove the old ones (`CLIENT_ID`, `CLIENT_SECRET` and `REFRESH_TOKEN`) when this is merged.