### PR TITLE
Verify that importing from the published package works

### DIFF
--- a/.github/workflows/cd-packaging-tests/bundler-parcel/index.ts
+++ b/.github/workflows/cd-packaging-tests/bundler-parcel/index.ts
@@ -1,0 +1,9 @@
+import { Session } from "@inrupt/solid-client-authn-browser";
+
+const session = new Session();
+console.log(session.info.sessionId);
+
+session.fetch("https://example.com").then(async (response) => {
+  const textContent = await response.text();
+  console.log("Fetched example.com:", textContent);
+});

--- a/.github/workflows/cd-packaging-tests/bundler-parcel/package.json
+++ b/.github/workflows/cd-packaging-tests/bundler-parcel/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "cd-packaging-test-parcel",
+  "private": true
+}

--- a/.github/workflows/cd-packaging-tests/bundler-webpack/package.json
+++ b/.github/workflows/cd-packaging-tests/bundler-webpack/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "cd-packaging-test-webpack",
+  "private": true
+}

--- a/.github/workflows/cd-packaging-tests/bundler-webpack/src/index.js
+++ b/.github/workflows/cd-packaging-tests/bundler-webpack/src/index.js
@@ -1,0 +1,10 @@
+// Verify that imports from the main export work:
+import { Session } from "@inrupt/solid-client-authn-browser";
+
+const session = new Session();
+console.log(session.info.sessionId);
+
+session.fetch("https://example.com").then(async (response) => {
+  const textContent = await response.text();
+  console.log("Fetched example.com:", textContent);
+});

--- a/.github/workflows/cd-packaging-tests/bundler-webpack/webpack.config.js
+++ b/.github/workflows/cd-packaging-tests/bundler-webpack/webpack.config.js
@@ -1,0 +1,11 @@
+// It should be possible to delete this file once solid-client-authn-browser has switched to jose@3:
+module.exports = {
+  resolve: {
+    fallback: {
+      crypto: require.resolve("crypto-browserify"),
+      stream: require.resolve("stream-browserify"),
+      util: require.resolve("util/"),
+      buffer: require.resolve("buffer/"),
+    },
+  },
+};

--- a/.github/workflows/cd-packaging-tests/node/commonjs.cjs
+++ b/.github/workflows/cd-packaging-tests/node/commonjs.cjs
@@ -1,0 +1,9 @@
+const { Session } = require("@inrupt/solid-client-authn-node");
+
+const session = new Session();
+console.log(session.info.sessionId);
+
+session.fetch("https://example.com").then(async (response) => {
+  const textContent = await response.text();
+  console.log("Fetched example.com:", textContent);
+});

--- a/.github/workflows/cd-packaging-tests/node/esmodule.mjs
+++ b/.github/workflows/cd-packaging-tests/node/esmodule.mjs
@@ -1,0 +1,10 @@
+// Verify that imports from the main export work:
+import { Session } from "@inrupt/solid-client-authn-node";
+
+const session = new Session();
+console.log(session.info.sessionId);
+
+session.fetch("https://example.com").then(async (response) => {
+  const textContent = await response.text();
+  console.log("Fetched example.com:", textContent);
+});

--- a/.github/workflows/cd-packaging-tests/node/package.json
+++ b/.github/workflows/cd-packaging-tests/node/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "cd-packaging-test-node",
+  "private": true
+}

--- a/.github/workflows/cd-preview.yml
+++ b/.github/workflows/cd-preview.yml
@@ -11,6 +11,8 @@ jobs:
   dev-release-npm:
     name: "NPM release under a dev tag"
     runs-on: ubuntu-18.04
+    outputs:
+      version-nr: ${{ steps.determine-npm-version.outputs.version-nr }}
     steps:
       - uses: actions/checkout@v2.3.4
       - name: Prepare for publication to GitHub Packages
@@ -24,6 +26,7 @@ jobs:
         run: echo "TAG_SLUG=$(echo ${GITHUB_REF#refs/heads/} | tr -cd '[:alnum:]-')" >> $GITHUB_ENV
       - run: npm ci
       - name: Prepare prerelease version
+        id: determine-npm-version
         run: |
           git config user.name $GITHUB_ACTOR
           git config user.email gh-actions-${GITHUB_ACTOR}@github.com
@@ -33,6 +36,10 @@ jobs:
           TIMESTAMP=$(date --utc +%s)
           # Make sure the prerelease is tagged with the branch name, and that they are sorted by build:
           npm run version -- prerelease --preid=$TAG_SLUG-$GITHUB_RUN_ID-$GITHUB_RUN_NUMBER-$TIMESTAMP --yes --no-push --exact
+          # Read the "version" key from one of our packages to determine the exact version nr
+          # the prerelease was published under:
+          VERSION_NR=$(cat packages/browser/package.json | npx json version)
+          echo "::set-output name=version-nr::$VERSION_NR"
       - run: npm run build
       - run: npm run publish-preview -- --dist-tag "$TAG_SLUG" --yes
         env:
@@ -41,3 +48,87 @@ jobs:
           echo "Package published. To install, run:"
           echo ""
           echo "    npm install @inrupt/solid-client-authn-browser@$TAG_SLUG"
+          echo ""
+          echo "or"
+          echo ""
+          echo "    npm install @inrupt/solid-client-authn-node@$TAG_SLUG"
+      - name: Waiting for npm CDNs to update...
+        run: |
+          echo "Giving npm some time to make the newly-published package available…"
+          sleep 5m
+          echo "Done — hopefully that was enough time for the follow-up jobs to install the just-published package, to verify that everything looks OK."
+
+  verify-imports-node:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        node-version: [14.x, 12.x, 10.x]
+    needs: [dev-release-npm]
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - uses: actions/setup-node@v2.1.4
+        with:
+          node-version: ${{ matrix.node-version }}
+          registry-url: 'https://registry.npmjs.org'
+      - name: Install the preview release of solid-client-authn-node in the packaging test project
+        run: |
+          cd .github/workflows/cd-packaging-tests/node
+          npm install @inrupt/solid-client-authn-node@$VERSION_NR
+        env:
+          VERSION_NR: ${{ needs.dev-release-npm.outputs.version-nr }}
+      - name: Verify that the package can be imported in Node from a CommonJS module
+        run: |
+          cd .github/workflows/cd-packaging-tests/node
+          node --unhandled-rejections=strict commonjs.cjs
+      - name: Verify that the package can be imported in Node from an ES module
+        run: |
+          cd .github/workflows/cd-packaging-tests/node
+          node --unhandled-rejections=strict esmodule.mjs
+        # Node 10 does not support ES modules:
+        if: matrix.node-version != '10.x'
+
+
+  verify-imports-parcel:
+    runs-on: ubuntu-20.04
+    needs: [dev-release-npm]
+    steps:
+    - uses: actions/checkout@v2.3.4
+    - uses: actions/setup-node@v2.1.4
+      with:
+        node-version: '14.x'
+        registry-url: 'https://registry.npmjs.org'
+    - name: Verify that the package can be imported in a Parcel project
+      run: |
+        cd .github/workflows/cd-packaging-tests/bundler-parcel
+        npm install @inrupt/solid-client-authn-browser@$VERSION_NR
+        npx parcel build index.ts
+      env:
+        VERSION_NR: ${{ needs.dev-release-npm.outputs.version-nr }}
+    - name: Archive Parcel build artifacts
+      uses: actions/upload-artifact@v2.2.1
+      with:
+        name: parcel-dist
+        path: .github/workflows/cd-packaging-tests/bundler-parcel/dist
+
+  verify-imports-webpack:
+    runs-on: ubuntu-20.04
+    needs: [dev-release-npm]
+    steps:
+    - uses: actions/checkout@v2.3.4
+    - uses: actions/setup-node@v2.1.4
+      with:
+        node-version: '14.x'
+        registry-url: 'https://registry.npmjs.org'
+    - name: Verify that the package can be imported in a Webpack project
+      run: |
+        cd .github/workflows/cd-packaging-tests/bundler-webpack
+        npm install @inrupt/solid-client-authn-browser@$VERSION_NR
+        npm install webpack@5 webpack-cli buffer crypto-browserify stream-browserify util
+        npx webpack --devtool source-map
+      env:
+        VERSION_NR: ${{ needs.dev-release-npm.outputs.version-nr }}
+    - name: Archive Webpack build artifacts
+      uses: actions/upload-artifact@v2.2.1
+      with:
+        name: webpack-dist
+        path: .github/workflows/cd-packaging-tests/bundler-webpack/dist

--- a/.github/workflows/cd-release.yml
+++ b/.github/workflows/cd-release.yml
@@ -98,3 +98,72 @@ jobs:
           state: failure
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+  verify-imports-node:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        node-version: [14.x, 12.x, 10.x]
+    needs: [publish-npm]
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - uses: actions/setup-node@v2.1.4
+        with:
+          node-version: ${{ matrix.node-version }}
+          registry-url: 'https://registry.npmjs.org'
+      - name: Install the preview release of solid-client-authn-node in the packaging test project
+        run: |
+          cd .github/workflows/cd-packaging-tests/node
+          npm install @inrupt/solid-client-authn-node
+      - name: Verify that the package can be imported in Node from a CommonJS module
+        run: |
+          cd .github/workflows/cd-packaging-tests/node
+          node --unhandled-rejections=strict commonjs.cjs
+      - name: Verify that the package can be imported in Node from an ES module
+        run: |
+          cd .github/workflows/cd-packaging-tests/node
+          node --unhandled-rejections=strict esmodule.mjs
+        # Node 10 does not support ES modules:
+        if: matrix.node-version != '10.x'
+
+
+  verify-imports-parcel:
+    runs-on: ubuntu-20.04
+    needs: [publish-npm]
+    steps:
+    - uses: actions/checkout@v2.3.4
+    - uses: actions/setup-node@v2.1.4
+      with:
+        node-version: '14.x'
+        registry-url: 'https://registry.npmjs.org'
+    - name: Verify that the package can be imported in a Parcel project
+      run: |
+        cd .github/workflows/cd-packaging-tests/bundler-parcel
+        npm install @inrupt/solid-client-authn-browser
+        npx parcel build index.ts
+    - name: Archive Parcel build artifacts
+      uses: actions/upload-artifact@v2.2.1
+      with:
+        name: parcel-dist
+        path: .github/workflows/cd-packaging-tests/bundler-parcel/dist
+
+  verify-imports-webpack:
+    runs-on: ubuntu-20.04
+    needs: [publish-npm]
+    steps:
+    - uses: actions/checkout@v2.3.4
+    - uses: actions/setup-node@v2.1.4
+      with:
+        node-version: '14.x'
+        registry-url: 'https://registry.npmjs.org'
+    - name: Verify that the package can be imported in a Webpack project
+      run: |
+        cd .github/workflows/cd-packaging-tests/bundler-webpack
+        npm install @inrupt/solid-client-authn-browser
+        npm install webpack@5 webpack-cli buffer
+        npx webpack --devtool source-map
+    - name: Archive Webpack build artifacts
+      uses: actions/upload-artifact@v2.2.1
+      with:
+        name: webpack-dist
+        path: .github/workflows/cd-packaging-tests/bundler-webpack/dist


### PR DESCRIPTION
This adds some barebones Parcel, Webpack and Node (both CommonJS and ES Module versions) projects that try to import from SCAB and SCAN, respectively. Building/running those, respectively, should fail if the JS files are not at the right location or not listed correctly, hopefully catching a bunch of potential bugs arising from the packaging process.