### PR TITLE
Add "main" entry back to package.json for browser package

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -4,6 +4,7 @@
   "license": "MIT",
   "types": "dist/index",
   "browser": "dist/index.js",
+  "main": "dist/index.js",
   "bundle": "dist/solid-client-authn.bundle.js",
   "repository": {
     "url": "https://github.com/inrupt/solid-client-authn"


### PR DESCRIPTION
#818 removed the main entry, which causes jest tests that use the browser package to fail. This re-adds the main entry.