### PR TITLE
Only emit login event when session info is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,7 @@ The following sections document changes that have been released already:
 
 #### browser and node
 
-- The `login` even was emitted before setting the session info, which
-could result in a race where the onLogin callback couldn't read session
-information, surch as the WebID.
+- The `onLogin` callback couldn't read session information, such as the WebID.
 
 ## 1.4.1 - 2020-01-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,13 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 The following sections document changes that have been released already:
 
-N/A
+### Bugfix
+
+#### browser and node
+
+- The `login` even was emitted before setting the session info, which
+could result in a race where the onLogin callback couldn't read session
+information, surch as the WebID.
 
 ## 1.4.1 - 2020-01-14
 

--- a/packages/browser/__tests__/Session.spec.ts
+++ b/packages/browser/__tests__/Session.spec.ts
@@ -438,15 +438,8 @@ describe("Session", () => {
   });
 
   describe("onLogin", () => {
-    // The `done` callback is used in order to make sure the callback passed to
-    // onLogin is called.
-    // eslint-disable-next-line jest/no-done-callback
-    it("calls the registered callback on login", async (done) => {
-      const myCallback = jest.fn((): void => {
-        if (done) {
-          done();
-        }
-      });
+    it("calls the registered callback on login", async () => {
+      const myCallback = jest.fn();
       const clientAuthentication = mockClientAuthentication();
       clientAuthentication.handleIncomingRedirect = jest.fn(
         async (_url: string) => {
@@ -504,6 +497,8 @@ describe("Session", () => {
       mySession.onLogin(myCallback);
       await mySession.handleIncomingRedirect("https://some.url");
       expect(myCallback).toHaveBeenCalled();
+      // Verify that the conditional assertion has been called
+      expect.assertions(2);
     });
   });
 

--- a/packages/browser/__tests__/Session.spec.ts
+++ b/packages/browser/__tests__/Session.spec.ts
@@ -442,13 +442,11 @@ describe("Session", () => {
     // onLogin is called.
     // eslint-disable-next-line jest/no-done-callback
     it("calls the registered callback on login", async (done) => {
-      let hasBeenCalled = false;
-      const myCallback = (): void => {
-        hasBeenCalled = true;
+      const myCallback = jest.fn((): void => {
         if (done) {
           done();
         }
-      };
+      });
       const clientAuthentication = mockClientAuthentication();
       clientAuthentication.handleIncomingRedirect = jest.fn(
         async (_url: string) => {
@@ -462,7 +460,7 @@ describe("Session", () => {
       const mySession = new Session({ clientAuthentication });
       mySession.onLogin(myCallback);
       await mySession.handleIncomingRedirect("https://some.url");
-      expect(hasBeenCalled).toEqual(true);
+      expect(myCallback).toHaveBeenCalled();
     });
 
     it("does not call the registered callback if login isn't successful", async () => {
@@ -489,7 +487,6 @@ describe("Session", () => {
     });
 
     it("sets the appropriate information before calling the callback", async () => {
-      let hasBeenCalled = false;
       const clientAuthentication = mockClientAuthentication();
       clientAuthentication.handleIncomingRedirect = jest.fn(
         async (_url: string) => {
@@ -501,13 +498,12 @@ describe("Session", () => {
         }
       );
       const mySession = new Session({ clientAuthentication });
-      const myCallback = (): void => {
-        hasBeenCalled = true;
+      const myCallback = jest.fn((): void => {
         expect(mySession.info.webId).toBe("https://some.webid#them");
-      };
+      });
       mySession.onLogin(myCallback);
       await mySession.handleIncomingRedirect("https://some.url");
-      expect(hasBeenCalled).toEqual(true);
+      expect(myCallback).toHaveBeenCalled();
     });
   });
 

--- a/packages/browser/__tests__/Session.spec.ts
+++ b/packages/browser/__tests__/Session.spec.ts
@@ -487,6 +487,28 @@ describe("Session", () => {
         mySession.handleIncomingRedirect("https://some.url")
       ).resolves.not.toThrow();
     });
+
+    it("sets the appropriate information before calling the callback", async () => {
+      let hasBeenCalled = false;
+      const clientAuthentication = mockClientAuthentication();
+      clientAuthentication.handleIncomingRedirect = jest.fn(
+        async (_url: string) => {
+          return {
+            isLoggedIn: true,
+            sessionId: "a session ID",
+            webId: "https://some.webid#them",
+          };
+        }
+      );
+      const mySession = new Session({ clientAuthentication });
+      const myCallback = (): void => {
+        hasBeenCalled = true;
+        expect(mySession.info.webId).toBe("https://some.webid#them");
+      };
+      mySession.onLogin(myCallback);
+      await mySession.handleIncomingRedirect("https://some.url");
+      expect(hasBeenCalled).toEqual(true);
+    });
   });
 
   describe("onLogout", () => {

--- a/packages/browser/src/Session.ts
+++ b/packages/browser/src/Session.ts
@@ -217,14 +217,14 @@ export class Session extends EventEmitter {
       url
     );
     if (sessionInfo) {
+      this.info.isLoggedIn = sessionInfo.isLoggedIn;
+      this.info.webId = sessionInfo.webId;
+      this.info.sessionId = sessionInfo.sessionId;
       if (sessionInfo.isLoggedIn) {
         // The login event can only be triggered **after** the user has been
         // redirected from the IdP with access and ID tokens.
         this.emit("login");
       }
-      this.info.isLoggedIn = sessionInfo.isLoggedIn;
-      this.info.webId = sessionInfo.webId;
-      this.info.sessionId = sessionInfo.sessionId;
     }
     this.tokenRequestInProgress = false;
     return sessionInfo;

--- a/packages/node/src/Session.spec.ts
+++ b/packages/node/src/Session.spec.ts
@@ -316,6 +316,31 @@ describe("Session", () => {
         mySession.handleIncomingRedirect("https://some.url")
       ).resolves.not.toThrow();
     });
+
+    it("sets the appropriate information before calling the callback", async (done) => {
+      let hasBeenCalled = false;
+      const clientAuthentication = mockClientAuthentication();
+      clientAuthentication.handleIncomingRedirect = jest.fn(
+        async (_url: string) => {
+          return {
+            isLoggedIn: true,
+            sessionId: "a session ID",
+            webId: "https://some.webid#them",
+          };
+        }
+      );
+      const mySession = new Session({ clientAuthentication });
+      const myCallback = (): void => {
+        hasBeenCalled = true;
+        expect(mySession.info.webId).toBe("https://some.webid#them");
+        if (done) {
+          done();
+        }
+      };
+      mySession.onLogin(myCallback);
+      await mySession.handleIncomingRedirect("https://some.url");
+      expect(hasBeenCalled).toEqual(true);
+    });
   });
 
   describe("onLogout", () => {

--- a/packages/node/src/Session.spec.ts
+++ b/packages/node/src/Session.spec.ts
@@ -267,15 +267,8 @@ describe("Session", () => {
   });
 
   describe("onLogin", () => {
-    // The `done` callback is used in order to make sure the callback passed to
-    // onLogin is called.
-    // eslint-disable-next-line jest/no-done-callback
-    it("calls the registered callback on login", async (done) => {
-      const myCallback = jest.fn((): void => {
-        if (done) {
-          done();
-        }
-      });
+    it("calls the registered callback on login", async () => {
+      const myCallback = jest.fn();
       const clientAuthentication = mockClientAuthentication();
       clientAuthentication.handleIncomingRedirect = jest.fn(
         async (_url: string) => {
@@ -333,6 +326,8 @@ describe("Session", () => {
       mySession.onLogin(myCallback);
       await mySession.handleIncomingRedirect("https://some.url");
       expect(myCallback).toHaveBeenCalled();
+      // Verify that the conditional assertion has been called
+      expect.assertions(2);
     });
   });
 

--- a/packages/node/src/Session.spec.ts
+++ b/packages/node/src/Session.spec.ts
@@ -271,13 +271,11 @@ describe("Session", () => {
     // onLogin is called.
     // eslint-disable-next-line jest/no-done-callback
     it("calls the registered callback on login", async (done) => {
-      let hasBeenCalled = false;
-      const myCallback = (): void => {
-        hasBeenCalled = true;
+      const myCallback = jest.fn((): void => {
         if (done) {
           done();
         }
-      };
+      });
       const clientAuthentication = mockClientAuthentication();
       clientAuthentication.handleIncomingRedirect = jest.fn(
         async (_url: string) => {
@@ -291,7 +289,7 @@ describe("Session", () => {
       const mySession = new Session({ clientAuthentication });
       mySession.onLogin(myCallback);
       await mySession.handleIncomingRedirect("https://some.url");
-      expect(hasBeenCalled).toEqual(true);
+      expect(myCallback).toHaveBeenCalled();
     });
 
     it("does not call the registered callback if login isn't successful", async () => {
@@ -317,8 +315,7 @@ describe("Session", () => {
       ).resolves.not.toThrow();
     });
 
-    it("sets the appropriate information before calling the callback", async (done) => {
-      let hasBeenCalled = false;
+    it("sets the appropriate information before calling the callback", async () => {
       const clientAuthentication = mockClientAuthentication();
       clientAuthentication.handleIncomingRedirect = jest.fn(
         async (_url: string) => {
@@ -330,16 +327,12 @@ describe("Session", () => {
         }
       );
       const mySession = new Session({ clientAuthentication });
-      const myCallback = (): void => {
-        hasBeenCalled = true;
+      const myCallback = jest.fn((): void => {
         expect(mySession.info.webId).toBe("https://some.webid#them");
-        if (done) {
-          done();
-        }
-      };
+      });
       mySession.onLogin(myCallback);
       await mySession.handleIncomingRedirect("https://some.url");
-      expect(hasBeenCalled).toEqual(true);
+      expect(myCallback).toHaveBeenCalled();
     });
   });
 

--- a/packages/node/src/Session.ts
+++ b/packages/node/src/Session.ts
@@ -207,21 +207,19 @@ export class Session extends EventEmitter {
         );
 
         if (sessionInfo) {
+          this.info.isLoggedIn = sessionInfo.isLoggedIn;
+          this.info.webId = sessionInfo.webId;
+          this.info.sessionId = sessionInfo.sessionId;
           if (sessionInfo.isLoggedIn) {
             // The login event can only be triggered **after** the user has been
             // redirected from the IdP with access and ID tokens.
             this.emit("login");
           }
-
-          this.info.isLoggedIn = sessionInfo.isLoggedIn;
-          this.info.webId = sessionInfo.webId;
-          this.info.sessionId = sessionInfo.sessionId;
         }
       } finally {
         this.tokenRequestInProgress = false;
       }
     }
-
     return sessionInfo;
   };
 


### PR DESCRIPTION
Resolves #955 

The login even was emitted *before* setting the session info, which
could result in a race where the onLogin callback couldn't read session
information, surch as the WebId.

- [X] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).