### PR TITLE
Retrieve WebID from stored RS cookie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ could be merely a patch release.
 - removed Implicit Flow code.
 - removed unused TokenSaver code.
 
+### Bugs fixed
+
+- Logging out of an app opened in multiple tabs logged the user back in automatically.
+
 The following sections document changes that have been released already:
 
 ## 1.5.0 - 2020-01-28

--- a/packages/browser/src/sessionInfo/SessionInfoManager.ts
+++ b/packages/browser/src/sessionInfo/SessionInfoManager.ts
@@ -55,10 +55,11 @@ export async function clear(
   sessionId: string,
   storage: IStorageUtility
 ): Promise<void> {
-  // The type assertion is okay, because it throws on undefined.
-  const webId = await storage.getForUser(sessionId, "webId", {
-    secure: true,
-  });
+  const storedSessionCookieReference = await storage.get(
+    "tmp-resource-server-session-info"
+  );
+  const reference = JSON.parse(storedSessionCookieReference ?? "{}");
+  const { webId } = reference;
   if (webId !== undefined) {
     const webIdAsUrl = new URL(webId);
     const resourceServerIri = webIdAsUrl.origin;


### PR DESCRIPTION
Instead of retrieving the WebID from the session information, which
aren't avalaible when the session has been restored in a new tab,
it is retrieved from local storage in the temporary RS cookie fix.

The absence of the WebID prevented the cookie workaround to be cleared,
forcing a session active in multiple tabs to remain open.

- [ ] I've added a unit test to test for potential regressions of this bug. N/A
- [x] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).