### PR TITLE
add current URL as default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased
 
+- Just as a convenience for the developer, on the `handleIncomingRedirect`
+  method of the `Session` class in the browser package, set the current browser
+  URL as the default value.
+
 The following sections document changes that have been released already:
 
 ### New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,12 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased
 
-- Just as a convenience for the developer, on the `handleIncomingRedirect`
-  method of the `Session` class in the browser package, set the current browser
-  URL as the default value.
+
+### New features
+
+#### browser
+
+- `handleIncomingRedirect` uses the current browser URL as a default value.
 
 The following sections document changes that have been released already:
 

--- a/packages/browser/__tests__/ClientAuthentication.spec.ts
+++ b/packages/browser/__tests__/ClientAuthentication.spec.ts
@@ -146,7 +146,7 @@ describe("ClientAuthentication", () => {
         "https://coolapp.com/redirect?state=userId&id_token=idToken&access_token=accessToken";
       await clientAuthn.handleIncomingRedirect(url);
 
-      // Calling handleredirect should give us an authenticated fetch.
+      // Calling handle redirect should give us an authenticated fetch.
       expect(clientAuthn.fetch).not.toBe(unauthFetch);
 
       await clientAuthn.logout("mySession");
@@ -198,7 +198,7 @@ describe("ClientAuthentication", () => {
       });
       expect(defaultMocks.redirectHandler.handle).toHaveBeenCalledWith(url);
 
-      // Calling handleredirect should have updated the fetch.
+      // Calling handle redirect should have updated the fetch.
       expect(clientAuthn.fetch).not.toBe(unauthFetch);
     });
 

--- a/packages/browser/__tests__/ClientAuthentication.spec.ts
+++ b/packages/browser/__tests__/ClientAuthentication.spec.ts
@@ -146,7 +146,7 @@ describe("ClientAuthentication", () => {
         "https://coolapp.com/redirect?state=userId&id_token=idToken&access_token=accessToken";
       await clientAuthn.handleIncomingRedirect(url);
 
-      // Calling handle redirect should give us an authenticated fetch.
+      // Calling the redirect handler should give us an authenticated fetch.
       expect(clientAuthn.fetch).not.toBe(unauthFetch);
 
       await clientAuthn.logout("mySession");
@@ -198,7 +198,7 @@ describe("ClientAuthentication", () => {
       });
       expect(defaultMocks.redirectHandler.handle).toHaveBeenCalledWith(url);
 
-      // Calling handle redirect should have updated the fetch.
+      // Calling the redirect handler should have updated the fetch.
       expect(clientAuthn.fetch).not.toBe(unauthFetch);
     });
 

--- a/packages/browser/__tests__/Session.spec.ts
+++ b/packages/browser/__tests__/Session.spec.ts
@@ -192,14 +192,14 @@ describe("Session", () => {
         window.history.replaceState = jest.fn();
 
         const clientAuthentication = mockClientAuthentication();
-        const clientAuthnHandler = jest.spyOn(
+        const incomingRedirectHandler = jest.spyOn(
           clientAuthentication,
           "handleIncomingRedirect"
         );
 
         const mySession = new Session({ clientAuthentication });
         await mySession.handleIncomingRedirect();
-        expect(clientAuthnHandler).toHaveBeenCalledWith(defaultLocation);
+        expect(incomingRedirectHandler).toHaveBeenCalledWith(defaultLocation);
       } finally {
         // Restore our 'window' state.
         window.location = location;
@@ -211,13 +211,13 @@ describe("Session", () => {
       // eslint-disable-next-line no-restricted-globals
       history.replaceState = jest.fn();
       const clientAuthentication = mockClientAuthentication();
-      const clientAuthnHandler = jest.spyOn(
+      const incomingRedirectHandler = jest.spyOn(
         clientAuthentication,
         "handleIncomingRedirect"
       );
       const mySession = new Session({ clientAuthentication });
       await mySession.handleIncomingRedirect("https://some.url");
-      expect(clientAuthnHandler).toHaveBeenCalled();
+      expect(incomingRedirectHandler).toHaveBeenCalled();
     });
 
     it("updates the session's info if relevant", async () => {
@@ -313,7 +313,7 @@ describe("Session", () => {
 
     it("preserves a binding to its Session instance", async () => {
       const clientAuthentication = mockClientAuthentication();
-      const clientAuthnHandlerIncomingRedirect = jest.spyOn(
+      const incomingRedirectHandler = jest.spyOn(
         clientAuthentication,
         "handleIncomingRedirect"
       );
@@ -324,7 +324,7 @@ describe("Session", () => {
       await objectWithHandleIncomingRedirect.handleIncomingRedirect(
         "https://some.url"
       );
-      expect(clientAuthnHandlerIncomingRedirect).toHaveBeenCalled();
+      expect(incomingRedirectHandler).toHaveBeenCalled();
     });
 
     // This workaround will be removed after we've settled on an API that allows us to silently

--- a/packages/browser/src/Session.ts
+++ b/packages/browser/src/Session.ts
@@ -142,12 +142,16 @@ export class Session extends EventEmitter {
   };
 
   /**
-   * Completes the login process by processing the information provided by the Solid identity provider through redirect.
+   * Completes the login process by processing the information provided by the
+   * Solid identity provider through redirect.
    *
-   * @param url The URL of the page handling the redirect, including the query parameters — these contain the information to process the login.
+   * @param url The URL of the page handling the redirect, including the query
+   * parameters — these contain the information to process the login.
+   * Note: as a convenience, if no URL value is specified here, we default to
+   * using the browser's current location.
    */
   handleIncomingRedirect = async (
-    url: string
+    url: string = window.location.href
   ): Promise<ISessionInfo | undefined> => {
     if (this.info.isLoggedIn) {
       return this.info;

--- a/packages/node/src/ClientAuthentication.spec.ts
+++ b/packages/node/src/ClientAuthentication.spec.ts
@@ -143,7 +143,7 @@ describe("ClientAuthentication", () => {
         "https://coolapp.com/redirect?state=userId&id_token=idToken&access_token=accessToken";
       await clientAuthn.handleIncomingRedirect(url);
 
-      // Calling handle redirect should give us an authenticated fetch.
+      // Calling the redirect handler should give us an authenticated fetch.
       expect(clientAuthn.fetch).not.toBe(unauthFetch);
 
       await clientAuthn.logout("mySession");
@@ -194,7 +194,7 @@ describe("ClientAuthentication", () => {
       });
       expect(defaultMocks.redirectHandler.handle).toHaveBeenCalledWith(url);
 
-      // Calling handle redirect should have updated the fetch.
+      // Calling the redirect handler should have updated the fetch.
       expect(clientAuthn.fetch).not.toBe(unauthFetch);
     });
   });

--- a/packages/node/src/ClientAuthentication.spec.ts
+++ b/packages/node/src/ClientAuthentication.spec.ts
@@ -143,7 +143,7 @@ describe("ClientAuthentication", () => {
         "https://coolapp.com/redirect?state=userId&id_token=idToken&access_token=accessToken";
       await clientAuthn.handleIncomingRedirect(url);
 
-      // Calling handleredirect should give us an authenticated fetch.
+      // Calling handle redirect should give us an authenticated fetch.
       expect(clientAuthn.fetch).not.toBe(unauthFetch);
 
       await clientAuthn.logout("mySession");
@@ -194,7 +194,7 @@ describe("ClientAuthentication", () => {
       });
       expect(defaultMocks.redirectHandler.handle).toHaveBeenCalledWith(url);
 
-      // Calling handleredirect should have updated the fetch.
+      // Calling handle redirect should have updated the fetch.
       expect(clientAuthn.fetch).not.toBe(unauthFetch);
     });
   });


### PR DESCRIPTION
# New feature description
On the handleIncomingRedirect method of the Session class, set
the current browser URL as the default value, just as a
convenience for the developer.

# Checklist

- [X] All acceptance criteria are met.
- [X] Relevant documentation, if any, has been written/updated.
- [X] The changelog has been updated, if applicable.
- [X] New functions/types have been exported in `index.ts`, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
