### PR TITLE
Feat/session management/rs cookies e2e

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased
 
+### New features
+
+- Updating the browser window will no longer log the user out if their WebID is
+hosted on an ESS instance (such as https://pod.inrupt.com). A better, global
+solution will be implemented later in order not to break compatibility in the 
+ecosystem.
+
 The following sections document changes that have been released already:
 
 ## 1.3.0 - 2020-01-06

--- a/e2e/browser/ITestConfig.ts
+++ b/e2e/browser/ITestConfig.ts
@@ -24,4 +24,5 @@ export default interface ITestConfig {
   performLogin: boolean;
   resourceToGet: string;
   expectResponseContainsAnyOf: string[];
+  refresh: boolean | undefined;
 }

--- a/e2e/browser/helpers/login.ts
+++ b/e2e/browser/helpers/login.ts
@@ -21,6 +21,7 @@
 
 import { Selector, t } from "testcafe";
 import LoginPage from "../page-models/LoginPage";
+import { CognitoPage } from "../page-models/cognito";
 
 // Login using NSS User
 export async function loginNss(username: string, password: string) {
@@ -123,4 +124,9 @@ export async function loginGluu(username: string, password: string) {
     .typeText("#loginForm\\:username", username)
     .typeText("#loginForm\\:password", password)
     .click("#loginForm\\:loginButton");
+}
+
+export async function loginCognito(username: string, password: string) {
+  const cognitoPage = new CognitoPage();
+  await cognitoPage.login(username, password);
 }

--- a/e2e/browser/page-models/cognito.ts
+++ b/e2e/browser/page-models/cognito.ts
@@ -1,5 +1,5 @@
-/*
- * Copyright 2021 Inrupt Inc.
+/**
+ * Copyright 2020 Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in
@@ -19,12 +19,31 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-export default interface IPodServerConfig {
-  description: string;
-  podResourceServer: string;
-  identityProvider: string;
-  envTestUserName: string;
-  envTestUserPassword: string;
-  brokeredIdp: "nss" | "Gluu" | "Google" | "Github" | "Auth0" | "Cognito";
-  authorizeClientAppMechanism: "nss" | "ess";
+import { t, Selector } from "testcafe";
+import { screen } from "@testing-library/testcafe";
+
+export class CognitoPage {
+  usernameInput;
+  passwordInput;
+  submitButton;
+
+  constructor() {
+    // The Cognito sign-in page contains the sign-in form twice and is basically confusing
+    // TestCafe/testing-library, hence the cumbersome selectors rather than selecting by label text.
+    this.usernameInput = screen.getByRole("textbox");
+    this.passwordInput = Selector(".visible-lg input[type=password]");
+    this.submitButton = Selector(".visible-lg input[type=submit]");
+  }
+
+  async login(username: string, password: string) {
+    await onCognitoPage();
+    await t
+      .typeText(this.usernameInput, username)
+      .typeText(this.passwordInput, password)
+      .click(this.submitButton);
+  }
+}
+
+export async function onCognitoPage() {
+  await t.expect(Selector("form[name=cognitoSignInForm]").exists).ok();
 }

--- a/e2e/browser/page-models/cognito.ts
+++ b/e2e/browser/page-models/cognito.ts
@@ -19,7 +19,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { t, Selector } from "testcafe";
+import { t, ClientFunction, Selector } from "testcafe";
 import { screen } from "@testing-library/testcafe";
 
 export class CognitoPage {

--- a/e2e/browser/test-suite-disabled.json
+++ b/e2e/browser/test-suite-disabled.json
@@ -1,15 +1,6 @@
 {
   "podServerList": [
     {
-      "description": "NSS",
-      "podResourceServer": "https://<TEST USER NAME>.inrupt.net/",
-      "identityProvider": "https://inrupt.net",
-      "envTestUserName": "E2E_NSS_USERNAME",
-      "envTestUserPassword": "E2E_NSS_PASSWORD",
-      "brokeredIdp": "nss",
-      "authorizeClientAppMechanism": "nss"
-    },
-    {
       "description": "ESS Prod - Gluu (default)",
       "podResourceServer": "https://ldp.pod.inrupt.com/<TEST USER NAME>/",
       "identityProvider": "https://broker.pod.inrupt.com",
@@ -27,5 +18,6 @@
       "brokeredIdp": "Cognito",
       "authorizeClientAppMechanism": "ess"
     }
-  ]
+  ],
+  "testList": []
 }

--- a/e2e/browser/test-suite-disabled.json
+++ b/e2e/browser/test-suite-disabled.json
@@ -1,12 +1,21 @@
 {
   "podServerList": [
     {
+      "description": "NSS",
+      "podResourceServer": "https://<TEST USER NAME>.inrupt.net/",
+      "identityProvider": "https://inrupt.net",
+      "envTestUserName": "E2E_NSS_USERNAME",
+      "envTestUserPassword": "E2E_NSS_PASSWORD",
+      "brokeredIdp": "nss",
+      "authorizeClientAppMechanism": "nss"
+    },
+    {
       "description": "ESS Prod - Gluu (default)",
       "podResourceServer": "https://ldp.pod.inrupt.com/<TEST USER NAME>/",
       "identityProvider": "https://broker.pod.inrupt.com",
       "envTestUserName": "E2E_ESS_USERNAME",
       "envTestUserPassword": "E2E_ESS_PASSWORD",
-      "brokeredIdp": "Gluu",
+      "brokeredIdp": "Cognito",
       "authorizeClientAppMechanism": "ess"
     },
     {
@@ -15,7 +24,7 @@
       "identityProvider": "https://broker.dev-ess.inrupt.com",
       "envTestUserName": "E2E_ESS_DEV_USERNAME",
       "envTestUserPassword": "E2E_ESS_DEV_PASSWORD",
-      "brokeredIdp": "Gluu",
+      "brokeredIdp": "Cognito",
       "authorizeClientAppMechanism": "ess"
     }
   ]

--- a/e2e/browser/test-suite.json
+++ b/e2e/browser/test-suite.json
@@ -1,8 +1,17 @@
 {
   "podServerList": [
     {
-      "description": "ESS Dev - select: Gluu",
-      "podResourceServer": "https://ldp.dev-ess.inrupt.com/<TEST USER NAME>/",
+      "description": "NSS",
+      "podResourceServer": "https://<TEST USER NAME>.inrupt.net/",
+      "identityProvider": "https://inrupt.net",
+      "envTestUserName": "E2E_NSS_USERNAME",
+      "envTestUserPassword": "E2E_NSS_PASSWORD",
+      "brokeredIdp": "nss",
+      "authorizeClientAppMechanism": "nss"
+    },
+    {
+      "description": "ESS Dev - Cognito",
+      "podResourceServer": "https://dev-ess.inrupt.com/<TEST USER NAME>/",
       "identityProvider": "https://broker.dev-ess.inrupt.com",
       "envTestUserName": "E2E_ESS_DEV_USERNAME",
       "envTestUserPassword": "E2E_ESS_DEV_PASSWORD",
@@ -56,6 +65,13 @@
         "\"Not Found\"",
         "Can't find file requested"
       ]
+    },
+    {
+      "name": "Private resource - logged in then refreshed",
+      "performLogin": true,
+      "resourceToGet": "<POD ROOT>private/",
+      "expectResponseContainsAnyOf": ["ldp:BasicContainer"],
+      "refresh": true
     }
   ]
 }

--- a/e2e/browser/test-suite.json
+++ b/e2e/browser/test-suite.json
@@ -1,13 +1,13 @@
 {
   "podServerList": [
     {
-      "description": "NSS",
-      "podResourceServer": "https://<TEST USER NAME>.inrupt.net/",
-      "identityProvider": "https://inrupt.net",
-      "envTestUserName": "E2E_NSS_USERNAME",
-      "envTestUserPassword": "E2E_NSS_PASSWORD",
-      "brokeredIdp": "nss",
-      "authorizeClientAppMechanism": "nss"
+      "description": "ESS Dev - select: Gluu",
+      "podResourceServer": "https://ldp.dev-ess.inrupt.com/<TEST USER NAME>/",
+      "identityProvider": "https://broker.dev-ess.inrupt.com",
+      "envTestUserName": "E2E_ESS_DEV_USERNAME",
+      "envTestUserPassword": "E2E_ESS_DEV_PASSWORD",
+      "brokeredIdp": "Cognito",
+      "authorizeClientAppMechanism": "ess"
     }
   ],
 

--- a/e2e/browser/testSuiteRunner.test.ts
+++ b/e2e/browser/testSuiteRunner.test.ts
@@ -133,7 +133,7 @@ testSuite.podServerList.forEach((server: IPodServerConfig) => {
           await performLogin(server, testUserName);
         }
 
-        // NSS does not support the RS session cookie
+        // NSS does not support the RS session cookie.
         if (data.refresh && server.podResourceServer === "ess") {
           await t.eval(() => location.reload());
         }

--- a/e2e/browser/testSuiteRunner.test.ts
+++ b/e2e/browser/testSuiteRunner.test.ts
@@ -181,11 +181,3 @@ testSuite.podServerList.forEach((server: IPodServerConfig) => {
     });
   }
 });
-
-// it("is still logged in after refresh", async () => {
-//   // Currently, this tests only works
-//   const server = import("./test-suite.json")["podServerList"][0];
-//   const testUserName = process.env[server.envTestUserName] as string;
-//   await performLogin(server, testUserName);
-//   await t.eval(() => location.reload());
-// })

--- a/e2e/browser/testSuiteRunner.test.ts
+++ b/e2e/browser/testSuiteRunner.test.ts
@@ -27,6 +27,7 @@ import ITestConfig from "./ITestConfig";
 import IPodServerConfig from "./IPodServerConfig";
 import { authorizeEss, authorizeNss } from "./helpers/authorizeClientApp";
 import LoginPage from "./page-models/LoginPage";
+import { CognitoPage } from "./page-models/cognito";
 
 // Could probably provide this via a system environment variable too...
 const testSuite = require("./test-suite.json");
@@ -81,6 +82,13 @@ async function performLogin(
     case "nss":
       await loginNss(testUserName, testUserPassword as string);
       break;
+
+    case "Cognito":
+      const cognitoPage = new CognitoPage();
+      await cognitoPage.login(
+        process.env.E2E_TEST_ESS_COGNITO_USER!,
+        process.env.E2E_TEST_ESS_COGNITO_PASSWORD!
+      );
 
     default:
       throw new Error(
@@ -172,3 +180,11 @@ testSuite.podServerList.forEach((server: IPodServerConfig) => {
     });
   }
 });
+
+// it("is still logged in after refresh", async () => {
+//   // Currently, this tests only works
+//   const server = import("./test-suite.json")["podServerList"][0];
+//   const testUserName = process.env[server.envTestUserName] as string;
+//   await performLogin(server, testUserName);
+//   await t.eval(() => location.reload());
+// })


### PR DESCRIPTION
This adds an end-to-end test to prevent regression of the logout-on-refresh issue. Note that the test is only enforced against ESS, since NSS does not implement this resource server side cookie. It will be necessary to update the test when a more permanent, client-side solution is implemented.

# Checklist

- [X] All acceptance criteria are met.
- [x] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).