### PR TITLE
Remove non-user-facing feature from changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,6 @@ The following sections document changes that have been released already:
 
 - Adds "main" entry to browser packages
 
-### Feature
-
-- Adds .env file loading for credentials, for node package
-
 ## 1.2.5 - 2020-12-17
 
 ### Bugfix


### PR DESCRIPTION
The loading of environment variables is only used for our own
end-to-end tests, to ease running them locally when having checked
out our source code. It does not affect usage of the library.
