### PR TITLE
Also list default session functions in API docs

### DIFF
--- a/packages/browser/docs/api/source/index.rst
+++ b/packages/browser/docs/api/source/index.rst
@@ -10,3 +10,4 @@ solid-client-authn-browser API
 
    /classes/*
    /interfaces/*
+   /modules/*

--- a/packages/browser/tsconfig.json
+++ b/packages/browser/tsconfig.json
@@ -8,7 +8,7 @@
 
   "typedocOptions": {
     "out": "website/docs/api/browser",
-    "entryPoints": ["./src/index.ts"],
+    "entryPoints": ["./src/index.ts", "./src/defaultSession.ts"],
     "entryDocument": "index.md"
   },
 


### PR DESCRIPTION
The API docs did not list the functions using the default session, because they were not listed in the toctree. I think this should fix that, but I'll mark this PR as a draft until I can verify for sure that this fixes it in the preview deployment.

- [ ] I've added a unit test to test for potential regressions of this bug. N/A
- [x] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
