### PR TITLE
Prevent e2e tests inclusion in the coverage

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -18,5 +18,6 @@ module.exports = {
     "!**/src/external-types/**",
     "!**/src/index.ts",
     "!**/dist/**",
+    "!**/*.spec.ts",
   ],
 };


### PR DESCRIPTION
Tests file should not themselves covered by tests, but for some reason the e2e test is reported in the test coverage.