### PR TITLE
Read the temporary session-workaround-cookie

### DIFF
--- a/packages/browser/__tests__/ClientAuthentication.spec.ts
+++ b/packages/browser/__tests__/ClientAuthentication.spec.ts
@@ -123,11 +123,13 @@ describe("ClientAuthentication", () => {
   });
 
   describe("fetch", () => {
-    it("calls fetch", async () => {
+    it("calls fetch using the browser cookies if available", async () => {
       window.fetch = jest.fn();
       const clientAuthn = getClientAuthentication();
       await clientAuthn.fetch("https://html5zombo.com");
-      expect(window.fetch).toHaveBeenCalledWith("https://html5zombo.com");
+      expect(window.fetch).toHaveBeenCalledWith("https://html5zombo.com", {
+        credentials: "include",
+      });
     });
   });
 

--- a/packages/browser/__tests__/ClientAuthentication.spec.ts
+++ b/packages/browser/__tests__/ClientAuthentication.spec.ts
@@ -135,9 +135,11 @@ describe("ClientAuthentication", () => {
 
   describe("logout", () => {
     it("reverts back to un-authenticated fetch on logout", async () => {
+      window.fetch = jest.fn();
       // eslint-disable-next-line no-restricted-globals
       history.replaceState = jest.fn();
       const clientAuthn = getClientAuthentication();
+
       const unauthFetch = clientAuthn.fetch;
 
       const url =
@@ -148,9 +150,14 @@ describe("ClientAuthentication", () => {
       expect(clientAuthn.fetch).not.toBe(unauthFetch);
 
       await clientAuthn.logout("mySession");
-
+      const spyFetch = jest.spyOn(window, "fetch");
+      await clientAuthn.fetch("https://example.com", {
+        credentials: "omit",
+      });
       // Calling logout should revert back to our un-authenticated fetch.
-      expect(clientAuthn.fetch).toBe(unauthFetch);
+      expect(spyFetch).toHaveBeenCalledWith("https://example.com", {
+        credentials: "omit",
+      });
     });
   });
 

--- a/packages/browser/__tests__/Session.spec.ts
+++ b/packages/browser/__tests__/Session.spec.ts
@@ -355,7 +355,7 @@ describe("Session", () => {
         });
       });
 
-      it("logs you in even if your Identity Provider is not your Resource server", async () => {
+      it("logs you in even if your Solid Identity Provider is not your Resource server", async () => {
         // Mock localStorage's `getItem` method:
         const existingLocalStorage = window.localStorage;
         const localStorageMock = {

--- a/packages/browser/__tests__/Session.spec.ts
+++ b/packages/browser/__tests__/Session.spec.ts
@@ -303,20 +303,22 @@ describe("Session", () => {
           value: localStorageMock,
           writable: true,
         });
-        const clientAuthentication = mockClientAuthentication();
-        clientAuthentication.handleIncomingRedirect = jest.fn();
-        const mySession = new Session({ clientAuthentication });
-        await mySession.handleIncomingRedirect("https://some.url");
-        expect(mySession.info.isLoggedIn).toEqual(true);
-        expect(mySession.info.webId).toEqual("https://my.pod/profile#me");
-        expect(
-          clientAuthentication.handleIncomingRedirect
-        ).toHaveBeenCalledTimes(0);
-
-        // Remove the mocked method:
-        Object.defineProperty(window, "localStorage", {
-          value: existingLocalStorage,
-        });
+        try {
+          const clientAuthentication = mockClientAuthentication();
+          clientAuthentication.handleIncomingRedirect = jest.fn();
+          const mySession = new Session({ clientAuthentication });
+          await mySession.handleIncomingRedirect("https://some.url");
+          expect(mySession.info.isLoggedIn).toEqual(true);
+          expect(mySession.info.webId).toEqual("https://my.pod/profile#me");
+          expect(
+            clientAuthentication.handleIncomingRedirect
+          ).toHaveBeenCalledTimes(0);
+        } finally {
+          // Remove the mocked method:
+          Object.defineProperty(window, "localStorage", {
+            value: existingLocalStorage,
+          });
+        }
       });
 
       it("does not mark an almost-expired session as logged in", async () => {

--- a/packages/browser/__tests__/Session.spec.ts
+++ b/packages/browser/__tests__/Session.spec.ts
@@ -267,6 +267,158 @@ describe("Session", () => {
       );
       expect(clientAuthnHandleIncomingRedirect).toHaveBeenCalled();
     });
+
+    // This workaround will be removed after we've settled on an API that allows us to silently
+    // re-activate the user's session after a refresh:
+    describe("(using the temporary workaround for losing a session after refresh)", () => {
+      it("does not report the user to be logged in when the workaround cookie is not present, and just executes the redirect", async () => {
+        const clientAuthentication = mockClientAuthentication();
+        clientAuthentication.handleIncomingRedirect = jest.fn(
+          async (_url: string) => undefined
+        );
+        const mySession = new Session({ clientAuthentication });
+        await mySession.handleIncomingRedirect("https://some.url");
+        expect(mySession.info.isLoggedIn).toEqual(false);
+        expect(mySession.info.webId).toBeUndefined();
+        expect(
+          clientAuthentication.handleIncomingRedirect
+        ).toHaveBeenCalledTimes(1);
+      });
+
+      it("re-initialises the user's WebID without redirection if the proper cookie is set", async () => {
+        // Mock localStorage's `getItem` method:
+        const existingLocalStorage = window.localStorage;
+        const localStorageMock = {
+          getItem: jest.fn(() =>
+            JSON.stringify({
+              webId: "https://my.pod/profile#me",
+              sessions: {
+                "https://my.pod/": { expiration: 9000000000000 },
+              },
+            })
+          ),
+        };
+
+        Object.defineProperty(window, "localStorage", {
+          value: localStorageMock,
+          writable: true,
+        });
+        const clientAuthentication = mockClientAuthentication();
+        clientAuthentication.handleIncomingRedirect = jest.fn();
+        const mySession = new Session({ clientAuthentication });
+        await mySession.handleIncomingRedirect("https://some.url");
+        expect(mySession.info.isLoggedIn).toEqual(true);
+        expect(mySession.info.webId).toEqual("https://my.pod/profile#me");
+        expect(
+          clientAuthentication.handleIncomingRedirect
+        ).toHaveBeenCalledTimes(0);
+
+        // Remove the mocked method:
+        Object.defineProperty(window, "localStorage", {
+          value: existingLocalStorage,
+        });
+      });
+
+      it("does not mark an almost-expired session as logged in", async () => {
+        // Mock localStorage's `getItem` method:
+        const existingLocalStorage = window.localStorage;
+        const localStorageMock = {
+          getItem: jest.fn(() =>
+            JSON.stringify({
+              webId: "https://my.pod/profile#me",
+              sessions: {
+                "https://my.pod/": { expiration: Date.now() + 10000 },
+              },
+            })
+          ),
+        };
+
+        Object.defineProperty(window, "localStorage", {
+          value: localStorageMock,
+          writable: true,
+        });
+        const clientAuthentication = mockClientAuthentication();
+        clientAuthentication.handleIncomingRedirect = jest.fn();
+        const mySession = new Session({ clientAuthentication });
+        await mySession.handleIncomingRedirect("https://some.url");
+        expect(mySession.info.isLoggedIn).toEqual(false);
+        expect(mySession.info.webId).toBeUndefined();
+        expect(
+          clientAuthentication.handleIncomingRedirect
+        ).toHaveBeenCalledTimes(1);
+
+        // Remove the mocked method:
+        Object.defineProperty(window, "localStorage", {
+          value: existingLocalStorage,
+        });
+      });
+
+      it("logs you in even if your Identity Provider is not your Resource server", async () => {
+        // Mock localStorage's `getItem` method:
+        const existingLocalStorage = window.localStorage;
+        const localStorageMock = {
+          getItem: jest.fn(() =>
+            JSON.stringify({
+              webId: "https://my.pod/profile#me",
+              sessions: {
+                "https://not.my.pod/": { expiration: 9000000000000 },
+              },
+            })
+          ),
+        };
+
+        Object.defineProperty(window, "localStorage", {
+          value: localStorageMock,
+          writable: true,
+        });
+        const clientAuthentication = mockClientAuthentication();
+        clientAuthentication.handleIncomingRedirect = jest.fn();
+        const mySession = new Session({ clientAuthentication });
+        await mySession.handleIncomingRedirect("https://some.url");
+        expect(mySession.info.isLoggedIn).toEqual(true);
+        expect(mySession.info.webId).toEqual("https://my.pod/profile#me");
+        expect(
+          clientAuthentication.handleIncomingRedirect
+        ).toHaveBeenCalledTimes(0);
+
+        // Remove the mocked method:
+        Object.defineProperty(window, "localStorage", {
+          value: existingLocalStorage,
+        });
+      });
+
+      it("does not log the user in if the data in the storage was invalid", async () => {
+        // Mock localStorage's `getItem` method:
+        const existingLocalStorage = window.localStorage;
+        const localStorageMock = {
+          getItem: jest.fn(() =>
+            JSON.stringify({
+              webId: "https://my.pod/profile#me",
+              // `sessions` key is intentionally missing
+            })
+          ),
+        };
+
+        Object.defineProperty(window, "localStorage", {
+          value: localStorageMock,
+          writable: true,
+        });
+        const clientAuthentication = mockClientAuthentication();
+        clientAuthentication.handleIncomingRedirect = jest.fn();
+        const mySession = new Session({ clientAuthentication });
+        await mySession.handleIncomingRedirect("https://some.url");
+        expect(mySession.info.isLoggedIn).toEqual(false);
+        expect(mySession.info.webId).toBeUndefined();
+        expect(
+          clientAuthentication.handleIncomingRedirect
+        ).toHaveBeenCalledTimes(1);
+
+        // Remove the mocked method:
+        Object.defineProperty(window, "localStorage", {
+          value: existingLocalStorage,
+        });
+      });
+    });
   });
 
   describe("onLogin", () => {

--- a/packages/browser/__tests__/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
+++ b/packages/browser/__tests__/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
@@ -145,8 +145,8 @@ function mockClientRegistrar(client: IClient): IClientRegistrar {
   };
 }
 
-const mockFetchOnce = (response: Response): void => {
-  window.fetch = jest.fn().mockReturnValueOnce(
+const mockFetch = (response: Response): void => {
+  window.fetch = jest.fn().mockReturnValue(
     new Promise((resolve) => {
       resolve(response);
     })
@@ -231,7 +231,7 @@ describe("AuthCodeRedirectHandler", () => {
     });
 
     it("retrieves the code verifier from memory", async () => {
-      mockFetchOnce(
+      mockFetch(
         new Response("", {
           status: 200,
         })
@@ -264,7 +264,7 @@ describe("AuthCodeRedirectHandler", () => {
     });
 
     it("Fails if a session was not retrieved", async () => {
-      mockFetchOnce(
+      mockFetch(
         new Response("", {
           status: 200,
         })
@@ -282,7 +282,7 @@ describe("AuthCodeRedirectHandler", () => {
     // We use ts-ignore comments here only to access mock call arguments
     /* eslint-disable @typescript-eslint/ban-ts-comment */
     it("returns an authenticated bearer fetch by default", async () => {
-      mockFetchOnce(
+      mockFetch(
         new Response("", {
           status: 200,
         })
@@ -358,7 +358,7 @@ describe("AuthCodeRedirectHandler", () => {
     // This mocks the fetch to the Resource Server session endpoint
     // Note: Currently, the endpoint only returns the webid in plain/text, it could
     // be extended later to also provide the cookie expiration.
-    mockFetchOnce(
+    mockFetch(
       new Response("https://my.webid", {
         status: 200,
       })
@@ -398,7 +398,7 @@ describe("AuthCodeRedirectHandler", () => {
     // This mocks the fetch to the Resource Server session endpoint
     // Note: Currently, the endpoint only returns the WebID in plain/text, it could
     // be extended later to also provide the cookie expiration.
-    mockFetchOnce(
+    mockFetch(
       new Response("", {
         status: 404,
       })
@@ -428,7 +428,7 @@ describe("AuthCodeRedirectHandler", () => {
     // This mocks the fetch to the Resource Server session endpoint
     // Note: Currently, the endpoint only returns the WebID in plain/text, it could
     // be extended later to also provide the cookie expiration.
-    mockFetchOnce(
+    mockFetch(
       new Response("", {
         status: 401,
       })

--- a/packages/browser/src/ClientAuthentication.ts
+++ b/packages/browser/src/ClientAuthentication.ts
@@ -101,7 +101,10 @@ export default class ClientAuthentication {
 
     // Restore our fetch() function back to the environment fetch(), effectively
     // leaving us with un-authenticated fetches from now on.
-    this.fetch = fetchWithCookies;
+    this.fetch = (
+      info: RequestInfo,
+      init?: RequestInit
+    ): ReturnType<typeof fetch> => window.fetch(info, init);
   };
 
   getSessionInfo = async (

--- a/packages/browser/src/ClientAuthentication.ts
+++ b/packages/browser/src/ClientAuthentication.ts
@@ -84,7 +84,15 @@ export default class ClientAuthentication {
   };
 
   // By default, our fetch() resolves to the environment fetch() function.
-  fetch = window.fetch;
+  fetch = async (
+    info: RequestInfo,
+    init?: RequestInit
+  ): ReturnType<typeof fetch> => {
+    return window.fetch(info, {
+      ...init,
+      credentials: "include",
+    });
+  };
 
   logout = async (sessionId: string): Promise<void> => {
     await this.logoutHandler.handle(sessionId);

--- a/packages/browser/src/ClientAuthentication.ts
+++ b/packages/browser/src/ClientAuthentication.ts
@@ -35,6 +35,16 @@ import {
 } from "@inrupt/solid-client-authn-core";
 import { removeOidcQueryParam } from "@inrupt/oidc-client-ext";
 
+const fetchWithCookies = (
+  info: RequestInfo,
+  init?: RequestInit
+): ReturnType<typeof fetch> => {
+  return window.fetch(info, {
+    ...init,
+    credentials: "include",
+  });
+};
+
 /**
  * @hidden
  */
@@ -84,22 +94,14 @@ export default class ClientAuthentication {
   };
 
   // By default, our fetch() resolves to the environment fetch() function.
-  fetch = async (
-    info: RequestInfo,
-    init?: RequestInit
-  ): ReturnType<typeof fetch> => {
-    return window.fetch(info, {
-      ...init,
-      credentials: "include",
-    });
-  };
+  fetch = fetchWithCookies;
 
   logout = async (sessionId: string): Promise<void> => {
     await this.logoutHandler.handle(sessionId);
 
     // Restore our fetch() function back to the environment fetch(), effectively
     // leaving us with un-authenticated fetches from now on.
-    this.fetch = window.fetch;
+    this.fetch = fetchWithCookies;
   };
 
   getSessionInfo = async (

--- a/packages/browser/src/Session.ts
+++ b/packages/browser/src/Session.ts
@@ -160,6 +160,67 @@ export class Session extends EventEmitter {
     if (this.tokenRequestInProgress) {
       return undefined;
     }
+
+    // Unfortunately, regular sessions are lost when the user refreshes the page or opens a new tab.
+    // While we're figuring out the API for a longer-term solution, as a temporary workaround some
+    // *resource* servers set a cookie that keeps the user logged in after authenticated requests,
+    // and expose the fact that they set it on a special endpoint.
+    // After login, we store that fact in LocalStorage. This means that we can now look for that
+    // data, and if present, indicate that the user is already logged in.
+    // Note that there are a lot of edge cases that won't work well with this approach, so it willl
+    // be removed in due time.
+    const storedSessionCookieReference = window.localStorage.getItem(
+      "tmp-resource-server-session-info"
+    );
+    if (typeof storedSessionCookieReference === "string") {
+      // TOOD: Re-use the type used when writing this data:
+      // https://github.com/inrupt/solid-client-authn-js/pull/920/files#diff-659ac87dfd3711f4cfcea3c7bf6970980f4740fd59df45f04c7977bffaa23e98R118
+      type ResourceServerSession = {
+        webId: string;
+        sessions: Record<string, { expiration: number }>;
+      };
+      // To keep temporary code together
+      // eslint-disable-next-line no-inner-declarations
+      function isValidSessionCookieReference(
+        reference: Record<string, unknown>
+      ): reference is ResourceServerSession {
+        const resourceServers = Object.keys(
+          (reference as ResourceServerSession).sessions ?? {}
+        );
+        return (
+          typeof (reference as ResourceServerSession).webId === "string" &&
+          resourceServers.length > 0 &&
+          typeof (reference as ResourceServerSession).sessions[
+            resourceServers[0]
+          ].expiration === "number"
+        );
+      }
+      const reference = JSON.parse(storedSessionCookieReference);
+      if (isValidSessionCookieReference(reference)) {
+        const resourceServers = Object.keys(reference.sessions);
+        const webIdOrigin = new URL(reference.webId).hostname;
+        const ownResourceServer = resourceServers.find((resourceServer) => {
+          return new URL(resourceServer).hostname === webIdOrigin;
+        });
+        // Usually the user's WebID is also a Resource server for them,
+        // so we pick the expiration time for that. If it doesn't exist,
+        // we just pick the first (and probably only) one:
+        const relevantServer = ownResourceServer ?? resourceServers[0];
+        // If the cookie is valid for fewer than five minutes,
+        // pretend it's not valid anymore already, to avoid small misalignments
+        // resulting in invalid states:
+        if (
+          reference.sessions[relevantServer].expiration - Date.now() >
+          5 * 60 * 1000
+        ) {
+          this.info.isLoggedIn = true;
+          this.info.webId = reference.webId;
+          return this.info;
+        }
+      }
+    }
+    // end of temporary workaround.
+
     this.tokenRequestInProgress = true;
     const sessionInfo = await this.clientAuthentication.handleIncomingRedirect(
       url

--- a/packages/browser/src/Session.ts
+++ b/packages/browser/src/Session.ts
@@ -133,7 +133,13 @@ export class Session extends EventEmitter {
       // TODO: why does this.clientAuthentication.fetch return throws
       // ""'fetch' called on an object that does not implement interface Window"
       // when unauthenticated ?
-      return window.fetch(url, init);
+      return window.fetch(url, {
+        ...init,
+        // TMP: This ensures that the HTTP requests will include any relevant cookie
+        // that could have been set by the resource server.
+        // https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters
+        credentials: "include",
+      });
     }
     return this.clientAuthentication.fetch(url, init);
   };

--- a/packages/browser/src/Session.ts
+++ b/packages/browser/src/Session.ts
@@ -27,6 +27,7 @@ import {
   ILoginInputOptions,
   ISessionInfo,
   IStorage,
+  ResourceServerSession,
 } from "@inrupt/solid-client-authn-core";
 import { v4 } from "uuid";
 import ClientAuthentication from "./ClientAuthentication";
@@ -175,10 +176,6 @@ export class Session extends EventEmitter {
     if (typeof storedSessionCookieReference === "string") {
       // TOOD: Re-use the type used when writing this data:
       // https://github.com/inrupt/solid-client-authn-js/pull/920/files#diff-659ac87dfd3711f4cfcea3c7bf6970980f4740fd59df45f04c7977bffaa23e98R118
-      type ResourceServerSession = {
-        webId: string;
-        sessions: Record<string, { expiration: number }>;
-      };
       // To keep temporary code together
       // eslint-disable-next-line no-inner-declarations
       function isValidSessionCookieReference(

--- a/packages/browser/src/Session.ts
+++ b/packages/browser/src/Session.ts
@@ -129,18 +129,6 @@ export class Session extends EventEmitter {
    * @param init Optional parameters customizing the request, by specifying an HTTP method, headers, a body, etc. Follows the [WHATWG Fetch Standard](https://fetch.spec.whatwg.org/).
    */
   fetch = async (url: RequestInfo, init?: RequestInit): Promise<Response> => {
-    if (!this.info.isLoggedIn) {
-      // TODO: why does this.clientAuthentication.fetch return throws
-      // ""'fetch' called on an object that does not implement interface Window"
-      // when unauthenticated ?
-      return window.fetch(url, {
-        ...init,
-        // TMP: This ensures that the HTTP requests will include any relevant cookie
-        // that could have been set by the resource server.
-        // https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters
-        credentials: "include",
-      });
-    }
     return this.clientAuthentication.fetch(url, init);
   };
 

--- a/packages/browser/src/authenticatedFetch/fetchFactory.ts
+++ b/packages/browser/src/authenticatedFetch/fetchFactory.ts
@@ -38,6 +38,7 @@ export function buildBearerFetch(
   return (init, options): Promise<Response> => {
     return fetch(init, {
       ...options,
+      credentials: "include",
       headers: {
         ...options?.headers,
         Authorization: `Bearer ${authToken}`,
@@ -63,6 +64,7 @@ async function buildDpopFetchOptions(
         dpopKey
       ),
     },
+    credentials: "include",
   };
 }
 

--- a/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
+++ b/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
@@ -71,7 +71,7 @@ export async function exchangeDpopToken(
 
 // A lifespan of 30 minutes is ESS's default. This could be removed if we configure the
 // server to return the remaining lifespan of the cookie.
-export const DEFAULT_LIFESPAN = 1800;
+export const DEFAULT_LIFESPAN = 1800 * 1000;
 
 /**
  * Stores the resource server session information in local storage, so that they

--- a/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
+++ b/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
@@ -87,6 +87,10 @@ async function setupResourceServerSession(
 ): Promise<void> {
   const webIdAsUrl = new URL(webId);
   const resourceServerIri = webIdAsUrl.origin;
+  // Querying the /session endpoint does not set the cookie, but issuing an
+  // authenticated request to any actual resource (even public ones) does,
+  // so we fetch the user's WebID before checking the /session endpoint.
+  await authenticatedFetch(webId);
   const resourceServerResponse = await authenticatedFetch(
     `${resourceServerIri}/session`
   );

--- a/packages/node/src/e2e/e2e-test.spec.ts
+++ b/packages/node/src/e2e/e2e-test.spec.ts
@@ -21,9 +21,9 @@
 
 import { it, describe } from "@jest/globals";
 import { config } from "dotenv-flow";
+import { custom } from "openid-client";
 import { Session } from "../Session";
 
-import { custom } from "openid-client";
 custom.setHttpOptionsDefaults({
   timeout: 15000,
 });

--- a/packages/node/src/e2e/e2e-test.spec.ts
+++ b/packages/node/src/e2e/e2e-test.spec.ts
@@ -69,6 +69,7 @@ describe("Authenticated fetch", () => {
       refreshToken: process.env.E2E_TEST_REFRESH_TOKEN,
       oidcIssuer: process.env.E2E_TEST_IDP_URL,
     });
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const publicResourceUrl = session.info.webId!;
     const response = await session.fetch(publicResourceUrl);
     expect(response.status).toEqual(200);
@@ -85,6 +86,7 @@ describe("Authenticated fetch", () => {
       refreshToken: process.env.E2E_TEST_REFRESH_TOKEN,
       oidcIssuer: process.env.E2E_TEST_IDP_URL,
     });
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const privateResourceUrl = process.env.E2E_TEST_ESS_POD!;
     const response = await session.fetch(privateResourceUrl);
     expect(response.status).toEqual(200);
@@ -93,6 +95,7 @@ describe("Authenticated fetch", () => {
 
   it("can fetch a private resource when logged in after the same fetch failed", async () => {
     const session = new Session();
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const privateResourceUrl = process.env.E2E_TEST_ESS_POD!;
     let response = await session.fetch(privateResourceUrl);
     expect(response.status).toEqual(401);
@@ -114,6 +117,7 @@ describe("Authenticated fetch", () => {
 
   it("only logs in the requested session", async () => {
     const authenticatedSession = new Session();
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const privateResourceUrl = process.env.E2E_TEST_ESS_POD!;
 
     await authenticatedSession.login({
@@ -141,6 +145,7 @@ describe("Unauthenticated fetch", () => {
       refreshToken: process.env.E2E_TEST_REFRESH_TOKEN,
       oidcIssuer: process.env.E2E_TEST_IDP_URL,
     });
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const publicResourceUrl = authenticatedSession.info.webId!;
 
     const unauthenticatedSession = new Session();
@@ -153,6 +158,7 @@ describe("Unauthenticated fetch", () => {
 
   it("cannot fetch a private resource when not logged in", async () => {
     const session = new Session();
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const privateResourceUrl = process.env.E2E_TEST_ESS_POD!;
     const response = await session.fetch(privateResourceUrl);
     expect(response.status).toEqual(401);
@@ -168,6 +174,7 @@ describe("Post-logout fetch", () => {
       refreshToken: process.env.E2E_TEST_REFRESH_TOKEN,
       oidcIssuer: process.env.E2E_TEST_IDP_URL,
     });
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const publicResourceUrl = session.info.webId!;
     await session.logout();
     const response = await session.fetch(publicResourceUrl);
@@ -179,6 +186,7 @@ describe("Post-logout fetch", () => {
 
   it("cannot fetch a private resource after logging out", async () => {
     const session = new Session();
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const privateResourceUrl = process.env.E2E_TEST_ESS_POD!;
     await session.login({
       clientId: process.env.E2E_TEST_CLIENT_ID,


### PR DESCRIPTION
# New feature description

Unfortunately, regular sessions are lost when the user refreshes
the page or opens a new tab.
While we're figuring out the API for a longer-term solution, as a
temporary workaround some *resource* servers set a cookie that
keeps the user logged in after authenticated requests, and expose
the fact that they set it on a special endpoint.
After login, we store that fact in LocalStorage. This means that we
can now look for that data, and if present, indicate that the user
is already logged in.
Note that there are a lot of edge cases that won't work well with
this approach, so it will be removed in due time.

The type also still needs to be aligned with the write-side, specifically [this one](https://github.com/inrupt/solid-client-authn-js/pull/920/files#diff-659ac87dfd3711f4cfcea3c7bf6970980f4740fd59df45f04c7977bffaa23e98R118) and [this one](https://github.com/inrupt/solid-client-authn-js/pull/921/files#diff-4f6320deb9e43b5216428fb7c2dd230f4b0c5325c6f147f6a73b15659c355fb9R176-R181). I'm just already pushing it because I'm not working tomorrow, so Nicolas can finish it up.

# Checklist

- [ ] All acceptance criteria are met. -> This changed slightly; it's now being done in `handleIncomingRedirect` rather than in the constructor, as this will almost certainly align with the real implementation.
- [ ] Relevant documentation, if any, has been written/updated. N/A, I think?
- [ ] The changelog has been updated, if applicable. N/A, I think?
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
