### PR TITLE
List session management functions in the API doc

### DIFF
--- a/packages/node/src/Session.spec.ts
+++ b/packages/node/src/Session.spec.ts
@@ -31,15 +31,15 @@ import {
   mockClientAuthentication,
   mockCustomClientAuthentication,
 } from "./__mocks__/ClientAuthentication";
+import { Session } from "./Session";
+import { mockStorage } from "../../core/src/storage/__mocks__/StorageUtility";
+import { mockSessionInfoManager } from "./sessionInfo/__mocks__/SessionInfoManager";
+import { REGISTERED_SESSIONS_KEY } from "./constants";
 import {
   clearSessionFromStorageAll,
   getSessionFromStorage,
   getSessionIdFromStorageAll,
-  Session,
-} from "./Session";
-import { mockStorage } from "../../core/src/storage/__mocks__/StorageUtility";
-import { mockSessionInfoManager } from "./sessionInfo/__mocks__/SessionInfoManager";
-import { REGISTERED_SESSIONS_KEY } from "./constants";
+} from "./multiSession";
 
 jest.mock("cross-fetch");
 jest.mock("./dependencies");

--- a/packages/node/src/Session.ts
+++ b/packages/node/src/Session.ts
@@ -73,7 +73,7 @@ export interface ISessionOptions {
 /**
  * If no external storage is provided, this storage gets used.
  */
-const defaultStorage = new InMemoryStorage();
+export const defaultStorage = new InMemoryStorage();
 
 /**
  * A {@link Session} object represents a user's session on an application. The session holds state, as it stores information enabling acces to private resources after login for instance.
@@ -251,63 +251,4 @@ export class Session extends EventEmitter {
   onLogout(callback: () => unknown): void {
     this.on("logout", callback);
   }
-}
-
-export async function getSessionFromStorage(
-  sessionId: string,
-  storage?: IStorage
-): Promise<Session | undefined> {
-  const clientAuth: ClientAuthentication = storage
-    ? getClientAuthenticationWithDependencies({
-        secureStorage: storage,
-        insecureStorage: storage,
-      })
-    : getClientAuthenticationWithDependencies({
-        secureStorage: defaultStorage,
-        insecureStorage: defaultStorage,
-      });
-  const sessionInfo = await clientAuth.getSessionInfo(sessionId);
-  if (sessionInfo === undefined) {
-    return undefined;
-  }
-  const session = new Session({
-    sessionInfo,
-    clientAuthentication: clientAuth,
-  });
-  if (sessionInfo.refreshToken) {
-    await session.login({
-      oidcIssuer: sessionInfo.issuer,
-    });
-  }
-  return session;
-}
-
-export async function getSessionIdFromStorageAll(
-  storage?: IStorage
-): Promise<string[]> {
-  const clientAuth: ClientAuthentication = storage
-    ? getClientAuthenticationWithDependencies({
-        secureStorage: storage,
-        insecureStorage: storage,
-      })
-    : getClientAuthenticationWithDependencies({
-        secureStorage: defaultStorage,
-        insecureStorage: defaultStorage,
-      });
-  return clientAuth.getSessionIdAll();
-}
-
-export async function clearSessionFromStorageAll(
-  storage?: IStorage
-): Promise<void> {
-  const clientAuth: ClientAuthentication = storage
-    ? getClientAuthenticationWithDependencies({
-        secureStorage: storage,
-        insecureStorage: storage,
-      })
-    : getClientAuthenticationWithDependencies({
-        secureStorage: defaultStorage,
-        insecureStorage: defaultStorage,
-      });
-  return clientAuth.clearSessionAll();
 }

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -19,13 +19,13 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+export { Session, ISessionOptions } from "./Session";
+
 export {
-  Session,
-  ISessionOptions,
   getSessionFromStorage,
   getSessionIdFromStorageAll,
   clearSessionFromStorageAll,
-} from "./Session";
+} from "./multiSession";
 
 export { SessionManager, ISessionManagerOptions } from "./SessionManager";
 

--- a/packages/node/src/multiSession.spec.ts
+++ b/packages/node/src/multiSession.spec.ts
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2021 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import "reflect-metadata";
+import { InMemoryStorage } from "@inrupt/solid-client-authn-core";
+import {
+  mockClientAuthentication,
+  mockCustomClientAuthentication,
+} from "./__mocks__/ClientAuthentication";
+import {
+  mockStorage,
+  mockStorageUtility,
+} from "../../core/src/storage/__mocks__/StorageUtility";
+import { REGISTERED_SESSIONS_KEY } from "./constants";
+import {
+  clearSessionFromStorageAll,
+  getSessionFromStorage,
+  getSessionIdFromStorageAll,
+} from "./multiSession";
+import { mockSessionInfoManager } from "./sessionInfo/__mocks__/SessionInfoManager";
+
+jest.mock("./dependencies");
+
+describe("getSessionFromStorage", () => {
+  it("returns a logged in Session if a refresh token is available in storage", async () => {
+    const clientAuthentication = mockClientAuthentication();
+    clientAuthentication.getSessionInfo = jest.fn().mockResolvedValue({
+      webId: "https://my.webid",
+      isLoggedIn: true,
+      refreshToken: "some token",
+      issuer: "https://my.idp",
+      sessionId: "mySession",
+    });
+    clientAuthentication.login = jest.fn().mockResolvedValue({
+      webId: "https://my.webid",
+      isLoggedIn: true,
+      sessionId: "mySession",
+    });
+    const dependencies = jest.requireMock("./dependencies");
+    dependencies.getClientAuthenticationWithDependencies = jest
+      .fn()
+      .mockReturnValue(clientAuthentication);
+    const mySession = await getSessionFromStorage("mySession", mockStorage({}));
+    expect(mySession?.info).toStrictEqual({
+      webId: "https://my.webid",
+      isLoggedIn: true,
+      sessionId: "mySession",
+    });
+  });
+
+  it("returns a logged out Session if no refresh token is available", async () => {
+    const clientAuthentication = mockClientAuthentication();
+    clientAuthentication.getSessionInfo = jest.fn().mockResolvedValueOnce({
+      webId: "https://my.webid",
+      isLoggedIn: true,
+      issuer: "https://my.idp",
+      sessionId: "mySession",
+    });
+    clientAuthentication.logout = jest.fn().mockResolvedValueOnce({
+      isLoggedIn: false,
+      sessionId: "mySession",
+    });
+    const dependencies = jest.requireMock("./dependencies");
+    dependencies.getClientAuthenticationWithDependencies = jest
+      .fn()
+      .mockReturnValue(clientAuthentication);
+    const mySession = await getSessionFromStorage("mySession", mockStorage({}));
+    expect(mySession?.info).toStrictEqual({
+      isLoggedIn: false,
+      sessionId: "mySession",
+      webId: "https://my.webid",
+    });
+  });
+
+  it("returns undefined if no session id matches in storage", async () => {
+    const clientAuthentication = mockClientAuthentication();
+    clientAuthentication.getSessionInfo = jest
+      .fn()
+      .mockResolvedValueOnce(undefined);
+    const dependencies = jest.requireMock("./dependencies");
+    dependencies.getClientAuthenticationWithDependencies = jest
+      .fn()
+      .mockReturnValue(clientAuthentication);
+    const mySession = await getSessionFromStorage("mySession", mockStorage({}));
+    expect(mySession?.info).toBeUndefined();
+  });
+
+  it("falls back to the environment storage if none is specified", async () => {
+    const clientAuthentication = mockClientAuthentication();
+    clientAuthentication.getSessionInfo = jest
+      .fn()
+      .mockResolvedValueOnce(undefined);
+    const dependencies = jest.requireMock("./dependencies");
+    dependencies.getClientAuthenticationWithDependencies = jest
+      .fn()
+      .mockReturnValue(clientAuthentication);
+    await getSessionFromStorage("mySession");
+    const mockDefaultStorage = new InMemoryStorage();
+    expect(
+      dependencies.getClientAuthenticationWithDependencies
+    ).toHaveBeenCalledWith({
+      insecureStorage: mockDefaultStorage,
+      secureStorage: mockDefaultStorage,
+    });
+  });
+});
+
+describe("getStoredSessionIdAll", () => {
+  it("returns all the session IDs available in storage", async () => {
+    const storage = mockStorageUtility({
+      [REGISTERED_SESSIONS_KEY]: JSON.stringify([
+        "a session",
+        "another session",
+      ]),
+    });
+
+    const clientAuthentication = mockCustomClientAuthentication({
+      sessionInfoManager: mockSessionInfoManager(storage),
+    });
+    const dependencies = jest.requireMock("./dependencies");
+    dependencies.getClientAuthenticationWithDependencies = jest
+      .fn()
+      .mockReturnValue(clientAuthentication);
+    const sessions = await getSessionIdFromStorageAll(mockStorage({}));
+    expect(sessions).toStrictEqual(["a session", "another session"]);
+  });
+
+  it("falls back to the environment storage if none is specified", async () => {
+    const storage = mockStorageUtility({
+      [REGISTERED_SESSIONS_KEY]: JSON.stringify([
+        "a session",
+        "another session",
+      ]),
+    });
+
+    const clientAuthentication = mockCustomClientAuthentication({
+      sessionInfoManager: mockSessionInfoManager(storage),
+    });
+    const dependencies = jest.requireMock("./dependencies");
+    dependencies.getClientAuthenticationWithDependencies = jest
+      .fn()
+      .mockReturnValue(clientAuthentication);
+    await getSessionIdFromStorageAll();
+    const mockDefaultStorage = new InMemoryStorage();
+    expect(
+      dependencies.getClientAuthenticationWithDependencies
+    ).toHaveBeenCalledWith({
+      insecureStorage: mockDefaultStorage,
+      secureStorage: mockDefaultStorage,
+    });
+  });
+});
+
+describe("clearSessionAll", () => {
+  it("clears all the sessions in storage", async () => {
+    const storage = mockStorageUtility({
+      [REGISTERED_SESSIONS_KEY]: JSON.stringify([
+        "a session",
+        "another session",
+      ]),
+    });
+
+    const clientAuthentication = mockCustomClientAuthentication({
+      sessionInfoManager: mockSessionInfoManager(storage),
+    });
+    const dependencies = jest.requireMock("./dependencies");
+    dependencies.getClientAuthenticationWithDependencies = jest
+      .fn()
+      .mockReturnValue(clientAuthentication);
+    await clearSessionFromStorageAll(storage);
+    await expect(storage.get(REGISTERED_SESSIONS_KEY)).resolves.toStrictEqual(
+      JSON.stringify([])
+    );
+  });
+
+  it("falls back to the environment storage if none is specified", async () => {
+    const storage = mockStorageUtility({});
+
+    const clientAuthentication = mockCustomClientAuthentication({
+      sessionInfoManager: mockSessionInfoManager(storage),
+    });
+    const dependencies = jest.requireMock("./dependencies");
+    dependencies.getClientAuthenticationWithDependencies = jest
+      .fn()
+      .mockReturnValue(clientAuthentication);
+    await clearSessionFromStorageAll();
+    const mockDefaultStorage = new InMemoryStorage();
+    expect(
+      dependencies.getClientAuthenticationWithDependencies
+    ).toHaveBeenCalledWith({
+      insecureStorage: mockDefaultStorage,
+      secureStorage: mockDefaultStorage,
+    });
+  });
+});

--- a/packages/node/src/multiSession.ts
+++ b/packages/node/src/multiSession.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2021 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { IStorage } from "@inrupt/solid-client-authn-core";
+import ClientAuthentication from "./ClientAuthentication";
+import { getClientAuthenticationWithDependencies } from "./dependencies";
+import { defaultStorage, Session } from "./Session";
+
+export async function getSessionFromStorage(
+  sessionId: string,
+  storage?: IStorage
+): Promise<Session | undefined> {
+  const clientAuth: ClientAuthentication = storage
+    ? getClientAuthenticationWithDependencies({
+        secureStorage: storage,
+        insecureStorage: storage,
+      })
+    : getClientAuthenticationWithDependencies({
+        secureStorage: defaultStorage,
+        insecureStorage: defaultStorage,
+      });
+  const sessionInfo = await clientAuth.getSessionInfo(sessionId);
+  if (sessionInfo === undefined) {
+    return undefined;
+  }
+  const session = new Session({
+    sessionInfo,
+    clientAuthentication: clientAuth,
+  });
+  if (sessionInfo.refreshToken) {
+    await session.login({
+      oidcIssuer: sessionInfo.issuer,
+    });
+  }
+  return session;
+}
+
+export async function getSessionIdFromStorageAll(
+  storage?: IStorage
+): Promise<string[]> {
+  const clientAuth: ClientAuthentication = storage
+    ? getClientAuthenticationWithDependencies({
+        secureStorage: storage,
+        insecureStorage: storage,
+      })
+    : getClientAuthenticationWithDependencies({
+        secureStorage: defaultStorage,
+        insecureStorage: defaultStorage,
+      });
+  return clientAuth.getSessionIdAll();
+}
+
+export async function clearSessionFromStorageAll(
+  storage?: IStorage
+): Promise<void> {
+  const clientAuth: ClientAuthentication = storage
+    ? getClientAuthenticationWithDependencies({
+        secureStorage: storage,
+        insecureStorage: storage,
+      })
+    : getClientAuthenticationWithDependencies({
+        secureStorage: defaultStorage,
+        insecureStorage: defaultStorage,
+      });
+  return clientAuth.clearSessionAll();
+}

--- a/packages/node/src/multiSession.ts
+++ b/packages/node/src/multiSession.ts
@@ -24,6 +24,23 @@ import ClientAuthentication from "./ClientAuthentication";
 import { getClientAuthenticationWithDependencies } from "./dependencies";
 import { defaultStorage, Session } from "./Session";
 
+/**
+ * Retrieve a Session from the given storage based on its session ID. If possible,
+ * the Session is logged in before it is returned, so that `session.fetch` may
+ * access private Resource without any additional interaction.
+ *
+ * If no storage is provided, a default in-memory storage will be used. It is
+ * instanciated once on load, and is shared across all the sessions. Since it
+ * is only available in memory, the storage is lost when the code stops running.
+ *
+ * A Session is available in storage as soon as it logged in once, and it is removed
+ * from storage on logout.
+ *
+ * @param sessionId The ID of the Session to retrieve
+ * @param storage The storage where the Session can be found
+ * @returns A session object, authenticated if possible, or undefined if no Session
+ * in storage matches the given ID.
+ */
 export async function getSessionFromStorage(
   sessionId: string,
   storage?: IStorage
@@ -53,6 +70,24 @@ export async function getSessionFromStorage(
   return session;
 }
 
+/**
+ * Retrieve the IDs for all the Sessions available in the given storage. Note that
+ * it is only the Session IDs that are returned, and not Session object. Given a
+ * Session ID, one may use [[getSessionFromStorage]] to get the actual Session
+ * object, while being conscious that logging in a Session required an HTTP
+ * interaction, so doing it in batch for a large number of sessions may result
+ * in performance issues.
+ *
+ * If no storage is provided, a default in-memory storage will be used. It is
+ * instanciated once on load, and is shared across all the sessions. Since it
+ * is only available in memory, the storage is lost when the code stops running.
+ *
+ * A Session is available in storage as soon as it logged in once, and it is removed
+ * from storage on logout.
+ *
+ * @param storage The storage where the Session can be found
+ * @returns An array of Session IDs
+ */
 export async function getSessionIdFromStorageAll(
   storage?: IStorage
 ): Promise<string[]> {
@@ -68,6 +103,20 @@ export async function getSessionIdFromStorageAll(
   return clientAuth.getSessionIdAll();
 }
 
+/**
+ * Clear the given storage from any existing Session ID. In order to remove an
+ * individual Session from storage, rather than going through this batch deletion,
+ * one may simply log the Session out calling `session.logout`.
+ *
+ * If no storage is provided, a default in-memory storage will be used. It is
+ * instanciated once on load, and is shared across all the sessions. Since it
+ * is only available in memory, the storage is lost when the code stops running.
+ *
+ * A Session is available in storage as soon as it logged in once, and it is removed
+ * from storage on logout.
+ *
+ * @param storage The storage where the Session can be found
+ */
 export async function clearSessionFromStorageAll(
   storage?: IStorage
 ): Promise<void> {

--- a/packages/node/tsconfig.json
+++ b/packages/node/tsconfig.json
@@ -8,7 +8,7 @@
 
   "typedocOptions": {
     "out": "website/docs/api/node",
-    "entryPoints": ["./src/index.ts"],
+    "entryPoints": ["./src/index.ts", "./src/multiSession.ts"],
     "entryDocument": "index.md"
   },
 


### PR DESCRIPTION
Functions not exposed by a class, such as `getSessionFromStorage`, were
not listed as part of the public API. This introduces the same issue
that was identified in https://github.com/inrupt/solid-client-authn-js/pull/990