### PR TITLE
Feat/1644 multi session/get session from storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ The following sections document changes that have been released already:
 
 #### node
 
-- Add a `getStoredSession` function to retrieve a session from storage based on
+- `getStoredSession`: a function to retrieve a session from storage based on
 its session ID (for multi-session management).
 
 ## 1.4.1 - 2020-01-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ The following sections document changes that have been released already:
 
 - The `onLogin` callback couldn't read session information, such as the WebID.
 
+### New features
+
+#### node
+
+- Add a `getStoredSession` function to retrieve a session from storage based on
+its session ID (for multi-session management).
+
 ## 1.4.1 - 2020-01-14
 
 ### Backward-compatible API changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 The following sections document changes that have been released already:
 
+### New features
+
+#### node
+
+- `getStoredSession`: a function to retrieve a session from storage based on
+its session ID (for multi-session management).
+
 ## 1.4.2 - 2020-01-19
 
 ### Bugfix
@@ -17,13 +24,6 @@ The following sections document changes that have been released already:
 #### browser and node
 
 - The `onLogin` callback couldn't read session information, such as the WebID.
-
-### New features
-
-#### node
-
-- `getStoredSession`: a function to retrieve a session from storage based on
-its session ID (for multi-session management).
 
 ## 1.4.1 - 2020-01-14
 

--- a/packages/browser/__tests__/sessionInfo/SessionInfoManager.spec.ts
+++ b/packages/browser/__tests__/sessionInfo/SessionInfoManager.spec.ts
@@ -76,13 +76,6 @@ describe("SessionInfoManager", () => {
         true
       );
 
-      // const storageUtility = defaultMocks.storageUtility;
-      // storageUtility.getForUser
-      //   .mockReturnValueOnce(
-      //     Promise.resolve("https://zoomies.com/commanderCool#me")
-      //   )
-      //   .mockReturnValueOnce(Promise.resolve("true"));
-
       const sessionManager = getSessionInfoManager({
         storageUtility: storageMock,
       });
@@ -100,6 +93,36 @@ describe("SessionInfoManager", () => {
       });
       const session = await sessionManager.get("commanderCool");
       expect(session).toBeUndefined();
+    });
+
+    it("retrieves internal session information from specified storage", async () => {
+      const sessionId = "commanderCool";
+
+      const webId = "https://zoomies.com/commanderCool#me";
+
+      const storageMock = mockStorageUtility(
+        {
+          [`solidClientAuthenticationUser:${sessionId}`]: {
+            webId,
+            isLoggedIn: "true",
+            refreshToken: "someToken",
+            issuer: "https://my.idp",
+          },
+        },
+        true
+      );
+
+      const sessionManager = getSessionInfoManager({
+        storageUtility: storageMock,
+      });
+      const session = await sessionManager.get(sessionId);
+      expect(session).toMatchObject({
+        sessionId,
+        webId,
+        isLoggedIn: true,
+        refreshToken: "someToken",
+        issuer: "https://my.idp",
+      });
     });
   });
 

--- a/packages/browser/src/sessionInfo/SessionInfoManager.ts
+++ b/packages/browser/src/sessionInfo/SessionInfoManager.ts
@@ -28,6 +28,7 @@ import { inject, injectable } from "tsyringe";
 import {
   ISessionInfo,
   ISessionInfoManager,
+  ISessionInternalInfo,
   ISessionInfoManagerOptions,
   IStorageUtility,
 } from "@inrupt/solid-client-authn-core";
@@ -120,7 +121,9 @@ export class SessionInfoManager implements ISessionInfoManager {
     throw new Error("Not Implemented");
   }
 
-  async get(sessionId: string): Promise<ISessionInfo | undefined> {
+  async get(
+    sessionId: string
+  ): Promise<(ISessionInfo & ISessionInternalInfo) | undefined> {
     const webId = await this.storageUtility.getForUser(sessionId, "webId", {
       secure: true,
     });
@@ -131,18 +134,30 @@ export class SessionInfoManager implements ISessionInfoManager {
         secure: true,
       }
     );
+    const refreshToken = await this.storageUtility.getForUser(
+      sessionId,
+      "refreshToken",
+      {
+        secure: true,
+      }
+    );
+    const issuer = await this.storageUtility.getForUser(sessionId, "issuer", {
+      secure: true,
+    });
     if (isLoggedIn !== undefined) {
       return {
         sessionId,
         webId,
         isLoggedIn: isLoggedIn === "true",
+        refreshToken,
+        issuer,
       };
     }
     return undefined;
   }
 
   // eslint-disable-next-line class-methods-use-this
-  async getAll(): Promise<ISessionInfo[]> {
+  async getAll(): Promise<(ISessionInfo & ISessionInternalInfo)[]> {
     throw new Error("Not implemented");
   }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -38,7 +38,7 @@ export {
 } from "./login/oidc/redirectHandler/IRedirectHandler";
 export { IRedirector, IRedirectorOptions } from "./login/oidc/IRedirector";
 
-export { default as ISessionInfo } from "./sessionInfo/ISessionInfo";
+export { ISessionInfo, ISessionInternalInfo } from "./sessionInfo/ISessionInfo";
 export {
   ISessionInfoManager,
   ISessionInfoManagerOptions,

--- a/packages/core/src/login/oidc/redirectHandler/IRedirectHandler.ts
+++ b/packages/core/src/login/oidc/redirectHandler/IRedirectHandler.ts
@@ -26,7 +26,7 @@
 
 import type { fetch } from "cross-fetch";
 import IHandleable from "../../../util/handlerPattern/IHandleable";
-import ISessionInfo from "../../../sessionInfo/ISessionInfo";
+import { ISessionInfo } from "../../../sessionInfo/ISessionInfo";
 
 export type RedirectResult = ISessionInfo & { fetch: typeof fetch };
 

--- a/packages/core/src/sessionInfo/ISessionInfo.ts
+++ b/packages/core/src/sessionInfo/ISessionInfo.ts
@@ -20,7 +20,8 @@
  */
 
 /**
- * Defines the data that should be persisted for each session.
+ * Defines the data that should be persisted for each session. This interface
+ * is exposed as part of our public API.
  */
 export interface ISessionInfo {
   /**
@@ -40,6 +41,12 @@ export interface ISessionInfo {
   sessionId: string;
 }
 
+/**
+ * Captures information about sessions that is persisted in storage, but that
+ * should not be exposed as part of our public API, and is only used for internal
+ * purpose. It is complementary to ISessionInfo when retrieving all information
+ * about a stored session, both public and internal.
+ */
 export interface ISessionInternalInfo {
   /**
    * The refresh token associated to the session (if any).

--- a/packages/core/src/sessionInfo/ISessionInfo.ts
+++ b/packages/core/src/sessionInfo/ISessionInfo.ts
@@ -22,7 +22,7 @@
 /**
  * Defines the data that should be persisted for each session.
  */
-export default interface ISessionInfo {
+export interface ISessionInfo {
   /**
    * 'true' if the session is currently logged into an associated identity
    * provider.
@@ -38,4 +38,16 @@ export default interface ISessionInfo {
    * A unique identifier for the session.
    */
   sessionId: string;
+}
+
+export interface ISessionInternalInfo {
+  /**
+   * The refresh token associated to the session (if any).
+   */
+  refreshToken?: string;
+
+  /**
+   * The OIDC issuer that issued the tokens authenticating the session.
+   */
+  issuer?: string;
 }

--- a/packages/core/src/sessionInfo/ISessionInfoManager.ts
+++ b/packages/core/src/sessionInfo/ISessionInfoManager.ts
@@ -24,7 +24,7 @@
  * @packageDocumentation
  */
 
-import ISessionInfo from "./ISessionInfo";
+import { ISessionInfo, ISessionInternalInfo } from "./ISessionInfo";
 
 /**
  * @hidden
@@ -39,7 +39,9 @@ export interface ISessionInfoManagerOptions {
  */
 export interface ISessionInfoManager {
   update(sessionId: string, options: ISessionInfoManagerOptions): Promise<void>;
-  get(sessionId: string): Promise<ISessionInfo | undefined>;
-  getAll(): Promise<ISessionInfo[]>;
+  get(
+    sessionId: string
+  ): Promise<(ISessionInfo & ISessionInternalInfo) | undefined>;
+  getAll(): Promise<(ISessionInfo & ISessionInternalInfo)[]>;
   clear(sessionId: string): Promise<void>;
 }

--- a/packages/node/src/ClientAuthentication.ts
+++ b/packages/node/src/ClientAuthentication.ts
@@ -31,6 +31,7 @@ import {
   ILogoutHandler,
   IRedirectHandler,
   ISessionInfo,
+  ISessionInternalInfo,
   ISessionInfoManager,
 } from "@inrupt/solid-client-authn-core";
 import { fetch } from "cross-fetch";
@@ -99,7 +100,7 @@ export default class ClientAuthentication {
 
   getSessionInfo = async (
     sessionId: string
-  ): Promise<ISessionInfo | undefined> => {
+  ): Promise<(ISessionInfo & ISessionInternalInfo) | undefined> => {
     // TODO complete
     return this.sessionInfoManager.get(sessionId);
   };

--- a/packages/node/src/Session.spec.ts
+++ b/packages/node/src/Session.spec.ts
@@ -384,13 +384,11 @@ describe("getStoredSession", () => {
       .fn()
       .mockReturnValue(clientAuthentication);
     const mySession = await getStoredSession("mySession", mockStorage({}));
-    expect(mySession?.info).toEqual(
-      expect.objectContaining({
-        webId: "https://my.webid",
-        isLoggedIn: true,
-        sessionId: "mySession",
-      })
-    );
+    expect(mySession?.info).toStrictEqual({
+      webId: "https://my.webid",
+      isLoggedIn: true,
+      sessionId: "mySession",
+    });
   });
 
   it("returns a logged out Session if no refresh token is available", async () => {
@@ -410,12 +408,11 @@ describe("getStoredSession", () => {
       .fn()
       .mockReturnValue(clientAuthentication);
     const mySession = await getStoredSession("mySession", mockStorage({}));
-    expect(mySession?.info).toEqual(
-      expect.objectContaining({
-        isLoggedIn: false,
-        sessionId: "mySession",
-      })
-    );
+    expect(mySession?.info).toStrictEqual({
+      isLoggedIn: false,
+      sessionId: "mySession",
+      webId: "https://my.webid",
+    });
   });
 
   it("returns undefined if no session id matches in storage", async () => {

--- a/packages/node/src/Session.spec.ts
+++ b/packages/node/src/Session.spec.ts
@@ -24,10 +24,11 @@ import "reflect-metadata";
 import { it, describe } from "@jest/globals";
 import { ISessionInfo } from "@inrupt/solid-client-authn-core";
 import { mockClientAuthentication } from "./__mocks__/ClientAuthentication";
-import { Session } from "./Session";
+import { getStoredSession, Session } from "./Session";
 import { mockStorage } from "../../core/src/storage/__mocks__/StorageUtility";
 
 jest.mock("cross-fetch");
+jest.mock("./dependencies");
 
 describe("Session", () => {
   describe("constructor", () => {
@@ -49,31 +50,43 @@ describe("Session", () => {
     });
 
     it("accepts legacy input storage", async () => {
+      const dependencies = jest.requireMock("./dependencies");
+      dependencies.getClientAuthenticationWithDependencies = jest.fn();
       const insecureStorage = mockStorage({});
       const secureStorage = mockStorage({});
+
       const mySession = new Session({
         insecureStorage,
         secureStorage,
       });
-      const clearSecureStorage = jest.spyOn(secureStorage, "delete");
-      const clearInsecureStorage = jest.spyOn(insecureStorage, "delete");
-      await mySession.logout();
-      expect(clearSecureStorage).toHaveBeenCalled();
-      expect(clearInsecureStorage).toHaveBeenCalled();
+      expect(mySession).not.toBeUndefined();
+      expect(
+        dependencies.getClientAuthenticationWithDependencies
+      ).toHaveBeenCalledWith({
+        secureStorage,
+        insecureStorage,
+      });
     });
 
     it("accepts input storage", async () => {
+      const dependencies = jest.requireMock("./dependencies");
+      dependencies.getClientAuthenticationWithDependencies = jest.fn();
       const storage = mockStorage({});
       const mySession = new Session({
         storage,
       });
-      const clearStorage = jest.spyOn(storage, "delete");
-      await mySession.logout();
-      // The unique storage object should be used as both secure and insecure storage.
-      expect(clearStorage).toHaveBeenCalledTimes(3);
+      expect(mySession).not.toBeUndefined();
+      expect(
+        dependencies.getClientAuthenticationWithDependencies
+      ).toHaveBeenCalledWith({
+        secureStorage: storage,
+        insecureStorage: storage,
+      });
     });
 
     it("ignores legacy input storage if new input storage is specified", async () => {
+      const dependencies = jest.requireMock("./dependencies");
+      dependencies.getClientAuthenticationWithDependencies = jest.fn();
       const insecureStorage = mockStorage({});
       const secureStorage = mockStorage({});
       const storage = mockStorage({});
@@ -82,13 +95,13 @@ describe("Session", () => {
         secureStorage,
         storage,
       });
-      const clearStorage = jest.spyOn(secureStorage, "delete");
-      const clearSecureStorage = jest.spyOn(secureStorage, "delete");
-      const clearInsecureStorage = jest.spyOn(insecureStorage, "delete");
-      await mySession.logout();
-      expect(clearStorage).not.toHaveBeenCalled();
-      expect(clearSecureStorage).not.toHaveBeenCalled();
-      expect(clearInsecureStorage).not.toHaveBeenCalled();
+      expect(mySession).not.toBeUndefined();
+      expect(
+        dependencies.getClientAuthenticationWithDependencies
+      ).toHaveBeenCalledWith({
+        secureStorage: storage,
+        insecureStorage: storage,
+      });
     });
 
     it("accepts session info", () => {
@@ -348,5 +361,89 @@ describe("Session", () => {
       mySession.onLogout(myCallback);
       await mySession.logout();
     });
+  });
+});
+
+describe("getStoredSession", () => {
+  it("returns a logged in Session if a refresh token is available in storage", async () => {
+    const clientAuthentication = mockClientAuthentication();
+    clientAuthentication.getSessionInfo = jest.fn().mockResolvedValue({
+      webId: "https://my.webid",
+      isLoggedIn: true,
+      refreshToken: "some token",
+      issuer: "https://my.idp",
+      sessionId: "mySession",
+    });
+    clientAuthentication.login = jest.fn().mockResolvedValue({
+      webId: "https://my.webid",
+      isLoggedIn: true,
+      sessionId: "mySession",
+    });
+    const dependencies = jest.requireMock("./dependencies");
+    dependencies.getClientAuthenticationWithDependencies = jest
+      .fn()
+      .mockReturnValue(clientAuthentication);
+    const mySession = await getStoredSession("mySession", mockStorage({}));
+    expect(mySession?.info).toEqual(
+      expect.objectContaining({
+        webId: "https://my.webid",
+        isLoggedIn: true,
+        sessionId: "mySession",
+      })
+    );
+  });
+
+  it("returns a logged out Session if no refresh token is available", async () => {
+    const clientAuthentication = mockClientAuthentication();
+    clientAuthentication.getSessionInfo = jest.fn().mockResolvedValueOnce({
+      webId: "https://my.webid",
+      isLoggedIn: true,
+      issuer: "https://my.idp",
+      sessionId: "mySession",
+    });
+    clientAuthentication.logout = jest.fn().mockResolvedValueOnce({
+      isLoggedIn: false,
+      sessionId: "mySession",
+    });
+    const dependencies = jest.requireMock("./dependencies");
+    dependencies.getClientAuthenticationWithDependencies = jest
+      .fn()
+      .mockReturnValue(clientAuthentication);
+    const mySession = await getStoredSession("mySession", mockStorage({}));
+    expect(mySession?.info).toEqual(
+      expect.objectContaining({
+        isLoggedIn: false,
+        sessionId: "mySession",
+      })
+    );
+  });
+
+  it("returns undefined if no session id matches in storage", async () => {
+    const clientAuthentication = mockClientAuthentication();
+    clientAuthentication.getSessionInfo = jest
+      .fn()
+      .mockResolvedValueOnce(undefined);
+    const dependencies = jest.requireMock("./dependencies");
+    dependencies.getClientAuthenticationWithDependencies = jest
+      .fn()
+      .mockReturnValue(clientAuthentication);
+    const mySession = await getStoredSession("mySession", mockStorage({}));
+    expect(mySession?.info).toBeUndefined();
+  });
+
+  it("falls back to the environment storage if none is specified", async () => {
+    const clientAuthentication = mockClientAuthentication();
+    clientAuthentication.getSessionInfo = jest
+      .fn()
+      .mockResolvedValueOnce(undefined);
+    const dependencies = jest.requireMock("./dependencies");
+    dependencies.getClientAuthenticationWithDependencies = jest
+      .fn()
+      .mockReturnValue(clientAuthentication);
+    await getStoredSession("mySession");
+
+    expect(
+      dependencies.getClientAuthenticationWithDependencies
+    ).toHaveBeenCalledWith({});
   });
 });

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -19,7 +19,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-export { Session, ISessionOptions } from "./Session";
+export { Session, ISessionOptions, getStoredSession } from "./Session";
 
 export { SessionManager, ISessionManagerOptions } from "./SessionManager";
 

--- a/packages/node/src/sessionInfo/SessionInfoManager.spec.ts
+++ b/packages/node/src/sessionInfo/SessionInfoManager.spec.ts
@@ -65,13 +65,6 @@ describe("SessionInfoManager", () => {
         },
       });
 
-      // const storageUtility = defaultMocks.storageUtility;
-      // storageUtility.getForUser
-      //   .mockReturnValueOnce(
-      //     Promise.resolve("https://zoomies.com/commanderCool#me")
-      //   )
-      //   .mockReturnValueOnce(Promise.resolve("true"));
-
       const sessionManager = getSessionInfoManager({
         storageUtility: storageMock,
       });
@@ -89,6 +82,33 @@ describe("SessionInfoManager", () => {
       });
       const session = await sessionManager.get("commanderCool");
       expect(session).toBeUndefined();
+    });
+
+    it("retrieves a session internal info from specified storage", async () => {
+      const sessionId = "commanderCool";
+
+      const webId = "https://zoomies.com/commanderCool#me";
+
+      const storageMock = mockStorageUtility({
+        [`solidClientAuthenticationUser:${sessionId}`]: {
+          webId,
+          isLoggedIn: "true",
+          refreshToken: "some token",
+          issuer: "https://my.idp/",
+        },
+      });
+
+      const sessionManager = getSessionInfoManager({
+        storageUtility: storageMock,
+      });
+      const session = await sessionManager.get(sessionId);
+      expect(session).toMatchObject({
+        sessionId,
+        webId,
+        isLoggedIn: true,
+        refreshToken: "some token",
+        issuer: "https://my.idp/",
+      });
     });
   });
 

--- a/packages/node/src/sessionInfo/SessionInfoManager.ts
+++ b/packages/node/src/sessionInfo/SessionInfoManager.ts
@@ -27,6 +27,7 @@
 import { inject, injectable } from "tsyringe";
 import {
   ISessionInfo,
+  ISessionInternalInfo,
   ISessionInfoManager,
   ISessionInfoManagerOptions,
   IStorageUtility,
@@ -111,18 +112,27 @@ export class SessionInfoManager implements ISessionInfoManager {
     throw new Error("Not Implemented");
   }
 
-  async get(sessionId: string): Promise<ISessionInfo | undefined> {
+  async get(
+    sessionId: string
+  ): Promise<(ISessionInfo & ISessionInternalInfo) | undefined> {
     const webId = await this.storageUtility.getForUser(sessionId, "webId");
     const isLoggedIn = await this.storageUtility.getForUser(
       sessionId,
       "isLoggedIn"
     );
+    const refreshToken = await this.storageUtility.getForUser(
+      sessionId,
+      "refreshToken"
+    );
+    const issuer = await this.storageUtility.getForUser(sessionId, "issuer");
 
     if (isLoggedIn !== undefined) {
       return {
         sessionId,
         webId,
         isLoggedIn: isLoggedIn === "true",
+        refreshToken,
+        issuer,
       };
     }
 
@@ -130,7 +140,7 @@ export class SessionInfoManager implements ISessionInfoManager {
   }
 
   // eslint-disable-next-line class-methods-use-this
-  async getAll(): Promise<ISessionInfo[]> {
+  async getAll(): Promise<(ISessionInfo & ISessionInternalInfo)[]> {
     throw new Error("Not implemented");
   }
 


### PR DESCRIPTION
getStoredSession is a function that will return a Session based on its
session ID if the provided ID exists in storage. It is mostly useful to
handle multiple sessions on the server side, where the session object
will not always be available in the scope of the function that processes
some data.

# Checklist

- [X] All acceptance criteria are met.
- [ ] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).