### PR TITLE
Renamed getStoredSession to getSessionFromStorage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The following sections document changes that have been released already:
 
 #### node
 
-- `getStoredSession`: a function to retrieve a session from storage based on
+- `getSessionFromStorage`: a function to retrieve a session from storage based on
 its session ID (for multi-session management).
 
 ## 1.4.2 - 2020-01-19

--- a/packages/node/src/Session.spec.ts
+++ b/packages/node/src/Session.spec.ts
@@ -24,7 +24,7 @@ import "reflect-metadata";
 import { it, describe } from "@jest/globals";
 import { ISessionInfo } from "@inrupt/solid-client-authn-core";
 import { mockClientAuthentication } from "./__mocks__/ClientAuthentication";
-import { getStoredSession, Session } from "./Session";
+import { getSessionFromStorage, Session } from "./Session";
 import { mockStorage } from "../../core/src/storage/__mocks__/StorageUtility";
 
 jest.mock("cross-fetch");
@@ -383,7 +383,7 @@ describe("getStoredSession", () => {
     dependencies.getClientAuthenticationWithDependencies = jest
       .fn()
       .mockReturnValue(clientAuthentication);
-    const mySession = await getStoredSession("mySession", mockStorage({}));
+    const mySession = await getSessionFromStorage("mySession", mockStorage({}));
     expect(mySession?.info).toStrictEqual({
       webId: "https://my.webid",
       isLoggedIn: true,
@@ -407,7 +407,7 @@ describe("getStoredSession", () => {
     dependencies.getClientAuthenticationWithDependencies = jest
       .fn()
       .mockReturnValue(clientAuthentication);
-    const mySession = await getStoredSession("mySession", mockStorage({}));
+    const mySession = await getSessionFromStorage("mySession", mockStorage({}));
     expect(mySession?.info).toStrictEqual({
       isLoggedIn: false,
       sessionId: "mySession",
@@ -424,7 +424,7 @@ describe("getStoredSession", () => {
     dependencies.getClientAuthenticationWithDependencies = jest
       .fn()
       .mockReturnValue(clientAuthentication);
-    const mySession = await getStoredSession("mySession", mockStorage({}));
+    const mySession = await getSessionFromStorage("mySession", mockStorage({}));
     expect(mySession?.info).toBeUndefined();
   });
 
@@ -437,7 +437,7 @@ describe("getStoredSession", () => {
     dependencies.getClientAuthenticationWithDependencies = jest
       .fn()
       .mockReturnValue(clientAuthentication);
-    await getStoredSession("mySession");
+    await getSessionFromStorage("mySession");
 
     expect(
       dependencies.getClientAuthenticationWithDependencies

--- a/packages/node/src/Session.spec.ts
+++ b/packages/node/src/Session.spec.ts
@@ -364,7 +364,7 @@ describe("Session", () => {
   });
 });
 
-describe("getStoredSession", () => {
+describe("getSessionFromStorage", () => {
   it("returns a logged in Session if a refresh token is available in storage", async () => {
     const clientAuthentication = mockClientAuthentication();
     clientAuthentication.getSessionInfo = jest.fn().mockResolvedValue({

--- a/packages/node/src/Session.ts
+++ b/packages/node/src/Session.ts
@@ -244,7 +244,7 @@ export class Session extends EventEmitter {
   }
 }
 
-export async function getStoredSession(
+export async function getSessionFromStorage(
   sessionId: string,
   storage?: IStorage
 ): Promise<Session | undefined> {

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -19,7 +19,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-export { Session, ISessionOptions, getStoredSession } from "./Session";
+export { Session, ISessionOptions, getSessionFromStorage } from "./Session";
 
 export { SessionManager, ISessionManagerOptions } from "./SessionManager";
 


### PR DESCRIPTION
This completes the change from https://github.com/inrupt/solid-client-authn-js/pull/962, where a review comment has been forgotten.