### PR TITLE
Do not auto-updated individual Lerna packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,26 +14,6 @@ updates:
       interval: daily
     open-pull-requests-limit: 10
   - package-ecosystem: npm
-    directory: "/packages/browser"
-    schedule:
-      interval: daily
-    open-pull-requests-limit: 10
-  - package-ecosystem: npm
-    directory: "/packages/node"
-    schedule:
-      interval: daily
-    open-pull-requests-limit: 10
-  - package-ecosystem: npm
-    directory: "/packages/core"
-    schedule:
-      interval: daily
-    open-pull-requests-limit: 10
-  - package-ecosystem: npm
-    directory: "/packages/oidc"
-    schedule:
-      interval: daily
-    open-pull-requests-limit: 10
-  - package-ecosystem: npm
     directory: "/packages/browser/examples/multi/bundle"
     schedule:
       interval: daily


### PR DESCRIPTION
According to [1], Dependabot will automatically recognise Lerna
projects and update all its dependencies in one go. This should
significantly cut down on the noise of four different pull requests
when a shared dependency releases a new version. And since issues
caused by a dependency upgrade are probably similar across the
different packages, it probably makes sense to fix them together as
well.

Question: what do you think about also removing the examples from Dependabot? Since we're not running automated tests against them, we're not verifying whether the updated dependencies actually work, so the automated updates are more performative than anything. Alternatives would be just not updating dependencies (to make sure they keep working), or removing the lock file (to make it clear that up-to-date dependencies are untested).

[1] https://dependabot.com/blog/lerna-support/
