### PR TITLE
Add standalone versions of Session methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,14 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased
 
-N/A
+### New feature
+
+- Although still possible, it is now no longer required to manually instantiate
+a new `Session` object when using `solid-client-authn-browser`. Instead, you can
+directly import `fetch`, `login`, `logout` and `handleIncomingRedirect`,
+which will instantiate a new Session implicitly behind the scenes. If you do
+need access to this Session, you can do so using the new function
+`getDefaultSession`.
 
 The following sections document changes that have been released already:
 

--- a/packages/browser/__tests__/Session.spec.ts
+++ b/packages/browser/__tests__/Session.spec.ts
@@ -82,6 +82,17 @@ describe("Session", () => {
       await mySession.login({});
       expect(clientAuthnLogin).toHaveBeenCalled();
     });
+
+    it("preserves a binding to its Session instance", async () => {
+      const clientAuthentication = mockClientAuthentication();
+      const clientAuthnLogin = jest.spyOn(clientAuthentication, "login");
+      const mySession = new Session({ clientAuthentication });
+      const objectWithLogin = {
+        login: mySession.login,
+      };
+      await objectWithLogin.login({});
+      expect(clientAuthnLogin).toHaveBeenCalled();
+    });
   });
 
   describe("logout", () => {
@@ -90,6 +101,17 @@ describe("Session", () => {
       const clientAuthnLogout = jest.spyOn(clientAuthentication, "logout");
       const mySession = new Session({ clientAuthentication });
       await mySession.logout();
+      expect(clientAuthnLogout).toHaveBeenCalled();
+    });
+
+    it("preserves a binding to its Session instance", async () => {
+      const clientAuthentication = mockClientAuthentication();
+      const clientAuthnLogout = jest.spyOn(clientAuthentication, "logout");
+      const mySession = new Session({ clientAuthentication });
+      const objectWithLogout = {
+        logout: mySession.logout,
+      };
+      await objectWithLogout.logout();
       expect(clientAuthnLogout).toHaveBeenCalled();
     });
   });
@@ -101,6 +123,18 @@ describe("Session", () => {
       const clientAuthnFetch = jest.spyOn(clientAuthentication, "fetch");
       const mySession = new Session({ clientAuthentication });
       await mySession.fetch("https://some.url");
+      expect(clientAuthnFetch).toHaveBeenCalled();
+    });
+
+    it("preserves a binding to its Session instance", async () => {
+      window.fetch = jest.fn();
+      const clientAuthentication = mockClientAuthentication();
+      const clientAuthnFetch = jest.spyOn(clientAuthentication, "fetch");
+      const mySession = new Session({ clientAuthentication });
+      const objectWithFetch = {
+        fetch: mySession.fetch,
+      };
+      await objectWithFetch.fetch("https://some.url");
       expect(clientAuthnFetch).toHaveBeenCalled();
     });
   });
@@ -208,6 +242,22 @@ describe("Session", () => {
       // One of the two token requests should not have reached the token endpoint
       // because the other was pending.
       expect(tokenRequests).toContain(undefined);
+    });
+
+    it("preserves a binding to its Session instance", async () => {
+      const clientAuthentication = mockClientAuthentication();
+      const clientAuthnHandleIncomingRedirect = jest.spyOn(
+        clientAuthentication,
+        "handleIncomingRedirect"
+      );
+      const mySession = new Session({ clientAuthentication });
+      const objectWithHandleIncomingRedirect = {
+        handleIncomingRedirect: mySession.handleIncomingRedirect,
+      };
+      await objectWithHandleIncomingRedirect.handleIncomingRedirect(
+        "https://some.url"
+      );
+      expect(clientAuthnHandleIncomingRedirect).toHaveBeenCalled();
     });
   });
 

--- a/packages/browser/__tests__/defaultSession.spec.ts
+++ b/packages/browser/__tests__/defaultSession.spec.ts
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { jest, it } from "@jest/globals";
+import {
+  fetch,
+  getDefaultSession,
+  handleIncomingRedirect,
+  login,
+  logout,
+  onLogin,
+  onLogout,
+} from "../src/defaultSession";
+import type * as SessionModuleType from "../src/Session";
+
+jest.mock("../src/Session.ts");
+
+it("does not instantiate a Session without calling one of its methods", () => {
+  const mockedSession = jest.requireMock(
+    "../src/Session.ts"
+  ) as typeof SessionModuleType;
+
+  expect(mockedSession.Session).not.toHaveBeenCalled();
+});
+
+it("re-uses the same Session when calling multiple methods", () => {
+  const mockedSession = jest.requireMock(
+    "../src/Session.ts"
+  ) as typeof SessionModuleType;
+
+  expect(mockedSession.Session).not.toHaveBeenCalled();
+
+  onLogin(jest.fn());
+
+  expect(mockedSession.Session).toHaveBeenCalledTimes(1);
+
+  onLogout(jest.fn());
+
+  expect(mockedSession.Session).toHaveBeenCalledTimes(1);
+});
+
+it("all functions pass on their arguments to the default session", () => {
+  const defaultSession = getDefaultSession();
+  const fetchSpy = jest.fn();
+  defaultSession.fetch = fetchSpy as typeof defaultSession.fetch;
+  const loginSpy = jest.fn();
+  defaultSession.login = loginSpy as typeof defaultSession.login;
+  const logoutSpy = jest.fn();
+  defaultSession.logout = logoutSpy as typeof defaultSession.logout;
+  const handleIncomingRedirectSpy = jest.fn();
+  defaultSession.handleIncomingRedirect = handleIncomingRedirectSpy as typeof defaultSession.handleIncomingRedirect;
+  const onLoginSpy = jest.spyOn(defaultSession, "onLogin");
+  const onLogoutSpy = jest.spyOn(defaultSession, "onLogout");
+
+  expect(fetchSpy).not.toHaveBeenCalled();
+  // eslint-disable-next-line @typescript-eslint/no-floating-promises
+  fetch("https://example.com");
+  expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+  expect(loginSpy).not.toHaveBeenCalled();
+  // eslint-disable-next-line @typescript-eslint/no-floating-promises
+  login({});
+  expect(loginSpy).toHaveBeenCalledTimes(1);
+
+  expect(logoutSpy).not.toHaveBeenCalled();
+  // eslint-disable-next-line @typescript-eslint/no-floating-promises
+  logout();
+  expect(logoutSpy).toHaveBeenCalledTimes(1);
+
+  expect(handleIncomingRedirectSpy).not.toHaveBeenCalled();
+  // eslint-disable-next-line @typescript-eslint/no-floating-promises
+  handleIncomingRedirect("https://example.com");
+  expect(handleIncomingRedirectSpy).toHaveBeenCalledTimes(1);
+
+  expect(onLoginSpy).not.toHaveBeenCalled();
+  onLogin(jest.fn());
+  expect(onLoginSpy).toHaveBeenCalledTimes(1);
+
+  expect(onLogoutSpy).not.toHaveBeenCalled();
+  onLogout(jest.fn());
+  expect(onLogoutSpy).toHaveBeenCalledTimes(1);
+});

--- a/packages/browser/src/Session.ts
+++ b/packages/browser/src/Session.ts
@@ -138,7 +138,7 @@ export class Session extends EventEmitter {
   };
 
   /**
-   * Logs the user out of the application. This does not log the user out of the identity provider, and should not redirect the user away.
+   * Logs the user out of the application. This does not log the user out of their Solid identity provider, and should not redirect the user away.
    */
   logout = async (): Promise<void> => {
     await this.clientAuthentication.logout(this.info.sessionId);
@@ -146,7 +146,7 @@ export class Session extends EventEmitter {
   };
 
   /**
-   * Completes the login process by processing the information provided by the identity provider through redirect.
+   * Completes the login process by processing the information provided by the Solid identity provider through redirect.
    *
    * @param url The URL of the page handling the redirect, including the query parameters — these contain the information to process the login.
    */

--- a/packages/browser/src/Session.ts
+++ b/packages/browser/src/Session.ts
@@ -68,12 +68,7 @@ export class Session extends EventEmitter {
    * Session object constructor. Typically called as follows:
    *
    * ```typescript
-   * const session = new Session(
-   *   {
-   *     clientAuthentication: getClientAuthenticationWithDependencies({})
-   *   },
-   *   "mySession"
-   * );
+   * const session = new Session();
    * ```
    * @param sessionOptions The options enabling the correct instantiation of
    * the session. Either both storages or clientAuthentication are required. For

--- a/packages/browser/src/defaultSession.ts
+++ b/packages/browser/src/defaultSession.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { Session } from "./Session";
+
+let defaultSession: Session;
+
+/**
+ * Obtain the {@link Session} used when not explicitly instantiating one yourself.
+ *
+ * When using the top-level exports {@link fetch}, {@link login}, {@link logout},
+ * {@link handleIncomingRedirect}, {@link onLogin} and {@link onLogout}, these apply to an
+ * implicitly-instantiated {@link Session}.
+ * This function returns a reference to that Session in order to obtain e.g. the current user's
+ * WebID.
+ */
+export function getDefaultSession(): Session {
+  if (typeof defaultSession === "undefined") {
+    defaultSession = new Session();
+  }
+  return defaultSession;
+}
+
+/**
+ * This function's signature is equal to `window.fetch`, but if the current user is authenticated
+ * (see [[login]] and [[handleIncomingRedirect]), requests made using it will include that user's
+ * credentials. If not, this will behave just like the regular `window.fetch`.
+ *
+ * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch}
+ */
+export const fetch: Session["fetch"] = (...args) => {
+  const session = getDefaultSession();
+  return session.fetch(...args);
+};
+
+/**
+ * Triggers the login process. Note that this method will redirect the user away from your app.
+ *
+ * @param options Parameter to customize the login behaviour. In particular, two options are mandatory: `options.oidcIssuer`, the user's identity provider, and `options.redirectUrl`, the URL to which the user will be redirected after logging in their identity provider.
+ * @returns This method should redirect the user away from the app: it does not return anything. The login process is completed by [[handleIncomingRedirect]].
+ */
+export const login: Session["login"] = (...args) => {
+  const session = getDefaultSession();
+  return session.login(...args);
+};
+/**
+ * Logs the user out of the application. This does not log the user out of their Solid identity provider, and should not redirect the user away.
+ */
+export const logout: Session["logout"] = (...args) => {
+  const session = getDefaultSession();
+  return session.logout(...args);
+};
+
+/**
+ * Completes the login process by processing the information provided by the Solid identity provider through redirect.
+ *
+ * @param url The URL of the page handling the redirect, including the query parameters — these contain the information to process the login.
+ */
+export const handleIncomingRedirect: Session["handleIncomingRedirect"] = (
+  ...args
+) => {
+  const session = getDefaultSession();
+  return session.handleIncomingRedirect(...args);
+};
+
+/**
+ * Register a callback function to be called when a user completes login.
+ *
+ * The callback is called when {@link handleIncomingRedirect} completes successfully.
+ *
+ * @param callback The function called when a user completes login.
+ */
+export const onLogin: Session["onLogin"] = (...args) => {
+  const session = getDefaultSession();
+  return session.onLogin(...args);
+};
+
+/**
+ * Register a callback function to be called when a user logs out:
+ *
+ * @param callback The function called when a user completes logout.
+ */
+export const onLogout: Session["onLogout"] = (...args) => {
+  const session = getDefaultSession();
+  return session.onLogout(...args);
+};

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -24,6 +24,8 @@ export { Session, ISessionOptions } from "./Session";
 export { SessionManager, ISessionManagerOptions } from "./SessionManager";
 export { getClientAuthenticationWithDependencies } from "./dependencies";
 
+export * from "./defaultSession";
+
 // Re-export of types defined in the core module and produced/consumed by our API
 
 export {


### PR DESCRIPTION
# New feature description

These instantiate a single "default session" behind the scenes that
they all operate on. It currently also exposes a
`getDefaultSession()` function to obtain that Session, because
there is no good other way to obtain session info like the current
user's WebID. It might make sense to extend the `login` event to
supply that information.

I also added the unit tests that were not added in #245, because I was considering reverting that to make the tests for this work, but had no way to verify whether I didn't regress on that. It turned out not to be necessary, but I figured it still made sense to keep the test.

# Checklist

- [x] All acceptance criteria are met.
- [ ] Relevant documentation, if any, has been written/updated. - I'm not sure if we should be updating our tutorials to use these until `onLogin` also returns the current user's WebID. API docs are added though.
- [x] The changelog has been updated, if applicable.
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
