### PR TITLE
Swallow exception when looking up custom endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ storage.
 
 ### Bugfix
 
+- Any exception thrown by the custom `/session` endpoint lookup is swallowed.
+
 #### node
 
 - Building multiple sessions with the default storage re-initialized a new storage 
@@ -65,7 +67,8 @@ deprecated, and replaced by `storage`.
 - Updating the browser window will no longer log the user out if their WebID is
 hosted on an ESS instance (such as https://pod.inrupt.com). A better, global
 solution will be implemented later in order not to break compatibility in the 
-ecosystem.
+ecosystem. The current solution is based on a custom `/session` endpoint lookup, 
+and a Resource Server cookie.
 
 ## 1.3.0 - 2020-01-06
 

--- a/packages/browser/__tests__/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
+++ b/packages/browser/__tests__/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
@@ -146,11 +146,10 @@ function mockClientRegistrar(client: IClient): IClientRegistrar {
 }
 
 const mockFetch = (response: Response): void => {
-  window.fetch = jest.fn().mockReturnValue(
-    new Promise((resolve) => {
-      resolve(response);
-    })
-  ) as jest.Mock<ReturnType<typeof window.fetch>, [RequestInfo, RequestInit?]>;
+  window.fetch = jest.fn().mockResolvedValue(response) as jest.Mock<
+    ReturnType<typeof window.fetch>,
+    [RequestInfo, RequestInit?]
+  >;
 };
 
 const defaultMocks = {

--- a/packages/browser/__tests__/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
+++ b/packages/browser/__tests__/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
@@ -427,18 +427,12 @@ describe("AuthCodeRedirectHandler", () => {
   it("swallows the exception if the fetch to the session endpoint fails", async () => {
     window.fetch = jest
       .fn()
-      .mockReturnValueOnce(
-        new Promise((resolve) => {
-          resolve(
-            new Response("https://my.webid", {
-              status: 200,
-            })
-          );
+      .mockResolvedValueOnce(
+        new Response("https://my.webid", {
+          status: 200,
         })
       )
-      .mockImplementation(() => {
-        throw new Error("Some error");
-      });
+      .mockRejectedValueOnce("Some error");
 
     const mockedStorage = mockStorageUtility({
       "solidClientAuthenticationUser:oauth2_state_value": {


### PR DESCRIPTION
Resolves #996 

This prevents a CORS error thrown by an internal fetch to bubble up an
discrupt the login flow. Note that this is part of a temporary code
snippet that will be removed once a longer-term solution for auth after
refresh is implemented.

- [X] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).