### PR TITLE
API Docs: tweak wording;add/fix link

### DIFF
--- a/packages/browser/src/Session.ts
+++ b/packages/browser/src/Session.ts
@@ -71,10 +71,13 @@ export class Session extends EventEmitter {
    * ```typescript
    * const session = new Session();
    * ```
+   *
+   * See also [getDefaultSession](https://docs.inrupt.com/developer-tools/api/javascript/solid-client-authn-browser/functions.html#getdefaultsession).
+   *
    * @param sessionOptions The options enabling the correct instantiation of
    * the session. Either both storages or clientAuthentication are required. For
    * more information, see {@link ISessionOptions}.
-   * @param sessionId A magic string uniquely identifying the session.
+   * @param sessionId A string uniquely identifying the session.
    *
    */
   constructor(

--- a/packages/browser/src/defaultSession.ts
+++ b/packages/browser/src/defaultSession.ts
@@ -42,7 +42,7 @@ export function getDefaultSession(): Session {
 
 /**
  * This function's signature is equal to `window.fetch`, but if the current user is authenticated
- * (see [[login]] and [[handleIncomingRedirect]), requests made using it will include that user's
+ * (see [[login]] and [[handleIncomingRedirect]]), requests made using it will include that user's
  * credentials. If not, this will behave just like the regular `window.fetch`.
  *
  * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch}

--- a/packages/node/src/Session.ts
+++ b/packages/node/src/Session.ts
@@ -102,7 +102,7 @@ export class Session extends EventEmitter {
    * @param sessionOptions The options enabling the correct instantiation of
    * the session. Either both storages or clientAuthentication are required. For
    * more information, see {@link ISessionOptions}.
-   * @param sessionId A magic string uniquely identifying the session.
+   * @param sessionId A string uniquely identifying the session.
    *
    */
   constructor(


### PR DESCRIPTION
Tweak API documentation:
- Remove the word "magic"
- Fix missing right square bracket ] for link
- Add link to getDefaultSession from the Session constructor. Because we do some processing for the defaultSession functions for their new destination page, could not use the {@link } or [[ link ]] typedoc linking since those would link to pre-processing index.html page instead.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

