### PR TITLE
Move reference to `window` into a getter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,23 +10,24 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 The following sections document changes that have been released already:
 
+N/A
+
+## 1.4.1 - 2020-01-14
+
 ### Backward-compatible API changes
+
+#### node
 
 - For `solid-client-authn-node`, the `secureStorage` and `insecureStorage` are
 deprecated, and replaced by `storage`.
 
 ### Bugfix
 
-
-#### node
-
-- When providing a storage that already contains session information in the NodeJS
-context (as demonstrated with the `FileSystemStorage` in `packages/node/example/bootstrappedApp`),
-the refresh token is now picked up instead of the request failing.
-
 #### browser
 
-- Calling `Session::fetch` before logging the Session in threw an error.
+- The `Session` constructor in solid-client-authn-browser no longer references
+  `window` so that it can be instantiated in a non-window context (although
+  it will continue to referene window.localstorage when you attempt to log in.)
 
 ## 1.4.0 - 2020-01-11
 

--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
   "packages": ["packages/*"],
-  "version": "1.4.0"
+  "version": "1.4.1"
 }

--- a/packages/browser/package-lock.json
+++ b/packages/browser/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/solid-client-authn-browser",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/solid-client-authn-browser",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "license": "MIT",
   "types": "dist/index",
   "browser": "dist/index.js",
@@ -64,8 +64,8 @@
     "webpack-merge": "^5.7.2"
   },
   "dependencies": {
-    "@inrupt/oidc-client-ext": "^1.4.0",
-    "@inrupt/solid-client-authn-core": "^1.4.0",
+    "@inrupt/oidc-client-ext": "^1.4.1",
+    "@inrupt/solid-client-authn-core": "^1.4.1",
     "@types/form-urlencoded": "^2.0.1",
     "@types/lodash.clonedeep": "^4.5.6",
     "@types/node": "^14.14.14",

--- a/packages/browser/src/storage/BrowserStorage.ts
+++ b/packages/browser/src/storage/BrowserStorage.ts
@@ -30,7 +30,9 @@ import { IStorage } from "@inrupt/solid-client-authn-core";
  * @hidden
  */
 export default class BrowserStorage implements IStorage {
-  private storage = window.localStorage;
+  get storage(): typeof window.localStorage {
+    return window.localStorage;
+  }
 
   async get(key: string): Promise<string | undefined> {
     return this.storage.getItem(key) || undefined;

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/solid-client-authn-core",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/solid-client-authn-core",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index",

--- a/packages/node/package-lock.json
+++ b/packages/node/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/solid-client-authn-node",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/solid-client-authn-node",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index",
@@ -30,7 +30,7 @@
     "typescript": "^4.0.5"
   },
   "dependencies": {
-    "@inrupt/solid-client-authn-core": "^1.4.0",
+    "@inrupt/solid-client-authn-core": "^1.4.1",
     "@types/node": "^14.14.14",
     "@types/uuid": "^8.3.0",
     "cross-fetch": "^3.0.6",

--- a/packages/oidc/package-lock.json
+++ b/packages/oidc/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/oidc-client-ext",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/oidc/package.json
+++ b/packages/oidc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/oidc-client-ext",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "A module extending oidc-client-js with new features, such as dynamic client registration and DPoP support.",
   "homepage": "https://github.com/inrupt/solid-client-authn-js/tree/master/packages/oidc/",
   "bugs": "https://github.com/inrupt/solid-client-authn-js/issues",


### PR DESCRIPTION
This prevents the session constructor from throwing errors, which is especially useful in test frameworks which do not stub window, and in SSR contexts such as Next.js which hand control to a single page app.

This specifically fixes the use-case in which the Session context provider is used from the React SDK, which calls a Session constructor; that constructor throws errors in the initial Node rendering of the page before the single-page-app takes over.