### PR TITLE
Feat/1644 multi session/get session from storage all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,9 @@ The following sections document changes that have been released already:
 
 - `getSessionFromStorage`: a function to retrieve a session from storage based on
 its session ID (for multi-session management).
-- `getStoredSessionIdAll`: a function to retrieve the session IDs for all stored
+- `getSessionIdFromStorageAll`: a function to retrieve the session IDs for all stored
 sessions.
-- `clearSessionAll`: a function to clear all information about all sessions in
+- `clearSessionFromStorageAll`: a function to clear all information about all sessions in
 storage.
 
 ## 1.4.2 - 2020-01-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ The following sections document changes that have been released already:
 
 - `getSessionFromStorage`: a function to retrieve a session from storage based on
 its session ID (for multi-session management).
+- `getStoredSessionIdAll`: a function to retrieve the session IDs for all stored
+sessions.
+- `clearSessionAll`: a function to clear all information about all sessions in
+storage.
 
 ## 1.4.2 - 2020-01-19
 

--- a/packages/browser/src/SessionManager.ts
+++ b/packages/browser/src/SessionManager.ts
@@ -38,6 +38,8 @@ export interface ISessionManager {
 /**
  * A SessionManager instance can be used to manage all the sessions in an
  * application, each session being associated with an individual user.
+ *
+ * @deprecated
  */
 @injectable()
 export class SessionManager extends EventEmitter implements ISessionManager {

--- a/packages/browser/src/sessionInfo/SessionInfoManager.ts
+++ b/packages/browser/src/sessionInfo/SessionInfoManager.ts
@@ -170,4 +170,26 @@ export class SessionInfoManager implements ISessionInfoManager {
   async clear(sessionId: string): Promise<void> {
     return clear(sessionId, this.storageUtility);
   }
+
+  /**
+   * Registers a new session, so that its ID can be retrieved.
+   * @param sessionId
+   */
+  async register(_sessionId: string): Promise<void> {
+    throw new Error("Unimplemented");
+  }
+  /**
+   * Returns all the registered session IDs. Differs from getAll, which also
+   * returns additional session information.
+   */
+  async getRegisteredSessionIdAll(): Promise<string[]> {
+    throw new Error("Unimplemented");
+  }
+
+  /**
+   * Deletes all information about all sessions, including their registrations.
+   */
+  async clearAll(): Promise<void> {
+    throw new Error("Unimplemented");
+  }
 }

--- a/packages/browser/src/sessionInfo/SessionInfoManager.ts
+++ b/packages/browser/src/sessionInfo/SessionInfoManager.ts
@@ -178,6 +178,7 @@ export class SessionInfoManager implements ISessionInfoManager {
   async register(_sessionId: string): Promise<void> {
     throw new Error("Unimplemented");
   }
+
   /**
    * Returns all the registered session IDs. Differs from getAll, which also
    * returns additional session information.

--- a/packages/browser/src/sessionInfo/__mocks__/SessionInfoManager.ts
+++ b/packages/browser/src/sessionInfo/__mocks__/SessionInfoManager.ts
@@ -36,17 +36,15 @@ export const SessionCreatorGetSessionResponse: ISessionInfo = SessionCreatorCrea
 
 export const SessionInfoManagerMock: jest.Mocked<ISessionInfoManager> = {
   update: jest.fn(
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function
-    async (sessionId: string, options: ISessionInfoManagerOptions) => {}
+    async (_sessionId: string, _options: ISessionInfoManagerOptions) => {}
   ),
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  get: jest.fn(async (sessionId: string) =>
+  get: jest.fn(async (_sessionId: string) =>
     Promise.resolve(SessionCreatorCreateResponse)
   ),
   getAll: jest.fn(async () => Promise.resolve([SessionCreatorCreateResponse])),
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  clear: jest.fn(async (sessionId: string) => Promise.resolve()),
-  register: jest.fn(async (sessionId: string) => Promise.resolve()),
+  clear: jest.fn(async (_sessionId: string) => Promise.resolve()),
+  register: jest.fn(async (_sessionId: string) => Promise.resolve()),
   clearAll: jest.fn(async () => Promise.resolve()),
   getRegisteredSessionIdAll: jest.fn(async () => Promise.resolve([])),
 };

--- a/packages/browser/src/sessionInfo/__mocks__/SessionInfoManager.ts
+++ b/packages/browser/src/sessionInfo/__mocks__/SessionInfoManager.ts
@@ -46,6 +46,9 @@ export const SessionInfoManagerMock: jest.Mocked<ISessionInfoManager> = {
   getAll: jest.fn(async () => Promise.resolve([SessionCreatorCreateResponse])),
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   clear: jest.fn(async (sessionId: string) => Promise.resolve()),
+  register: jest.fn(async (sessionId: string) => Promise.resolve()),
+  clearAll: jest.fn(async () => Promise.resolve()),
+  getRegisteredSessionIdAll: jest.fn(async () => Promise.resolve([])),
 };
 
 export function mockSessionInfoManager(

--- a/packages/core/src/sessionInfo/ISessionInfoManager.ts
+++ b/packages/core/src/sessionInfo/ISessionInfoManager.ts
@@ -39,9 +39,34 @@ export interface ISessionInfoManagerOptions {
  */
 export interface ISessionInfoManager {
   update(sessionId: string, options: ISessionInfoManagerOptions): Promise<void>;
+  /**
+   * Returns all information about a registered session
+   * @param sessionId
+   */
   get(
     sessionId: string
   ): Promise<(ISessionInfo & ISessionInternalInfo) | undefined>;
+  /**
+   * Returns all information about all registered sessions
+   */
   getAll(): Promise<(ISessionInfo & ISessionInternalInfo)[]>;
+  /**
+   * Registers a new session, so that its ID can be retrieved.
+   * @param sessionId
+   */
+  register(sessionId: string): Promise<void>;
+  /**
+   * Returns all the registered session IDs. Differs from getAll, which also
+   * returns additional session information.
+   */
+  getRegisteredSessionIdAll(): Promise<string[]>;
+  /**
+   * Deletes all information regarding one session, including its registration.
+   * @param sessionId
+   */
   clear(sessionId: string): Promise<void>;
+  /**
+   * Deletes all information about all sessions, including their registrations.
+   */
+  clearAll(): Promise<void>;
 }

--- a/packages/node/src/ClientAuthentication.spec.ts
+++ b/packages/node/src/ClientAuthentication.spec.ts
@@ -182,6 +182,45 @@ describe("ClientAuthentication", () => {
     });
   });
 
+  describe("getSessionIdAll", () => {
+    it("calls the session manager", async () => {
+      const sessionInfoManager = mockSessionInfoManager(mockStorageUtility({}));
+      const sessionManagerGetAllSpy = jest.spyOn(
+        sessionInfoManager,
+        "getRegisteredSessionIdAll"
+      );
+      const clientAuthn = getClientAuthentication({
+        sessionInfoManager,
+      });
+      await clientAuthn.getSessionIdAll();
+      expect(sessionManagerGetAllSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe("registerSession", () => {
+    it("calls the session manager", async () => {
+      const sessionInfoManager = mockSessionInfoManager(mockStorageUtility({}));
+      const sessionManagerRegister = jest.spyOn(sessionInfoManager, "register");
+      const clientAuthn = getClientAuthentication({
+        sessionInfoManager,
+      });
+      await clientAuthn.registerSession("some session");
+      expect(sessionManagerRegister).toHaveBeenCalled();
+    });
+  });
+
+  describe("clearSessionAll", () => {
+    it("calls the session manager", async () => {
+      const sessionInfoManager = mockSessionInfoManager(mockStorageUtility({}));
+      const sessionManagerClearAll = jest.spyOn(sessionInfoManager, "clearAll");
+      const clientAuthn = getClientAuthentication({
+        sessionInfoManager,
+      });
+      await clientAuthn.clearSessionAll();
+      expect(sessionManagerClearAll).toHaveBeenCalled();
+    });
+  });
+
   describe("handleIncomingRedirect", () => {
     it("calls handle redirect", async () => {
       const clientAuthn = getClientAuthentication();

--- a/packages/node/src/ClientAuthentication.ts
+++ b/packages/node/src/ClientAuthentication.ts
@@ -59,6 +59,8 @@ export default class ClientAuthentication {
     // could return to a previous redirect URL that contains OIDC params that
     // are now longer valid - so just to be safe, strip relevant params now.
     const { redirectUrl } = options;
+    // Keep track of the session ID
+    await this.sessionInfoManager.register(sessionId);
     const loginReturn = await this.loginHandler.handle({
       sessionId,
       oidcIssuer: options.oidcIssuer,
@@ -103,6 +105,18 @@ export default class ClientAuthentication {
   ): Promise<(ISessionInfo & ISessionInternalInfo) | undefined> => {
     // TODO complete
     return this.sessionInfoManager.get(sessionId);
+  };
+
+  getSessionIdAll = async (): Promise<string[]> => {
+    return this.sessionInfoManager.getRegisteredSessionIdAll();
+  };
+
+  registerSession = async (sessionId: string): Promise<void> => {
+    return this.sessionInfoManager.register(sessionId);
+  };
+
+  clearSessionAll = async (): Promise<void> => {
+    return this.sessionInfoManager.clearAll();
   };
 
   getAllSessionInfo = async (): Promise<ISessionInfo[]> => {

--- a/packages/node/src/ClientAuthentication.ts
+++ b/packages/node/src/ClientAuthentication.ts
@@ -55,9 +55,6 @@ export default class ClientAuthentication {
     sessionId: string,
     options: ILoginInputOptions
   ): Promise<ISessionInfo | undefined> => {
-    // In the case of the user hitting the 'back' button in their browser, they
-    // could return to a previous redirect URL that contains OIDC params that
-    // are now longer valid - so just to be safe, strip relevant params now.
     const { redirectUrl } = options;
     // Keep track of the session ID
     await this.sessionInfoManager.register(sessionId);

--- a/packages/node/src/Session.spec.ts
+++ b/packages/node/src/Session.spec.ts
@@ -31,9 +31,9 @@ import {
   mockCustomClientAuthentication,
 } from "./__mocks__/ClientAuthentication";
 import {
-  clearSessionAll,
+  clearSessionFromStorageAll,
   getSessionFromStorage,
-  getStoredSessionIdAll,
+  getSessionIdFromStorageAll,
   Session,
 } from "./Session";
 import { mockStorage } from "../../core/src/storage/__mocks__/StorageUtility";
@@ -474,7 +474,7 @@ describe("getStoredSessionIdAll", () => {
     dependencies.getClientAuthenticationWithDependencies = jest
       .fn()
       .mockReturnValue(clientAuthentication);
-    const sessions = await getStoredSessionIdAll(mockStorage({}));
+    const sessions = await getSessionIdFromStorageAll(mockStorage({}));
     expect(sessions).toStrictEqual(["a session", "another session"]);
   });
 
@@ -493,7 +493,7 @@ describe("getStoredSessionIdAll", () => {
     dependencies.getClientAuthenticationWithDependencies = jest
       .fn()
       .mockReturnValue(clientAuthentication);
-    await getStoredSessionIdAll();
+    await getSessionIdFromStorageAll();
 
     expect(
       dependencies.getClientAuthenticationWithDependencies
@@ -517,7 +517,7 @@ describe("clearSessionAll", () => {
     dependencies.getClientAuthenticationWithDependencies = jest
       .fn()
       .mockReturnValue(clientAuthentication);
-    await clearSessionAll(storage);
+    await clearSessionFromStorageAll(storage);
     await expect(storage.get(REGISTERED_SESSIONS_KEY)).resolves.toStrictEqual(
       JSON.stringify([])
     );
@@ -533,7 +533,7 @@ describe("clearSessionAll", () => {
     dependencies.getClientAuthenticationWithDependencies = jest
       .fn()
       .mockReturnValue(clientAuthentication);
-    await clearSessionAll();
+    await clearSessionFromStorageAll();
 
     expect(
       dependencies.getClientAuthenticationWithDependencies

--- a/packages/node/src/Session.ts
+++ b/packages/node/src/Session.ts
@@ -272,7 +272,7 @@ export async function getSessionFromStorage(
   return session;
 }
 
-export async function getStoredSessionIdAll(
+export async function getSessionIdFromStorageAll(
   storage?: IStorage
 ): Promise<string[]> {
   const clientAuth: ClientAuthentication = storage
@@ -284,7 +284,9 @@ export async function getStoredSessionIdAll(
   return clientAuth.getSessionIdAll();
 }
 
-export async function clearSessionAll(storage?: IStorage): Promise<void> {
+export async function clearSessionFromStorageAll(
+  storage?: IStorage
+): Promise<void> {
   const clientAuth: ClientAuthentication = storage
     ? getClientAuthenticationWithDependencies({
         secureStorage: storage,

--- a/packages/node/src/Session.ts
+++ b/packages/node/src/Session.ts
@@ -271,3 +271,25 @@ export async function getSessionFromStorage(
   }
   return session;
 }
+
+export async function getStoredSessionIdAll(
+  storage?: IStorage
+): Promise<string[]> {
+  const clientAuth: ClientAuthentication = storage
+    ? getClientAuthenticationWithDependencies({
+        secureStorage: storage,
+        insecureStorage: storage,
+      })
+    : getClientAuthenticationWithDependencies({});
+  return clientAuth.getSessionIdAll();
+}
+
+export async function clearSessionAll(storage?: IStorage): Promise<void> {
+  const clientAuth: ClientAuthentication = storage
+    ? getClientAuthenticationWithDependencies({
+        secureStorage: storage,
+        insecureStorage: storage,
+      })
+    : getClientAuthenticationWithDependencies({});
+  return clientAuth.clearSessionAll();
+}

--- a/packages/node/src/SessionManager.ts
+++ b/packages/node/src/SessionManager.ts
@@ -38,6 +38,7 @@ export interface ISessionManager {
 /**
  * A SessionManager instance can be used to manage all the sessions in an
  * application, each session being associated with an individual user.
+ * @deprecated
  */
 @injectable()
 export class SessionManager extends EventEmitter implements ISessionManager {

--- a/packages/node/src/__mocks__/ClientAuthentication.ts
+++ b/packages/node/src/__mocks__/ClientAuthentication.ts
@@ -25,6 +25,7 @@ import {
   IRedirectHandler,
   ISessionInfoManager,
   IStorageUtility,
+  mockStorageUtility,
 } from "@inrupt/solid-client-authn-core";
 import ClientAuthentication from "../ClientAuthentication";
 import { RedirectHandlerMock } from "../login/oidc/redirectHandler/__mocks__/RedirectHandler";
@@ -56,10 +57,12 @@ type CustomMocks = {
 
 export const mockCustomClientAuthentication = (
   mocks: Partial<CustomMocks>
-): ClientAuthentication =>
-  new ClientAuthentication(
+): ClientAuthentication => {
+  const storage = mocks.storage ?? mockStorageUtility({});
+  return new ClientAuthentication(
     mocks.loginHandler ?? LoginHandlerMock,
     mocks.redirectHandler ?? RedirectHandlerMock,
-    mocks.logoutHandler ?? mockLogoutHandler(mocks.storage!),
-    mocks.sessionInfoManager ?? mockSessionInfoManager(mocks.storage!)
+    mocks.logoutHandler ?? mockLogoutHandler(storage),
+    mocks.sessionInfoManager ?? mockSessionInfoManager(storage)
   );
+};

--- a/packages/node/src/__mocks__/ClientAuthentication.ts
+++ b/packages/node/src/__mocks__/ClientAuthentication.ts
@@ -19,11 +19,24 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+import {
+  ILoginHandler,
+  ILogoutHandler,
+  IRedirectHandler,
+  ISessionInfoManager,
+  IStorageUtility,
+} from "@inrupt/solid-client-authn-core";
 import ClientAuthentication from "../ClientAuthentication";
 import { RedirectHandlerMock } from "../login/oidc/redirectHandler/__mocks__/RedirectHandler";
 import { LoginHandlerMock } from "../login/__mocks__/LoginHandler";
-import { LogoutHandlerMock } from "../logout/__mocks__/LogoutHandler";
-import { SessionInfoManagerMock } from "../sessionInfo/__mocks__/SessionInfoManager";
+import {
+  LogoutHandlerMock,
+  mockLogoutHandler,
+} from "../logout/__mocks__/LogoutHandler";
+import {
+  mockSessionInfoManager,
+  SessionInfoManagerMock,
+} from "../sessionInfo/__mocks__/SessionInfoManager";
 
 export const mockClientAuthentication = (): ClientAuthentication =>
   new ClientAuthentication(
@@ -31,4 +44,22 @@ export const mockClientAuthentication = (): ClientAuthentication =>
     RedirectHandlerMock,
     LogoutHandlerMock,
     SessionInfoManagerMock
+  );
+
+type CustomMocks = {
+  storage: IStorageUtility;
+  sessionInfoManager: ISessionInfoManager;
+  loginHandler: ILoginHandler;
+  redirectHandler: IRedirectHandler;
+  logoutHandler: ILogoutHandler;
+};
+
+export const mockCustomClientAuthentication = (
+  mocks: Partial<CustomMocks>
+): ClientAuthentication =>
+  new ClientAuthentication(
+    mocks.loginHandler ?? LoginHandlerMock,
+    mocks.redirectHandler ?? RedirectHandlerMock,
+    mocks.logoutHandler ?? mockLogoutHandler(mocks.storage!),
+    mocks.sessionInfoManager ?? mockSessionInfoManager(mocks.storage!)
   );

--- a/packages/node/src/constants.ts
+++ b/packages/node/src/constants.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2021 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+export const REGISTERED_SESSIONS_KEY = "solidClientAuthn:registeredSessions";

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -19,17 +19,13 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-<<<<<<< HEAD
-export { Session, ISessionOptions, getSessionFromStorage } from "./Session";
-=======
 export {
   Session,
   ISessionOptions,
-  getStoredSession,
-  getStoredSessionIdAll,
-  clearSessionAll,
+  getSessionFromStorage,
+  getSessionIdFromStorageAll,
+  clearSessionFromStorageAll,
 } from "./Session";
->>>>>>> EUpdated exports and changelog
 
 export { SessionManager, ISessionManagerOptions } from "./SessionManager";
 

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -19,7 +19,17 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+<<<<<<< HEAD
 export { Session, ISessionOptions, getSessionFromStorage } from "./Session";
+=======
+export {
+  Session,
+  ISessionOptions,
+  getStoredSession,
+  getStoredSessionIdAll,
+  clearSessionAll,
+} from "./Session";
+>>>>>>> EUpdated exports and changelog
 
 export { SessionManager, ISessionManagerOptions } from "./SessionManager";
 

--- a/packages/node/src/sessionInfo/SessionInfoManager.spec.ts
+++ b/packages/node/src/sessionInfo/SessionInfoManager.spec.ts
@@ -24,6 +24,7 @@ import { mockStorageUtility } from "@inrupt/solid-client-authn-core";
 import { UuidGeneratorMock } from "../util/__mocks__/UuidGenerator";
 import { LogoutHandlerMock } from "../logout/__mocks__/LogoutHandler";
 import { SessionInfoManager } from "./SessionInfoManager";
+import { REGISTERED_SESSIONS_KEY } from "../constants";
 
 describe("SessionInfoManager", () => {
   const defaultMocks = {
@@ -166,6 +167,97 @@ describe("SessionInfoManager", () => {
         storageUtility: mockStorageUtility({}),
       });
       await expect(sessionManager.getAll).rejects.toThrow("Not implemented");
+    });
+  });
+
+  describe("register", () => {
+    it("adds a new entry in the registered sessions list", async () => {
+      const storage = mockStorageUtility({});
+      const sessionManager = getSessionInfoManager({
+        storageUtility: storage,
+      });
+      await sessionManager.register("someSession");
+
+      await expect(storage.get(REGISTERED_SESSIONS_KEY)).resolves.toBe(
+        JSON.stringify(["someSession"])
+      );
+    });
+
+    it("does not overwrite registered sessions already in storage", async () => {
+      const storage = mockStorageUtility({
+        [REGISTERED_SESSIONS_KEY]: JSON.stringify(["some existing session"]),
+      });
+      const sessionManager = getSessionInfoManager({
+        storageUtility: storage,
+      });
+      await sessionManager.register("some session");
+
+      await expect(storage.get(REGISTERED_SESSIONS_KEY)).resolves.toBe(
+        JSON.stringify(["some existing session", "some session"])
+      );
+    });
+
+    it("does not register an already registered session", async () => {
+      const storage = mockStorageUtility({
+        [REGISTERED_SESSIONS_KEY]: JSON.stringify(["some session"]),
+      });
+      const sessionManager = getSessionInfoManager({
+        storageUtility: storage,
+      });
+      await sessionManager.register("some session");
+
+      await expect(storage.get(REGISTERED_SESSIONS_KEY)).resolves.toBe(
+        JSON.stringify(["some session"])
+      );
+    });
+
+    it("does not overwrite registered sessions", async () => {
+      const storage = mockStorageUtility({});
+      const sessionManager = getSessionInfoManager({
+        storageUtility: storage,
+      });
+      await sessionManager.register("some session");
+      await sessionManager.register("some other session");
+
+      await expect(storage.get(REGISTERED_SESSIONS_KEY)).resolves.toBe(
+        JSON.stringify(["some session", "some other session"])
+      );
+    });
+  });
+
+  describe("getRegisteredSessionIdAll", () => {
+    it("returns a list of all registered session IDs", async () => {
+      const sessionManager = getSessionInfoManager({
+        storageUtility: mockStorageUtility({}),
+      });
+      await expect(sessionManager.getRegisteredSessionIdAll()).rejects.toThrow(
+        "Unimplemented"
+      );
+    });
+
+    it("returns an empty list if no session IDs are registered", async () => {
+      const sessionManager = getSessionInfoManager({
+        storageUtility: mockStorageUtility({}),
+      });
+      await expect(sessionManager.getRegisteredSessionIdAll()).rejects.toThrow(
+        "Unimplemented"
+      );
+    });
+  });
+
+  describe("clearAll", () => {
+    it("clears all sessions registrations", async () => {
+      const sessionManager = getSessionInfoManager({
+        storageUtility: mockStorageUtility({}),
+      });
+      await expect(sessionManager.clearAll()).rejects.toThrow("Unimplemented");
+    });
+
+    it("clears all sessions information", async () => {
+      const sessionManager = getSessionInfoManager({
+        storageUtility: mockStorageUtility({}),
+      });
+      await expect(sessionManager.clearAll()).rejects.toThrow("Unimplemented");
     });
   });
 });

--- a/packages/node/src/sessionInfo/SessionInfoManager.spec.ts
+++ b/packages/node/src/sessionInfo/SessionInfoManager.spec.ts
@@ -227,21 +227,28 @@ describe("SessionInfoManager", () => {
 
   describe("getRegisteredSessionIdAll", () => {
     it("returns a list of all registered session IDs", async () => {
-      const sessionManager = getSessionInfoManager({
-        storageUtility: mockStorageUtility({}),
+      const storage = mockStorageUtility({
+        [REGISTERED_SESSIONS_KEY]: JSON.stringify([
+          "a session",
+          "another session",
+        ]),
       });
-      await expect(sessionManager.getRegisteredSessionIdAll()).rejects.toThrow(
-        "Unimplemented"
-      );
+      const sessionManager = getSessionInfoManager({
+        storageUtility: storage,
+      });
+
+      await expect(
+        sessionManager.getRegisteredSessionIdAll()
+      ).resolves.toStrictEqual(["a session", "another session"]);
     });
 
     it("returns an empty list if no session IDs are registered", async () => {
       const sessionManager = getSessionInfoManager({
         storageUtility: mockStorageUtility({}),
       });
-      await expect(sessionManager.getRegisteredSessionIdAll()).rejects.toThrow(
-        "Unimplemented"
-      );
+      await expect(
+        sessionManager.getRegisteredSessionIdAll()
+      ).resolves.toStrictEqual([]);
     });
   });
 

--- a/packages/node/src/sessionInfo/SessionInfoManager.spec.ts
+++ b/packages/node/src/sessionInfo/SessionInfoManager.spec.ts
@@ -159,6 +159,22 @@ describe("SessionInfoManager", () => {
         await mockStorage.getForUser("mySession", "key", { secure: false })
       ).toBeUndefined();
     });
+
+    it("clears the session registration", async () => {
+      const storage = mockStorageUtility({
+        [REGISTERED_SESSIONS_KEY]: JSON.stringify([
+          "a session",
+          "another session",
+        ]),
+      });
+      const sessionManager = getSessionInfoManager({
+        storageUtility: storage,
+      });
+      await sessionManager.clear("a session");
+      await expect(storage.get(REGISTERED_SESSIONS_KEY)).resolves.toStrictEqual(
+        JSON.stringify(["another session"])
+      );
+    });
   });
 
   describe("getAll", () => {

--- a/packages/node/src/sessionInfo/SessionInfoManager.spec.ts
+++ b/packages/node/src/sessionInfo/SessionInfoManager.spec.ts
@@ -254,17 +254,46 @@ describe("SessionInfoManager", () => {
 
   describe("clearAll", () => {
     it("clears all sessions registrations", async () => {
-      const sessionManager = getSessionInfoManager({
-        storageUtility: mockStorageUtility({}),
+      const storage = mockStorageUtility({
+        [REGISTERED_SESSIONS_KEY]: JSON.stringify([
+          "a session",
+          "another session",
+        ]),
       });
-      await expect(sessionManager.clearAll()).rejects.toThrow("Unimplemented");
+      const sessionManager = getSessionInfoManager({
+        storageUtility: storage,
+      });
+      await sessionManager.clearAll();
+      await expect(storage.get(REGISTERED_SESSIONS_KEY)).resolves.toStrictEqual(
+        JSON.stringify([])
+      );
     });
 
     it("clears all sessions information", async () => {
-      const sessionManager = getSessionInfoManager({
-        storageUtility: mockStorageUtility({}),
+      const storage = mockStorageUtility({
+        [REGISTERED_SESSIONS_KEY]: JSON.stringify(["a session"]),
+        "solidClientAuthenticationUser:a session": {
+          "some user info": "a value",
+        },
       });
-      await expect(sessionManager.clearAll()).rejects.toThrow("Unimplemented");
+      const sessionManager = getSessionInfoManager({
+        storageUtility: storage,
+      });
+      await sessionManager.clearAll();
+      await expect(
+        storage.getForUser("a session", "some user info")
+      ).resolves.toBeUndefined();
+    });
+
+    it("does not fail if no session information arae available", async () => {
+      const storage = mockStorageUtility({});
+      const sessionManager = getSessionInfoManager({
+        storageUtility: storage,
+      });
+      await sessionManager.clearAll();
+      await expect(
+        storage.getForUser("a session", "some user info")
+      ).resolves.toBeUndefined();
     });
   });
 });

--- a/packages/node/src/sessionInfo/SessionInfoManager.ts
+++ b/packages/node/src/sessionInfo/SessionInfoManager.ts
@@ -34,6 +34,7 @@ import {
 } from "@inrupt/solid-client-authn-core";
 import { v4 } from "uuid";
 import { fetch } from "cross-fetch";
+import { REGISTERED_SESSIONS_KEY } from "../constants";
 
 export function getUnauthenticatedSession(): ISessionInfo & {
   fetch: typeof fetch;
@@ -159,8 +160,24 @@ export class SessionInfoManager implements ISessionInfoManager {
    * @param sessionId
    */
   async register(sessionId: string): Promise<void> {
-    throw new Error("Unimplemented");
+    const rawSessions = await this.storageUtility.get(REGISTERED_SESSIONS_KEY);
+    if (rawSessions === undefined) {
+      return this.storageUtility.set(
+        REGISTERED_SESSIONS_KEY,
+        JSON.stringify([sessionId])
+      );
+    }
+    const sessions: string[] = JSON.parse(rawSessions);
+    if (!sessions.includes(sessionId)) {
+      sessions.push(sessionId);
+      return this.storageUtility.set(
+        REGISTERED_SESSIONS_KEY,
+        JSON.stringify(sessions)
+      );
+    }
+    return Promise.resolve();
   }
+
   /**
    * Returns all the registered session IDs. Differs from getAll, which also
    * returns additional session information.

--- a/packages/node/src/sessionInfo/SessionInfoManager.ts
+++ b/packages/node/src/sessionInfo/SessionInfoManager.ts
@@ -195,6 +195,12 @@ export class SessionInfoManager implements ISessionInfoManager {
    * Deletes all information about all sessions, including their registrations.
    */
   async clearAll(): Promise<void> {
-    throw new Error("Unimplemented");
+    const rawSessions = await this.storageUtility.get(REGISTERED_SESSIONS_KEY);
+    if (rawSessions === undefined) {
+      return Promise.resolve();
+    }
+    const sessions: string[] = JSON.parse(rawSessions);
+    await Promise.all(sessions.map((sessionId) => this.clear(sessionId)));
+    return this.storageUtility.set(REGISTERED_SESSIONS_KEY, JSON.stringify([]));
   }
 }

--- a/packages/node/src/sessionInfo/SessionInfoManager.ts
+++ b/packages/node/src/sessionInfo/SessionInfoManager.ts
@@ -183,7 +183,12 @@ export class SessionInfoManager implements ISessionInfoManager {
    * returns additional session information.
    */
   async getRegisteredSessionIdAll(): Promise<string[]> {
-    throw new Error("Unimplemented");
+    return this.storageUtility.get(REGISTERED_SESSIONS_KEY).then((data) => {
+      if (data === undefined) {
+        return [];
+      }
+      return JSON.parse(data);
+    });
   }
 
   /**

--- a/packages/node/src/sessionInfo/SessionInfoManager.ts
+++ b/packages/node/src/sessionInfo/SessionInfoManager.ts
@@ -152,6 +152,16 @@ export class SessionInfoManager implements ISessionInfoManager {
    * @hidden
    */
   async clear(sessionId: string): Promise<void> {
+    const rawSessions = await this.storageUtility.get(REGISTERED_SESSIONS_KEY);
+    if (rawSessions !== undefined) {
+      const sessions: string[] = JSON.parse(rawSessions);
+      await this.storageUtility.set(
+        REGISTERED_SESSIONS_KEY,
+        JSON.stringify(
+          sessions.filter((storedSessionId) => storedSessionId !== sessionId)
+        )
+      );
+    }
     return clear(sessionId, this.storageUtility);
   }
 

--- a/packages/node/src/sessionInfo/SessionInfoManager.ts
+++ b/packages/node/src/sessionInfo/SessionInfoManager.ts
@@ -153,4 +153,26 @@ export class SessionInfoManager implements ISessionInfoManager {
   async clear(sessionId: string): Promise<void> {
     return clear(sessionId, this.storageUtility);
   }
+
+  /**
+   * Registers a new session, so that its ID can be retrieved.
+   * @param sessionId
+   */
+  async register(sessionId: string): Promise<void> {
+    throw new Error("Unimplemented");
+  }
+  /**
+   * Returns all the registered session IDs. Differs from getAll, which also
+   * returns additional session information.
+   */
+  async getRegisteredSessionIdAll(): Promise<string[]> {
+    throw new Error("Unimplemented");
+  }
+
+  /**
+   * Deletes all information about all sessions, including their registrations.
+   */
+  async clearAll(): Promise<void> {
+    throw new Error("Unimplemented");
+  }
 }

--- a/packages/node/src/sessionInfo/__mocks__/SessionInfoManager.ts
+++ b/packages/node/src/sessionInfo/__mocks__/SessionInfoManager.ts
@@ -36,16 +36,16 @@ export const SessionCreatorGetSessionResponse: ISessionInfo = SessionCreatorCrea
 
 export const SessionInfoManagerMock: jest.Mocked<ISessionInfoManager> = {
   update: jest.fn(
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function
-    async (sessionId: string, options: ISessionInfoManagerOptions) => {}
+    async (_sessionId: string, _options: ISessionInfoManagerOptions) => {}
   ),
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  get: jest.fn(async (sessionId: string) =>
+  get: jest.fn(async (_sessionId: string) =>
     Promise.resolve(SessionCreatorCreateResponse)
   ),
   getAll: jest.fn(async () => Promise.resolve([SessionCreatorCreateResponse])),
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  clear: jest.fn(async (sessionId: string) => Promise.resolve()),
+  clear: jest.fn(async (_sessionId: string) => Promise.resolve()),
+  register: jest.fn(async (sessionId: string) => Promise.resolve()),
+  clearAll: jest.fn(async () => Promise.resolve()),
+  getRegisteredSessionIdAll: jest.fn(async () => Promise.resolve([])),
 };
 
 export function mockSessionInfoManager(

--- a/packages/node/src/sessionInfo/__mocks__/SessionInfoManager.ts
+++ b/packages/node/src/sessionInfo/__mocks__/SessionInfoManager.ts
@@ -43,7 +43,7 @@ export const SessionInfoManagerMock: jest.Mocked<ISessionInfoManager> = {
   ),
   getAll: jest.fn(async () => Promise.resolve([SessionCreatorCreateResponse])),
   clear: jest.fn(async (_sessionId: string) => Promise.resolve()),
-  register: jest.fn(async (sessionId: string) => Promise.resolve()),
+  register: jest.fn(async (_sessionId: string) => Promise.resolve()),
   clearAll: jest.fn(async () => Promise.resolve()),
   getRegisteredSessionIdAll: jest.fn(async () => Promise.resolve([])),
 };


### PR DESCRIPTION
This implements the different functions required to list all the known session IDs for a given storage, in order to be able to iterate through them is required. Note that `getSessionFromStorage` returns a Session object, potentially logged in, while `getSessionIdFromStorageAll` only returns the session ids, and it is up to the caller to the manually retrieve individual sessions. This is mostly for performance concerns: logging a session in requires an HTTP interaction, so if multiple sessions need to be logged in at once, that could represent a costly operation (that the server is still able to perform with the proposed API anyway). 

# Checklist

- [X] All acceptance criteria are met.
- [x] The changelog has been updated, if applicable.
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).