### PR TITLE
Log the user out when the session expires

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,13 @@ within this mono-repo.
 
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-
 ## Unreleased
+
+### Bugfix
+
+#### Browser
+
+- When a session expires, the session is now marked as logged out, and a `logout` event is thrown.
 
 The following sections document changes that have been released already:
 
@@ -28,7 +33,7 @@ controls enable choosing one's flow, so this has no user impact.
 - store the user's issuer claim, specifically to 'localStorage' to allow
   retrieval on tab refresh.
 
-### Bugs fixed
+### Bugfix
 
 - Logging out of an app opened in multiple tabs logged the user back in automatically.
 

--- a/packages/browser/src/ClientAuthentication.ts
+++ b/packages/browser/src/ClientAuthentication.ts
@@ -148,6 +148,7 @@ export default class ClientAuthentication {
       isLoggedIn: redirectInfo.isLoggedIn,
       webId: redirectInfo.webId,
       sessionId: redirectInfo.sessionId,
+      expirationDate: redirectInfo.expirationDate,
     };
   };
 }

--- a/packages/browser/src/Session.ts
+++ b/packages/browser/src/Session.ts
@@ -232,6 +232,12 @@ export class Session extends EventEmitter {
         // redirected from the IdP with access and ID tokens.
         this.emit("login");
       }
+
+      if (typeof sessionInfo.expirationDate === "number") {
+        setTimeout(async () => {
+          await this.logout();
+        }, sessionInfo.expirationDate - Date.now());
+      }
     }
     this.tokenRequestInProgress = false;
     return sessionInfo;

--- a/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
+++ b/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
@@ -191,6 +191,7 @@ export class AuthCodeRedirectHandler implements IRedirectHandler {
 
     let tokens: TokenEndpointResponse | TokenEndpointDpopResponse;
     let authFetch: typeof fetch;
+    const referenceTime = Date.now();
 
     if (isDpop) {
       const codeVerifier = (await this.storageUtility.getForUser(
@@ -255,6 +256,10 @@ export class AuthCodeRedirectHandler implements IRedirectHandler {
 
     return Object.assign(sessionInfo, {
       fetch: authFetch,
+      expirationDate:
+        typeof tokens.expiresIn === "number"
+          ? referenceTime + tokens.expiresIn * 1000
+          : null,
     });
   }
 }

--- a/packages/core/src/sessionInfo/ISessionInfo.ts
+++ b/packages/core/src/sessionInfo/ISessionInfo.ts
@@ -39,6 +39,12 @@ export interface ISessionInfo {
    * A unique identifier for the session.
    */
   sessionId: string;
+
+  /**
+   * UNIX timestamp (number of milliseconds since Jan 1st 1970) representing the
+   * time until which this session is valid.
+   */
+  expirationDate?: number;
 }
 
 /**

--- a/packages/oidc/src/dpop/tokenExchange.spec.ts
+++ b/packages/oidc/src/dpop/tokenExchange.spec.ts
@@ -30,6 +30,7 @@ import {
   getDpopToken,
   getTokens,
   TokenEndpointInput,
+  validateTokenEndpointResponse,
 } from "./tokenExchange";
 import { decodeJwt, signJwt } from "./dpop";
 
@@ -175,6 +176,76 @@ const mockFetch = (
   global.fetch = mockedFetch;
   return mockedFetch;
 };
+
+describe("validateTokenEndpointResponse", () => {
+  describe("for DPoP tokens", () => {
+    const fakeTokenEndpointResponse = {
+      access_token: "Arbitrary access token",
+      id_token: "Arbitrary ID token",
+      token_type: "DPoP",
+    };
+
+    it("does not throw when the Response contains a valid expiration time", () => {
+      const fakeValidResponse = {
+        ...fakeTokenEndpointResponse,
+        expires_in: 1337,
+      };
+      expect(() =>
+        validateTokenEndpointResponse(fakeValidResponse, true)
+      ).not.toThrow();
+    });
+
+    it("does not throw when the Response does not contain an expiration time", () => {
+      expect(() =>
+        validateTokenEndpointResponse(fakeTokenEndpointResponse, true)
+      ).not.toThrow();
+    });
+
+    it("throws when the Response contains an invalid expiration time", () => {
+      const fakeInvalidResponse = {
+        ...fakeTokenEndpointResponse,
+        expires_in: "Not a number",
+      };
+      expect(() =>
+        validateTokenEndpointResponse(fakeInvalidResponse, true)
+      ).toThrow();
+    });
+  });
+
+  describe("for Bearer tokens", () => {
+    const fakeTokenEndpointResponse = {
+      access_token: "Arbitrary access token",
+      id_token: "Arbitrary ID token",
+      token_type: "Bearer",
+    };
+
+    it("does not throw when the Response contains a valid expiration time", () => {
+      const fakeValidResponse = {
+        ...fakeTokenEndpointResponse,
+        expires_in: 1337,
+      };
+      expect(() =>
+        validateTokenEndpointResponse(fakeValidResponse, false)
+      ).not.toThrow();
+    });
+
+    it("does not throw when the Response does not contain an expiration time", () => {
+      expect(() =>
+        validateTokenEndpointResponse(fakeTokenEndpointResponse, false)
+      ).not.toThrow();
+    });
+
+    it("throws when the Response contains an invalid expiration time", () => {
+      const fakeInvalidResponse = {
+        ...fakeTokenEndpointResponse,
+        expires_in: "Not a number",
+      };
+      expect(() =>
+        validateTokenEndpointResponse(fakeInvalidResponse, false)
+      ).toThrow();
+    });
+  });
+});
 
 describe("getTokens", () => {
   it("throws if the grant type isn't supported", async () => {


### PR DESCRIPTION
When the session expired, `session.info.isLoggedIn` would still be `true`, and there was no way for the developer to know that the session was no longer valid.

With this change, we check the expiration time as sent by the server, add it to a timestamp we generated _before_ sending a request to the server (to ensure we're not running behind), and then log the session out when it expires (this also generates a `logout` event).

- [x] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
