### PR TITLE
Feat/session management/rs cookie write

### DIFF
--- a/packages/browser/__tests__/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
+++ b/packages/browser/__tests__/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
@@ -325,10 +325,6 @@ describe("AuthCodeRedirectHandler", () => {
     });
 
     it("returns an authenticated dpop fetch if requested", async () => {
-      window.fetch = jest.fn() as jest.Mock<
-        ReturnType<typeof window.fetch>,
-        [RequestInfo, RequestInit?]
-      >;
       window.fetch = jest.fn().mockReturnValue(
         new Promise((resolve) => {
           resolve(

--- a/packages/browser/__tests__/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
+++ b/packages/browser/__tests__/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
@@ -33,6 +33,7 @@ import { JSONWebKey } from "jose";
 import { Response } from "cross-fetch";
 import {
   AuthCodeRedirectHandler,
+  DEFAULT_LIFESPAN,
   exchangeDpopToken,
 } from "../../../../src/login/oidc/redirectHandler/AuthCodeRedirectHandler";
 import { RedirectorMock } from "../../../../src/login/oidc/__mocks__/Redirector";
@@ -363,7 +364,8 @@ describe("AuthCodeRedirectHandler", () => {
       })
     );
 
-    Date.now = jest.fn().mockReturnValueOnce(10000);
+    const MOCK_TIMESTAMP = 10000;
+    Date.now = jest.fn().mockReturnValueOnce(MOCK_TIMESTAMP);
 
     const mockedStorage = mockStorageUtility({
       "solidClientAuthenticationUser:oauth2_state_value": {
@@ -386,7 +388,7 @@ describe("AuthCodeRedirectHandler", () => {
       webId: "https://my.webid",
       sessions: {
         "https://my.webid": {
-          expiration: 11800,
+          expiration: MOCK_TIMESTAMP + DEFAULT_LIFESPAN,
         },
       },
     });

--- a/packages/browser/__tests__/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
+++ b/packages/browser/__tests__/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
@@ -144,6 +144,14 @@ function mockClientRegistrar(client: IClient): IClientRegistrar {
   };
 }
 
+const mockFetchOnce = (response: Response): void => {
+  window.fetch = jest.fn().mockReturnValueOnce(
+    new Promise((resolve) => {
+      resolve(response);
+    })
+  ) as jest.Mock<ReturnType<typeof window.fetch>, [RequestInfo, RequestInit?]>;
+};
+
 const defaultMocks = {
   storageUtility: StorageUtilityMock,
   redirector: RedirectorMock,
@@ -222,18 +230,11 @@ describe("AuthCodeRedirectHandler", () => {
     });
 
     it("retrieves the code verifier from memory", async () => {
-      window.fetch = jest.fn().mockReturnValueOnce(
-        new Promise((resolve) => {
-          resolve({
-            ...new Response("", {
-              status: 200,
-            }),
-          });
+      mockFetchOnce(
+        new Response("", {
+          status: 200,
         })
-      ) as jest.Mock<
-        ReturnType<typeof window.fetch>,
-        [RequestInfo, RequestInit?]
-      >;
+      );
       const storage = mockStorageUtility({
         "solidClientAuthenticationUser:oauth2_state_value": {
           sessionId: "userId",
@@ -262,18 +263,11 @@ describe("AuthCodeRedirectHandler", () => {
     });
 
     it("Fails if a session was not retrieved", async () => {
-      window.fetch = jest.fn().mockReturnValueOnce(
-        new Promise((resolve) => {
-          resolve({
-            ...new Response("", {
-              status: 200,
-            }),
-          });
+      mockFetchOnce(
+        new Response("", {
+          status: 200,
         })
-      ) as jest.Mock<
-        ReturnType<typeof window.fetch>,
-        [RequestInfo, RequestInit?]
-      >;
+      );
       defaultMocks.sessionInfoManager.get.mockResolvedValueOnce(undefined);
 
       const authCodeRedirectHandler = getAuthCodeRedirectHandler();
@@ -287,18 +281,11 @@ describe("AuthCodeRedirectHandler", () => {
     // We use ts-ignore comments here only to access mock call arguments
     /* eslint-disable @typescript-eslint/ban-ts-comment */
     it("returns an authenticated bearer fetch by default", async () => {
-      window.fetch = jest.fn().mockReturnValueOnce(
-        new Promise((resolve) => {
-          resolve({
-            ...new Response("", {
-              status: 200,
-            }),
-          });
+      mockFetchOnce(
+        new Response("", {
+          status: 200,
         })
-      ) as jest.Mock<
-        ReturnType<typeof window.fetch>,
-        [RequestInfo, RequestInit?]
-      >;
+      );
 
       const authCodeRedirectHandler = getAuthCodeRedirectHandler({
         storageUtility: mockStorageUtility({
@@ -370,18 +357,11 @@ describe("AuthCodeRedirectHandler", () => {
     // This mocks the fetch to the Resource Server session endpoint
     // Note: Currently, the endpoint only returns the webid in plain/text, it could
     // be extended later to also provide the cookie expiration.
-    window.fetch = jest.fn().mockReturnValueOnce(
-      new Promise((resolve) => {
-        resolve(
-          new Response("https://my.webid", {
-            status: 200,
-          })
-        );
+    mockFetchOnce(
+      new Response("https://my.webid", {
+        status: 200,
       })
-    ) as jest.Mock<
-      ReturnType<typeof window.fetch>,
-      [RequestInfo, RequestInit?]
-    >;
+    );
 
     Date.now = jest.fn().mockReturnValueOnce(10000);
 
@@ -416,18 +396,11 @@ describe("AuthCodeRedirectHandler", () => {
     // This mocks the fetch to the Resource Server session endpoint
     // Note: Currently, the endpoint only returns the WebID in plain/text, it could
     // be extended later to also provide the cookie expiration.
-    window.fetch = jest.fn().mockReturnValueOnce(
-      new Promise((resolve) => {
-        resolve(
-          new Response("", {
-            status: 404,
-          })
-        );
+    mockFetchOnce(
+      new Response("", {
+        status: 404,
       })
-    ) as jest.Mock<
-      ReturnType<typeof window.fetch>,
-      [RequestInfo, RequestInit?]
-    >;
+    );
 
     const mockedStorage = mockStorageUtility({
       "solidClientAuthenticationUser:oauth2_state_value": {
@@ -453,18 +426,11 @@ describe("AuthCodeRedirectHandler", () => {
     // This mocks the fetch to the Resource Server session endpoint
     // Note: Currently, the endpoint only returns the WebID in plain/text, it could
     // be extended later to also provide the cookie expiration.
-    window.fetch = jest.fn().mockReturnValueOnce(
-      new Promise((resolve) => {
-        resolve(
-          new Response("", {
-            status: 401,
-          })
-        );
+    mockFetchOnce(
+      new Response("", {
+        status: 401,
       })
-    ) as jest.Mock<
-      ReturnType<typeof window.fetch>,
-      [RequestInfo, RequestInit?]
-    >;
+    );
 
     const mockedStorage = mockStorageUtility({
       "solidClientAuthenticationUser:oauth2_state_value": {

--- a/packages/browser/__tests__/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
+++ b/packages/browser/__tests__/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
@@ -366,7 +366,7 @@ describe("AuthCodeRedirectHandler", () => {
     });
   });
 
-  it("stores information about the resource server cookie in local storage on on successful authentication", async () => {
+  it("stores information about the resource server cookie in local storage on successful authentication", async () => {
     // This mocks the fetch to the Resource Server session endpoint
     // Note: Currently, the endpoint only returns the webid in plain/text, it could
     // be extended later to also provide the cookie expiration.
@@ -414,7 +414,7 @@ describe("AuthCodeRedirectHandler", () => {
 
   it("store nothing if the resource server has no session endpoint", async () => {
     // This mocks the fetch to the Resource Server session endpoint
-    // Note: Currently, the endpoint only returns the webid in plain/text, it could
+    // Note: Currently, the endpoint only returns the WebID in plain/text, it could
     // be extended later to also provide the cookie expiration.
     window.fetch = jest.fn().mockReturnValueOnce(
       new Promise((resolve) => {
@@ -451,7 +451,7 @@ describe("AuthCodeRedirectHandler", () => {
 
   it("store nothing if the resource server does not recognize the user", async () => {
     // This mocks the fetch to the Resource Server session endpoint
-    // Note: Currently, the endpoint only returns the webid in plain/text, it could
+    // Note: Currently, the endpoint only returns the WebID in plain/text, it could
     // be extended later to also provide the cookie expiration.
     window.fetch = jest.fn().mockReturnValueOnce(
       new Promise((resolve) => {

--- a/packages/browser/__tests__/sessionInfo/SessionInfoManager.spec.ts
+++ b/packages/browser/__tests__/sessionInfo/SessionInfoManager.spec.ts
@@ -162,11 +162,6 @@ describe("SessionInfoManager", () => {
         "https://my.pod",
         10000
       );
-      console.log(
-        await mockStorage.get("tmp-resource-server-session-info", {
-          secure: false,
-        })
-      );
       const sessionManager = getSessionInfoManager({
         storageUtility: mockStorage,
       });

--- a/packages/browser/__tests__/sessionInfo/SessionInfoManager.spec.ts
+++ b/packages/browser/__tests__/sessionInfo/SessionInfoManager.spec.ts
@@ -147,6 +147,38 @@ describe("SessionInfoManager", () => {
         await mockStorage.getForUser("mySession", "key", { secure: false })
       ).toBeUndefined();
     });
+
+    it("clears resource server session info from local storage", async () => {
+      const mockStorage = mockStorageUtility(
+        {
+          "solidClientAuthenticationUser:mySession": {
+            webId: "https://my.pod/profile#me",
+          },
+        },
+        true
+      );
+      await mockStorage.storeResourceServerSessionInfo(
+        "https://my.pod/profile#me",
+        "https://my.pod",
+        10000
+      );
+      console.log(
+        await mockStorage.get("tmp-resource-server-session-info", {
+          secure: false,
+        })
+      );
+      const sessionManager = getSessionInfoManager({
+        storageUtility: mockStorage,
+      });
+      await sessionManager.clear("mySession");
+      expect(
+        JSON.parse(
+          (await mockStorage.get("tmp-resource-server-session-info", {
+            secure: false,
+          })) ?? ""
+        )
+      ).toEqual({});
+    });
   });
 
   describe("getAll", () => {

--- a/packages/browser/package-lock.json
+++ b/packages/browser/package-lock.json
@@ -3315,7 +3315,8 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "handlebars": {
       "version": "4.7.6",
@@ -3794,6 +3795,7 @@
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
       "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-docker": "^2.0.0"
       }
@@ -5153,6 +5155,7 @@
       "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-8.0.1.tgz",
       "integrity": "sha512-BvEXF+UmsnAfYfoapKM9nGxnP+Wn7P91YfXmrKnfcYCx6VBeoN5Ez5Ogck6I8Bi5k4RlpqRYaw75pAwzX9OphA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "growly": "^1.3.0",
         "is-wsl": "^2.2.0",
@@ -5167,6 +5170,7 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
           "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -6458,7 +6462,8 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "shiki": {
       "version": "0.2.7",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -49,6 +49,7 @@
     "@types/jest": "^26.0.19",
     "@types/node-fetch": "^2.5.6",
     "concurrently": "^5.3.0",
+    "cross-fetch": "^3.0.6",
     "eslint": "^7.16.0",
     "jest": "^26.6.3",
     "license-checker": "^25.0.1",

--- a/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
+++ b/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
@@ -74,8 +74,8 @@ export async function exchangeDpopToken(
 export const DEFAULT_LIFESPAN = 1800;
 
 /**
- * Stores the resoure server session information in local storage, so that they
- * can be leveraged on refresh.
+ * Stores the resource server session information in local storage, so that they
+ * can be used on refresh.
  * @param webId
  * @param authenticatedFetch
  * @param storageUtility
@@ -97,7 +97,7 @@ async function setupResourceServerSession(
     // In this case, the resource server either:
     // - does not have the expected endpoint, or
     // - does not recognize the user
-    // Either ways, no cookie is expected to be set there, and any existing
+    // Either way, no cookie is expected to be set there, and any existing
     // session information should be cleared.
     await storageUtility.clearResourceServerSessionInfo(resourceServerIri);
     return;

--- a/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
+++ b/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
@@ -98,10 +98,7 @@ async function setupResourceServerSession(
     // - does not recognize the user
     // Either ways, no cookie is expected to be set there, and any existing
     // session information should be cleared.
-    await storageUtility.clearResourceServerSessionInfo(
-      webId,
-      resourceServerIri
-    );
+    await storageUtility.clearResourceServerSessionInfo(resourceServerIri);
     return;
   }
   await storageUtility.storeResourceServerSessionInfo(

--- a/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
+++ b/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
@@ -69,7 +69,8 @@ export async function exchangeDpopToken(
   });
 }
 
-// We
+// A lifespan of 30 minutes is ESS's default. This could be removed if we configure the
+// server to return the remaining lifespan of the cookie.
 const DEFAULT_LIFESPAN = 1800;
 
 /**

--- a/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
+++ b/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
@@ -71,7 +71,7 @@ export async function exchangeDpopToken(
 
 // A lifespan of 30 minutes is ESS's default. This could be removed if we configure the
 // server to return the remaining lifespan of the cookie.
-const DEFAULT_LIFESPAN = 1800;
+export const DEFAULT_LIFESPAN = 1800;
 
 /**
  * Stores the resoure server session information in local storage, so that they

--- a/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
+++ b/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
@@ -90,26 +90,24 @@ async function setupResourceServerSession(
   const resourceServerResponse = await authenticatedFetch(
     `${resourceServerIri}/session`
   );
-  if (
-    resourceServerResponse.status === 404 ||
-    resourceServerResponse.status === 401
-  ) {
-    // In this case, the resource server either:
-    // - does not have the expected endpoint, or
-    // - does not recognize the user
-    // Either way, no cookie is expected to be set there, and any existing
-    // session information should be cleared.
-    await storageUtility.clearResourceServerSessionInfo(resourceServerIri);
+
+  if (resourceServerResponse.status === 200) {
+    await storageUtility.storeResourceServerSessionInfo(
+      webId,
+      resourceServerIri,
+      // Note that here, if the lifespan of the cookie was returned by the server,
+      // we'd expect a relative value (the remaining time of validity) rather than
+      // an absolute one (the moment when the cookie expires).
+      Date.now() + DEFAULT_LIFESPAN
+    );
     return;
   }
-  await storageUtility.storeResourceServerSessionInfo(
-    webId,
-    resourceServerIri,
-    // Note that here, if the lifespan of the cookie was returned by the server,
-    // we'd expect a relative value (the remaining time of validity) rather than
-    // an absolute one (the moment when the cookie expires).
-    Date.now() + DEFAULT_LIFESPAN
-  );
+  // In this case, the resource server either:
+  // - does not have the expected endpoint, or
+  // - does not recognize the user
+  // Either way, no cookie is expected to be set there, and any existing
+  // session information should be cleared.
+  await storageUtility.clearResourceServerSessionInfo(resourceServerIri);
 }
 
 /**

--- a/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
+++ b/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
@@ -104,6 +104,9 @@ async function setupResourceServerSession(
   await storageUtility.storeResourceServerSessionInfo(
     webId,
     resourceServerIri,
+    // Note that here, if the lifespan of the cookie was returned by the server,
+    // we'd expect a relative value (the remaining time of validity) rather than
+    // an absolute one (the moment when the cookie expires).
     Date.now() + DEFAULT_LIFESPAN
   );
 }

--- a/packages/browser/src/sessionInfo/SessionInfoManager.ts
+++ b/packages/browser/src/sessionInfo/SessionInfoManager.ts
@@ -53,6 +53,15 @@ export async function clear(
   sessionId: string,
   storage: IStorageUtility
 ): Promise<void> {
+  // The type assertion is okay, because it throws on undefined.
+  const webId = await storage.getForUser(sessionId, "webId", {
+    secure: true,
+  });
+  if (webId !== undefined) {
+    const webIdAsUrl = new URL(webId);
+    const resourceServerIri = webIdAsUrl.origin;
+    await storage.clearResourceServerSessionInfo(resourceServerIri);
+  }
   await Promise.all([
     storage.deleteAllUserData(sessionId, { secure: false }),
     storage.deleteAllUserData(sessionId, { secure: true }),

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -66,6 +66,7 @@ export {
   loadOidcContextFromStorage,
   saveSessionInfoToStorage,
   getSessionIdFromOauthState,
+  ResourceServerSession,
 } from "./storage/StorageUtility";
 export { default as InMemoryStorage } from "./storage/InMemoryStorage";
 

--- a/packages/core/src/storage/IStorageUtility.ts
+++ b/packages/core/src/storage/IStorageUtility.ts
@@ -71,10 +71,7 @@ export default interface IStorageUtility {
    * @param webId
    * @param resourceServerIri
    */
-  clearResourceServerSessionInfo(
-    webId: string,
-    resourceServerIri: string
-  ): Promise<void>;
+  clearResourceServerSessionInfo(resourceServerIri: string): Promise<void>;
 
   /**
    * Retrieve from local storage

--- a/packages/core/src/storage/IStorageUtility.ts
+++ b/packages/core/src/storage/IStorageUtility.ts
@@ -54,6 +54,11 @@ export default interface IStorageUtility {
     userId: string,
     options?: { secure?: boolean }
   ): Promise<void>;
+  storeResourceServerSessionInfo(
+    webId: string,
+    resourceServerIri: string,
+    sessionExpires: string
+  ): Promise<void>;
 
   /**
    * Retrieve from local storage

--- a/packages/core/src/storage/IStorageUtility.ts
+++ b/packages/core/src/storage/IStorageUtility.ts
@@ -63,7 +63,7 @@ export default interface IStorageUtility {
   storeResourceServerSessionInfo(
     webId: string,
     resourceServerIri: string,
-    sessionExpires: string
+    sessionExpires: number
   ): Promise<void>;
   /**
    * Removes session information for a given WebID and a given Resource Server.

--- a/packages/core/src/storage/IStorageUtility.ts
+++ b/packages/core/src/storage/IStorageUtility.ts
@@ -54,10 +54,26 @@ export default interface IStorageUtility {
     userId: string,
     options?: { secure?: boolean }
   ): Promise<void>;
+  /**
+   * Register a new session for a given WebID against a given Resource Server.
+   * @param webId
+   * @param resourceServerIri
+   * @param sessionExpires
+   */
   storeResourceServerSessionInfo(
     webId: string,
     resourceServerIri: string,
     sessionExpires: string
+  ): Promise<void>;
+  /**
+   * Removes session information for a given WebID and a given Resource Server.
+   * Note that if the WebID has no associated session, nothing happens.
+   * @param webId
+   * @param resourceServerIri
+   */
+  clearResourceServerSessionInfo(
+    webId: string,
+    resourceServerIri: string
   ): Promise<void>;
 
   /**

--- a/packages/core/src/storage/StorageUtility.spec.ts
+++ b/packages/core/src/storage/StorageUtility.spec.ts
@@ -448,7 +448,7 @@ describe("StorageUtility", () => {
       ).resolves.toEqual(JSON.stringify({}));
     });
 
-    it("removes a resource server session info to a WebID that is already registered", async () => {
+    it("clears the session info object if no session is active", async () => {
       const storageUtility = getStorageUtility({
         insecureStorage: mockStorage({
           "tmp-resource-server-session-info": JSON.stringify({
@@ -467,15 +467,10 @@ describe("StorageUtility", () => {
       );
       await expect(
         storageUtility.get("tmp-resource-server-session-info")
-      ).resolves.toEqual(
-        JSON.stringify({
-          webId: "https://some.pod/profile#me",
-          sessions: {},
-        })
-      );
+      ).resolves.toEqual(JSON.stringify({}));
     });
 
-    it("does not remove a different resource server session info", async () => {
+    it("removes the given resource server session info", async () => {
       const storageUtility = getStorageUtility({
         insecureStorage: mockStorage({
           "tmp-resource-server-session-info": JSON.stringify({

--- a/packages/core/src/storage/StorageUtility.spec.ts
+++ b/packages/core/src/storage/StorageUtility.spec.ts
@@ -445,7 +445,7 @@ describe("StorageUtility", () => {
       );
       await expect(
         storageUtility.get("tmp-resource-server-session-info")
-      ).resolves.toEqual(JSON.stringify({}));
+      ).resolves.toBeUndefined();
     });
 
     it("clears the session info object if no session is active", async () => {

--- a/packages/core/src/storage/StorageUtility.spec.ts
+++ b/packages/core/src/storage/StorageUtility.spec.ts
@@ -351,18 +351,18 @@ describe("StorageUtility", () => {
         "https://some-resource.provider/",
         1610026667
       );
-      await expect(
-        storageUtility.get("tmp-resource-server-session-info")
-      ).resolves.toEqual(
-        JSON.stringify({
-          webId: "https://some.pod/profile#me",
-          sessions: {
-            "https://some-resource.provider/": {
-              expiration: 1610026667,
-            },
+      expect(
+        JSON.parse(
+          (await storageUtility.get("tmp-resource-server-session-info")) ?? "{}"
+        )
+      ).toEqual({
+        webId: "https://some.pod/profile#me",
+        sessions: {
+          "https://some-resource.provider/": {
+            expiration: 1610026667,
           },
-        })
-      );
+        },
+      });
     });
 
     it("adds a new resource server to a WebID that is already registered", async () => {
@@ -441,7 +441,6 @@ describe("StorageUtility", () => {
         insecureStorage: mockStorage({}),
       });
       await storageUtility.clearResourceServerSessionInfo(
-        "https://some.pod/profile#me",
         "https://some-resource.provider/"
       );
       await expect(
@@ -464,7 +463,6 @@ describe("StorageUtility", () => {
       });
 
       await storageUtility.clearResourceServerSessionInfo(
-        "https://some.pod/profile#me",
         "https://some-resource.provider/"
       );
       await expect(
@@ -492,7 +490,6 @@ describe("StorageUtility", () => {
       });
 
       await storageUtility.clearResourceServerSessionInfo(
-        "https://some.pod/profile#me",
         "https://some-other-resource.provider/"
       );
       await expect(

--- a/packages/core/src/storage/StorageUtility.spec.ts
+++ b/packages/core/src/storage/StorageUtility.spec.ts
@@ -349,15 +349,16 @@ describe("StorageUtility", () => {
       await storageUtility.storeResourceServerSessionInfo(
         "https://some.pod/profile#me",
         "https://some-resource.provider/",
-        "1h"
+        1610026667
       );
       await expect(
         storageUtility.get("tmp-resource-server-session-info")
       ).resolves.toEqual(
         JSON.stringify({
-          "https://some.pod/profile#me": {
+          webId: "https://some.pod/profile#me",
+          sessions: {
             "https://some-resource.provider/": {
-              expiration: "1h",
+              expiration: 1610026667,
             },
           },
         })
@@ -368,9 +369,10 @@ describe("StorageUtility", () => {
       const storageUtility = getStorageUtility({
         insecureStorage: mockStorage({
           "tmp-resource-server-session-info": JSON.stringify({
-            "https://some.pod/profile#me": {
+            webId: "https://some.pod/profile#me",
+            sessions: {
               "https://some-other-resource.provider/": {
-                expiration: "1h",
+                expiration: 1610026667,
               },
             },
           }),
@@ -380,18 +382,52 @@ describe("StorageUtility", () => {
       await storageUtility.storeResourceServerSessionInfo(
         "https://some.pod/profile#me",
         "https://some-resource.provider/",
-        "1h"
+        1610026667
       );
       await expect(
         storageUtility.get("tmp-resource-server-session-info")
       ).resolves.toEqual(
         JSON.stringify({
-          "https://some.pod/profile#me": {
+          webId: "https://some.pod/profile#me",
+          sessions: {
             "https://some-other-resource.provider/": {
-              expiration: "1h",
+              expiration: 1610026667,
             },
             "https://some-resource.provider/": {
-              expiration: "1h",
+              expiration: 1610026667,
+            },
+          },
+        })
+      );
+    });
+
+    it("overwrites existing sessions when storing a session for a new WebID", async () => {
+      const storageUtility = getStorageUtility({
+        insecureStorage: mockStorage({
+          "tmp-resource-server-session-info": JSON.stringify({
+            webId: "https://some-other.pod/profile#me",
+            sessions: {
+              "https://some-other-resource.provider/": {
+                expiration: 1610026667,
+              },
+            },
+          }),
+        }),
+      });
+
+      await storageUtility.storeResourceServerSessionInfo(
+        "https://some.pod/profile#me",
+        "https://some-resource.provider/",
+        1610026667
+      );
+      await expect(
+        storageUtility.get("tmp-resource-server-session-info")
+      ).resolves.toEqual(
+        JSON.stringify({
+          webId: "https://some.pod/profile#me",
+          sessions: {
+            "https://some-resource.provider/": {
+              expiration: 1610026667,
             },
           },
         })
@@ -400,7 +436,7 @@ describe("StorageUtility", () => {
   });
 
   describe("clearResourceServerSessionInfo", () => {
-    it("doesn not fail if the WebID does not exist", async () => {
+    it("doesn't not fail if the WebID does not exist", async () => {
       const storageUtility = getStorageUtility({
         insecureStorage: mockStorage({}),
       });
@@ -417,9 +453,10 @@ describe("StorageUtility", () => {
       const storageUtility = getStorageUtility({
         insecureStorage: mockStorage({
           "tmp-resource-server-session-info": JSON.stringify({
-            "https://some.pod/profile#me": {
+            webId: "https://some.pod/profile#me",
+            sessions: {
               "https://some-resource.provider/": {
-                expiration: "1h",
+                expiration: 1610026667,
               },
             },
           }),
@@ -432,16 +469,22 @@ describe("StorageUtility", () => {
       );
       await expect(
         storageUtility.get("tmp-resource-server-session-info")
-      ).resolves.toEqual(JSON.stringify({ "https://some.pod/profile#me": {} }));
+      ).resolves.toEqual(
+        JSON.stringify({
+          webId: "https://some.pod/profile#me",
+          sessions: {},
+        })
+      );
     });
 
     it("does not remove a different resource server session info", async () => {
       const storageUtility = getStorageUtility({
         insecureStorage: mockStorage({
           "tmp-resource-server-session-info": JSON.stringify({
-            "https://some.pod/profile#me": {
+            webId: "https://some.pod/profile#me",
+            sessions: {
               "https://some-resource.provider/": {
-                expiration: "1h",
+                expiration: 1610026667,
               },
             },
           }),
@@ -456,9 +499,10 @@ describe("StorageUtility", () => {
         storageUtility.get("tmp-resource-server-session-info")
       ).resolves.toEqual(
         JSON.stringify({
-          "https://some.pod/profile#me": {
+          webId: "https://some.pod/profile#me",
+          sessions: {
             "https://some-resource.provider/": {
-              expiration: "1h",
+              expiration: 1610026667,
             },
           },
         })

--- a/packages/core/src/storage/StorageUtility.ts
+++ b/packages/core/src/storage/StorageUtility.ts
@@ -289,10 +289,7 @@ export default class StorageUtility implements IStorageUtility {
   async clearResourceServerSessionInfo(
     resourceServerIri: string
   ): Promise<void> {
-    const sessions: Record<
-      string,
-      Record<string, ResourceServerSession>
-    > = JSON.parse(
+    const sessions: ResourceServerSession = JSON.parse(
       (await this.insecureStorage.get(
         this.RESOURCE_SERVER_SESSION_INFORMATION_KEY
       )) ?? "{}"
@@ -300,10 +297,21 @@ export default class StorageUtility implements IStorageUtility {
     if (sessions.sessions !== undefined) {
       delete sessions.sessions[resourceServerIri];
     }
-    await this.insecureStorage.set(
-      this.RESOURCE_SERVER_SESSION_INFORMATION_KEY,
-      JSON.stringify(sessions)
-    );
+    if (
+      sessions.sessions !== undefined &&
+      Object.keys(sessions.sessions).length === 0
+    ) {
+      // If there isn't any active session left, the whole object is cleared.
+      await this.insecureStorage.set(
+        this.RESOURCE_SERVER_SESSION_INFORMATION_KEY,
+        "{}"
+      );
+    } else {
+      await this.insecureStorage.set(
+        this.RESOURCE_SERVER_SESSION_INFORMATION_KEY,
+        JSON.stringify(sessions)
+      );
+    }
   }
 
   /**

--- a/packages/core/src/storage/StorageUtility.ts
+++ b/packages/core/src/storage/StorageUtility.ts
@@ -115,7 +115,7 @@ export async function saveSessionInfoToStorage(
   }
 }
 
-type ResourceServerSession = {
+export type ResourceServerSession = {
   webId: string;
   sessions: Record<
     string,

--- a/packages/core/src/storage/StorageUtility.ts
+++ b/packages/core/src/storage/StorageUtility.ts
@@ -296,21 +296,19 @@ export default class StorageUtility implements IStorageUtility {
     );
     if (sessions.sessions !== undefined) {
       delete sessions.sessions[resourceServerIri];
-    }
-    if (
-      sessions.sessions !== undefined &&
-      Object.keys(sessions.sessions).length === 0
-    ) {
-      // If there isn't any active session left, the whole object is cleared.
-      await this.insecureStorage.set(
-        this.RESOURCE_SERVER_SESSION_INFORMATION_KEY,
-        "{}"
-      );
-    } else {
-      await this.insecureStorage.set(
-        this.RESOURCE_SERVER_SESSION_INFORMATION_KEY,
-        JSON.stringify(sessions)
-      );
+
+      if (Object.keys(sessions.sessions).length === 0) {
+        // If there isn't any active session left, the whole object is cleared.
+        await this.insecureStorage.set(
+          this.RESOURCE_SERVER_SESSION_INFORMATION_KEY,
+          "{}"
+        );
+      } else {
+        await this.insecureStorage.set(
+          this.RESOURCE_SERVER_SESSION_INFORMATION_KEY,
+          JSON.stringify(sessions)
+        );
+      }
     }
   }
 

--- a/packages/core/src/storage/StorageUtility.ts
+++ b/packages/core/src/storage/StorageUtility.ts
@@ -278,7 +278,7 @@ export default class StorageUtility implements IStorageUtility {
     }
     sessions.webId = webId;
     sessions.sessions[resourceServerIri] = {
-      expiration: expiration,
+      expiration,
     };
     await this.insecureStorage.set(
       this.RESOURCE_SERVER_SESSION_INFORMATION_KEY,

--- a/packages/core/src/storage/StorageUtility.ts
+++ b/packages/core/src/storage/StorageUtility.ts
@@ -287,7 +287,6 @@ export default class StorageUtility implements IStorageUtility {
   }
 
   async clearResourceServerSessionInfo(
-    webId: string,
     resourceServerIri: string
   ): Promise<void> {
     const sessions: Record<

--- a/packages/core/src/storage/StorageUtility.ts
+++ b/packages/core/src/storage/StorageUtility.ts
@@ -286,6 +286,27 @@ export default class StorageUtility implements IStorageUtility {
     );
   }
 
+  async clearResourceServerSessionInfo(
+    webId: string,
+    resourceServerIri: string
+  ): Promise<void> {
+    const sessions: Record<
+      string,
+      Record<string, ResourceServerSession>
+    > = JSON.parse(
+      (await this.insecureStorage.get(
+        this.RESOURCE_SERVER_SESSION_INFORMATION_KEY
+      )) ?? "{}"
+    );
+    if (sessions[webId] !== undefined) {
+      delete sessions[webId][resourceServerIri];
+    }
+    await this.insecureStorage.set(
+      this.RESOURCE_SERVER_SESSION_INFORMATION_KEY,
+      JSON.stringify(sessions)
+    );
+  }
+
   /**
    * Get an object from storage with the guarantee that it matches a given schema.
    *

--- a/packages/core/src/storage/StorageUtility.ts
+++ b/packages/core/src/storage/StorageUtility.ts
@@ -273,6 +273,12 @@ export default class StorageUtility implements IStorageUtility {
       sessions[webId][resourceServerIri] = {
         expiration: sessionExpires,
       };
+    } else {
+      sessions[webId] = {
+        [resourceServerIri]: {
+          expiration: sessionExpires,
+        },
+      };
     }
     await this.insecureStorage.set(
       this.RESOURCE_SERVER_SESSION_INFORMATION_KEY,

--- a/packages/core/src/storage/StorageUtility.ts
+++ b/packages/core/src/storage/StorageUtility.ts
@@ -265,7 +265,7 @@ export default class StorageUtility implements IStorageUtility {
   async storeResourceServerSessionInfo(
     webId: string,
     resourceServerIri: string,
-    sessionExpires: number
+    expiration: number
   ): Promise<void> {
     const sessions: ResourceServerSession = JSON.parse(
       (await this.insecureStorage.get(
@@ -273,12 +273,12 @@ export default class StorageUtility implements IStorageUtility {
       )) ?? "{}"
     );
     if (sessions.webId !== webId) {
-      // Clear sessions active previously
+      // Clear all previously active sessions.
       sessions.sessions = {};
     }
     sessions.webId = webId;
     sessions.sessions[resourceServerIri] = {
-      expiration: sessionExpires,
+      expiration: expiration,
     };
     await this.insecureStorage.set(
       this.RESOURCE_SERVER_SESSION_INFORMATION_KEY,
@@ -298,7 +298,7 @@ export default class StorageUtility implements IStorageUtility {
       delete sessions.sessions[resourceServerIri];
 
       if (Object.keys(sessions.sessions).length === 0) {
-        // If there isn't any active session left, the whole object is cleared.
+        // If there aren't any active sessions left, the whole object is cleared.
         await this.insecureStorage.set(
           this.RESOURCE_SERVER_SESSION_INFORMATION_KEY,
           "{}"

--- a/packages/core/src/storage/__mocks__/StorageUtility.ts
+++ b/packages/core/src/storage/__mocks__/StorageUtility.ts
@@ -78,7 +78,6 @@ export const StorageUtilityMock: IStorageUtility = {
     // Do nothing
   },
   clearResourceServerSessionInfo: async (
-    _webId: string,
     _resourceServerIri: string
   ): Promise<void> => {
     // Do nothing

--- a/packages/core/src/storage/__mocks__/StorageUtility.ts
+++ b/packages/core/src/storage/__mocks__/StorageUtility.ts
@@ -73,7 +73,7 @@ export const StorageUtilityMock: IStorageUtility = {
   storeResourceServerSessionInfo: async (
     _webId: string,
     _resourceServerIri: string,
-    _sessionExpires: string
+    _sessionExpires: number
   ): Promise<void> => {
     // Do nothing
   },

--- a/packages/core/src/storage/__mocks__/StorageUtility.ts
+++ b/packages/core/src/storage/__mocks__/StorageUtility.ts
@@ -77,6 +77,12 @@ export const StorageUtilityMock: IStorageUtility = {
   ): Promise<void> => {
     // Do nothing
   },
+  clearResourceServerSessionInfo: async (
+    _webId: string,
+    _resourceServerIri: string
+  ): Promise<void> => {
+    // Do nothing
+  },
 };
 
 export const mockStorage = (

--- a/packages/core/src/storage/__mocks__/StorageUtility.ts
+++ b/packages/core/src/storage/__mocks__/StorageUtility.ts
@@ -70,6 +70,13 @@ export const StorageUtilityMock: IStorageUtility = {
     }>
   ) => StorageUtilitySafeGetResponse,
   /* eslint-enable @typescript-eslint/no-unused-vars */
+  storeResourceServerSessionInfo: async (
+    _webId: string,
+    _resourceServerIri: string,
+    _sessionExpires: string
+  ): Promise<void> => {
+    // Do nothing
+  },
 };
 
 export const mockStorage = (

--- a/packages/node/src/e2e/e2e-test.spec.ts
+++ b/packages/node/src/e2e/e2e-test.spec.ts
@@ -23,8 +23,6 @@ import { it, describe } from "@jest/globals";
 import { config } from "dotenv-flow";
 import { Session } from "../Session";
 
-jest.setTimeout(15000);
-
 // Load environment variables from .env.local if available:
 config({
   path: __dirname,

--- a/packages/node/src/e2e/e2e-test.spec.ts
+++ b/packages/node/src/e2e/e2e-test.spec.ts
@@ -23,6 +23,8 @@ import { it, describe } from "@jest/globals";
 import { config } from "dotenv-flow";
 import { Session } from "../Session";
 
+jest.setTimeout(15000);
+
 // Load environment variables from .env.local if available:
 config({
   path: __dirname,

--- a/packages/node/src/e2e/e2e-test.spec.ts
+++ b/packages/node/src/e2e/e2e-test.spec.ts
@@ -23,6 +23,11 @@ import { it, describe } from "@jest/globals";
 import { config } from "dotenv-flow";
 import { Session } from "../Session";
 
+import { custom } from "openid-client";
+custom.setHttpOptionsDefaults({
+  timeout: 15000,
+});
+
 // Load environment variables from .env.local if available:
 config({
   path: __dirname,


### PR DESCRIPTION
# New feature description

This write information about sessions on resource servers into local storage. When logging in an IdP, the library checks if the resource server that hosts the user's WebID has a `/session` endpoint. If so, information is stored in local storage following this schema:
```
"tmp-resource-server-session-info": {
  webId: <the user's WebID>,
  sessions: {
    <some-resource-server-iri>: {
      expires: <some timestamp>
    }
  }
}
```

Initially, only the resource server hosting the WebID will be persisted, but the model allows additional servers. 

The purpose of this information is to be able (in an upcoming PR) to be able to be aware that one has an active cookie for a given resource server, in order to initialize the session object appropriately. This approach is based on strong assumptions (the WebID is hosted on the same Pod as the data the user is going to access for instance), and it has known shortcomins. It is only a stopgap solution until a more permanent solution is implemented, which wouldn't require a cookie on the resource server side.

# Checklist

- [X] All acceptance criteria are met.
- [ ] The changelog has been updated, if applicable.
- [ ] New functions/types have been exported in `index.ts`, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).