### PR TITLE
Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,31 +8,18 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased
 
+The following sections document changes that have been released already:
+
+## 1.5.1 - 2020-02-03
+
 ### Deprecation
 
 #### browser
 
 - Deprecated SessionManager
-
-### Internal refactor
-
-These changes are being reflected here even though normally internal refactoring 
-shouldn't be mentioned in the CHANGELOG (since it's meant for the consumers of
-the library, whereas library developers would rather read the commit history).
-In this case though, it is indeed a change that should be mentioned to
-library users, as it's really a feature change: i.e., the implicit flow is no
-longer supported.
-
-Whether this is really breaking or not is up for debate, because while it
-technically is a breaking change, we don't think any OIDC issuers only support
-the implicit flow and not the auth code flow, and no user-facing controls enable
-chosing one's flow, so there's no reason why this should be breaking, and it
-could be merely a patch release.
-
-#### browser
-
-- removed Implicit Flow code.
-- removed unused TokenSaver code.
+- The implicit flow is no longer supported. However, no known Solid Identity issuer
+only supports the implicit flow and not the auth code flow, and no user-facing
+controls enable choosing one's flow, so this has no user impact.
 
 ### New features
 
@@ -40,12 +27,10 @@ could be merely a patch release.
 
 - store the user's issuer claim, specifically to 'localStorage' to allow
   retrieval on tab refresh.
-=======
+
 ### Bugs fixed
 
 - Logging out of an app opened in multiple tabs logged the user back in automatically.
-
-The following sections document changes that have been released already:
 
 ## 1.5.0 - 2020-01-28
 

--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
   "packages": ["packages/*"],
-  "version": "1.5.0"
+  "version": "1.5.1"
 }

--- a/packages/browser/package-lock.json
+++ b/packages/browser/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/solid-client-authn-browser",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/solid-client-authn-browser",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "license": "MIT",
   "types": "dist/index",
   "browser": "dist/index.js",
@@ -64,8 +64,8 @@
     "webpack-merge": "^5.7.2"
   },
   "dependencies": {
-    "@inrupt/oidc-client-ext": "^1.5.0",
-    "@inrupt/solid-client-authn-core": "^1.5.0",
+    "@inrupt/oidc-client-ext": "^1.5.1",
+    "@inrupt/solid-client-authn-core": "^1.5.1",
     "@types/form-urlencoded": "^2.0.1",
     "@types/lodash.clonedeep": "^4.5.6",
     "@types/node": "^14.14.14",

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/solid-client-authn-core",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/solid-client-authn-core",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index",

--- a/packages/node/package-lock.json
+++ b/packages/node/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/solid-client-authn-node",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/solid-client-authn-node",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index",
@@ -30,7 +30,7 @@
     "typescript": "^4.0.5"
   },
   "dependencies": {
-    "@inrupt/solid-client-authn-core": "^1.5.0",
+    "@inrupt/solid-client-authn-core": "^1.5.1",
     "@types/node": "^14.14.14",
     "@types/uuid": "^8.3.0",
     "cross-fetch": "^3.0.6",

--- a/packages/oidc/package-lock.json
+++ b/packages/oidc/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/oidc-client-ext",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/oidc/package.json
+++ b/packages/oidc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/oidc-client-ext",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "A module extending oidc-client-js with new features, such as dynamic client registration and DPoP support.",
   "homepage": "https://github.com/inrupt/solid-client-authn-js/tree/master/packages/oidc/",
   "bugs": "https://github.com/inrupt/solid-client-authn-js/issues",


### PR DESCRIPTION
This PR bumps the version to 1.5.1.

Note that even though this technically adds a "new feature" (saving the ID token), I listed this as a patch release, because the feature in question doesn't change anything on the user experience yet, and no additional API functionnality is added. I also somewhat shrinked the CHANGELOG note about the implicit flow support to make it more compact and list it under the deprecation section.

# Checklist

- [X] I used `lerna version <major|minor|patch> --no-push` to update the version number, first inspecting the CHANGELOG to determine if the release was major, minor or patch.
- [X] The CHANGELOG has been updated to show version and release date - https://keepachangelog.com/en/1.0.0/.
- [X] The **only** commits in this PR are:
  - the CHANGELOG update.
  - the version update.
- [ ] I will make sure **not** to squash these commits, but **rebase** instead.
- [ ] Once this PR is merged, I will push the tag created by `lerna version ...` (e.g. `git push origin vX.X.X`).
