### PR TITLE
Bugfix: logout did not update session info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ which will instantiate a new Session implicitly behind the scenes. If you do
 need access to this Session, you can do so using the new function
 `getDefaultSession`.
 
+### Bugfix
+
+- The `session.info.isLoggedIn` property is now set to false on logout. 
+
 The following sections document changes that have been released already:
 
 ## 1.2.6 - 2020-12-23

--- a/packages/browser/__tests__/Session.spec.ts
+++ b/packages/browser/__tests__/Session.spec.ts
@@ -114,6 +114,14 @@ describe("Session", () => {
       await objectWithLogout.logout();
       expect(clientAuthnLogout).toHaveBeenCalled();
     });
+
+    it("updates the session's info", async () => {
+      const clientAuthentication = mockClientAuthentication();
+      const mySession = new Session({ clientAuthentication });
+      mySession.info.isLoggedIn = true;
+      await mySession.logout();
+      expect(mySession.info.isLoggedIn).toEqual(false);
+    });
   });
 
   describe("fetch", () => {

--- a/packages/browser/src/Session.ts
+++ b/packages/browser/src/Session.ts
@@ -142,6 +142,7 @@ export class Session extends EventEmitter {
    */
   logout = async (): Promise<void> => {
     await this.clientAuthentication.logout(this.info.sessionId);
+    this.info.isLoggedIn = false;
     this.emit("logout");
   };
 


### PR DESCRIPTION
On logout, the `info` property on the sessio object wasn't updated, so
after logout, `session.info.isLoggedIn` still returned true. This is now
fixed.

This PR fixes bug #894.

- [X] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).