### PR TITLE
store current URL in handlerIncomingRedirect

### DIFF
--- a/packages/browser/.eslintrc.js
+++ b/packages/browser/.eslintrc.js
@@ -1,6 +1,13 @@
 module.exports = {
   extends: ["../../.eslintrc.js"],
   rules: {
+    // Only needed for a test that uses an 'enum' and that fails due to a
+    // TS/ESLint bug: https://github.com/typescript-eslint/typescript-eslint/issues/2483
+    // This is only for one test (TokenRequest.spec.ts), that is due to be
+    // removed, at which point this workaround can be removed...
+    "no-shadow": "off",
+    "@typescript-eslint/no-shadow": "error",
+
     "license-header/header": ["error", "../../resources/license-header.js"],
   },
   parserOptions: {

--- a/packages/browser/__tests__/authenticatedFetch/headers/HeadersUtils.spec.ts
+++ b/packages/browser/__tests__/authenticatedFetch/headers/HeadersUtils.spec.ts
@@ -23,6 +23,15 @@ import { Headers as NodeHeaders } from "node-fetch";
 import { flattenHeaders } from "../../../src/authenticatedFetch/headers/HeadersUtils";
 
 describe("Headers interoperability function", () => {
+  it("returns empty object if nothing to flatten", () => {
+    expect(flattenHeaders(undefined)).toEqual({});
+  });
+
+  it("returns input if already a Record<>", () => {
+    const headersToFlatten: Record<string, string> = { key: "some value" };
+    expect(flattenHeaders(headersToFlatten)).toStrictEqual(headersToFlatten);
+  });
+
   it("transforms an incoming Headers object into a flat headers structure", () => {
     const myHeaders = new NodeHeaders();
     myHeaders.append("accept", "application/json");

--- a/packages/browser/__tests__/index.browser.spec.ts
+++ b/packages/browser/__tests__/index.browser.spec.ts
@@ -19,8 +19,9 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { SOLID_CLIENT_AUTHN_KEY_PREFIX } from "@inrupt/solid-client-authn-core";
+import { it } from "@jest/globals";
+import * as solidClientAuthentication from "../src/index.browser";
 
-export const KEY_CURRENT_ISSUER = `${SOLID_CLIENT_AUTHN_KEY_PREFIX}currentIssuer`;
-
-export const KEY_CURRENT_URL = `${SOLID_CLIENT_AUTHN_KEY_PREFIX}currentUrl`;
+it("exports the public API from the entrypoint", () => {
+  expect(solidClientAuthentication).toBeDefined();
+});

--- a/packages/browser/__tests__/login/oidc/OidcLoginHandler.spec.ts
+++ b/packages/browser/__tests__/login/oidc/OidcLoginHandler.spec.ts
@@ -83,6 +83,7 @@ describe("OidcLoginHandler", () => {
 
   it("should lookup client ID if not provided, if not found do DCR", async () => {
     // Override our default mock storage utility to deliberately return nothing.
+    let savedValue: Record<string, string> = {};
     const NothingStoredMock = {
       ...StorageUtilityMock,
       getForUser: async (
@@ -93,14 +94,30 @@ describe("OidcLoginHandler", () => {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         options?: { errorIfNull?: boolean; secure?: boolean }
       ) => undefined,
+
+      // We expect only one call to our storage, so save whatever was set in a
+      // single local variable.
+      setForUser: async (
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        userId: string,
+        values: Record<string, string>,
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        options?: { secure?: boolean }
+      ) => {
+        savedValue = values;
+      },
     };
 
     const actualHandler = defaultMocks.oidcHandler;
+    const actualRegistrar = defaultMocks.clientRegistrar;
     const handler = getInitialisedHandler({
       oidcHandler: actualHandler,
       storageUtility: NothingStoredMock,
+      clientRegistrar: actualRegistrar,
     });
 
+    // We're not providing a client ID here (and we've explicitly cleared our
+    // storage above), so we expect this call to use DCR to get a client ID...
     await handler.handle({
       sessionId: "mySession",
       oidcIssuer: "https://arbitrary.url",
@@ -109,6 +126,13 @@ describe("OidcLoginHandler", () => {
     });
 
     expect(actualHandler.handle.mock.calls).toHaveLength(1);
+    expect(actualRegistrar.getClient.mock.calls).toHaveLength(1);
+
+    // Get the response from the expected mocked DCR call, and ensure it matches
+    // the value we expect to have been stored in our storage.
+    const registrarResult = await actualRegistrar.getClient.mock.results[0]
+      .value;
+    expect(registrarResult.clientId).toEqual(savedValue.clientId);
   });
 
   it("should throw an error when called without an issuer", async () => {

--- a/packages/browser/__tests__/login/oidc/OidcLoginHandler.spec.ts
+++ b/packages/browser/__tests__/login/oidc/OidcLoginHandler.spec.ts
@@ -21,7 +21,10 @@
 
 // Required by TSyringe:
 import "reflect-metadata";
-import { StorageUtilityMock } from "@inrupt/solid-client-authn-core";
+import {
+  StorageUtilityGetResponse,
+  StorageUtilityMock,
+} from "@inrupt/solid-client-authn-core";
 import { OidcHandlerMock } from "../../../src/login/oidc/__mocks__/IOidcHandler";
 import { IssuerConfigFetcherMock } from "../../../src/login/oidc/__mocks__/IssuerConfigFetcher";
 import OidcLoginHandler from "../../../src/login/oidc/OidcLoginHandler";
@@ -62,6 +65,9 @@ describe("OidcLoginHandler", () => {
   it("should lookup client ID if not provided", async () => {
     const actualHandler = defaultMocks.oidcHandler;
     const handler = getInitialisedHandler({ oidcHandler: actualHandler });
+
+    // If no 'clientId' passed in, we expect it to be looked up in storage
+    // (which our test setup does).
     await handler.handle({
       sessionId: "mySession",
       oidcIssuer: "https://arbitrary.url",
@@ -70,6 +76,9 @@ describe("OidcLoginHandler", () => {
     });
 
     expect(actualHandler.handle.mock.calls).toHaveLength(1);
+
+    const calledWith = actualHandler.handle.mock.calls[0][0];
+    expect(calledWith.client.clientId).toEqual(StorageUtilityGetResponse);
   });
 
   it("should lookup client ID if not provided, if not found do DCR", async () => {

--- a/packages/browser/__tests__/login/oidc/Redirector.spec.ts
+++ b/packages/browser/__tests__/login/oidc/Redirector.spec.ts
@@ -20,13 +20,14 @@
  */
 
 import "reflect-metadata";
+import { jest } from "@jest/globals";
 import Redirector from "../../../src/login/oidc/Redirector";
 
 /**
  * Test for Redirector
  */
 describe("Redirector", () => {
-  describe("Redirect", () => {
+  describe("redirect", () => {
     const {
       location,
       history: { replaceState },
@@ -71,6 +72,19 @@ describe("Redirector", () => {
         "https://someUrl.com/redirect"
       );
       expect(window.location.href).toBe("https://coolSite.com");
+    });
+
+    it("calls redirect handler", () => {
+      const handler = jest.fn();
+      const redirectUrl = "https://someUrl.com/redirect";
+      const redirector = new Redirector();
+      redirector.redirect(redirectUrl, {
+        redirectByReplacingState: true,
+        handleRedirect: handler,
+      });
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(handler).toHaveBeenCalledWith(redirectUrl);
     });
   });
 });

--- a/packages/browser/__tests__/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
+++ b/packages/browser/__tests__/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
@@ -311,7 +311,7 @@ describe("AuthCodeRedirectHandler", () => {
     // We use ts-ignore comments here only to access mock call arguments
     /* eslint-disable @typescript-eslint/ban-ts-comment */
     it("returns an authenticated bearer fetch by default", async () => {
-      /* tslint:disable-next-line:no-any */
+      /* eslint-disable  @typescript-eslint/no-explicit-any */
       (window as any).localStorage = new LocalStorageMock();
 
       mockFetch(
@@ -358,7 +358,7 @@ describe("AuthCodeRedirectHandler", () => {
     });
 
     it("returns an authenticated DPoP fetch if requested", async () => {
-      /* tslint:disable-next-line:no-any */
+      /* eslint-disable  @typescript-eslint/no-explicit-any */
       (window as any).localStorage = new LocalStorageMock();
 
       window.fetch = jest.fn().mockReturnValue(
@@ -441,7 +441,7 @@ describe("AuthCodeRedirectHandler", () => {
   });
 
   it("stores information about the resource server cookie in local storage on successful authentication", async () => {
-    /* tslint:disable-next-line:no-any */
+    /* eslint-disable  @typescript-eslint/no-explicit-any */
     (window as any).localStorage = new LocalStorageMock();
 
     // This mocks the fetch to the Resource Server session endpoint

--- a/packages/browser/__tests__/sessionInfo/SessionInfoManager.spec.ts
+++ b/packages/browser/__tests__/sessionInfo/SessionInfoManager.spec.ts
@@ -51,12 +51,37 @@ describe("SessionInfoManager", () => {
 
   describe("update", () => {
     it("is not implemented yet", async () => {
-      const sessionManager = getSessionInfoManager({
-        storageUtility: mockStorageUtility({}),
-      });
+      const sessionManager = getSessionInfoManager();
       await expect(async () =>
         sessionManager.update("commanderCool", {})
       ).rejects.toThrow("Not Implemented");
+    });
+  });
+
+  describe("register", () => {
+    it("is not implemented yet", async () => {
+      const sessionManager = getSessionInfoManager();
+      await expect(async () =>
+        sessionManager.register("commanderCool")
+      ).rejects.toThrow("Not implemented");
+    });
+  });
+
+  describe("getRegisteredSessionIdAll", () => {
+    it("is not implemented yet", async () => {
+      const sessionManager = getSessionInfoManager();
+      await expect(async () =>
+        sessionManager.getRegisteredSessionIdAll()
+      ).rejects.toThrow("Not implemented");
+    });
+  });
+
+  describe("clearAll", () => {
+    it("is not implemented yet", async () => {
+      const sessionManager = getSessionInfoManager();
+      await expect(async () => sessionManager.clearAll()).rejects.toThrow(
+        "Not implemented"
+      );
     });
   });
 

--- a/packages/browser/src/ClientAuthentication.ts
+++ b/packages/browser/src/ClientAuthentication.ts
@@ -35,6 +35,7 @@ import {
   ISessionInfoManager,
 } from "@inrupt/solid-client-authn-core";
 import { removeOidcQueryParam } from "@inrupt/oidc-client-ext";
+import { KEY_CURRENT_URL } from "./constant";
 
 // TMP: This ensures that the HTTP requests will include any relevant cookie
 // that could have been set by the resource server.
@@ -137,12 +138,26 @@ export default class ClientAuthentication {
     cleanedUpUrl.searchParams.delete("id_token");
     cleanedUpUrl.searchParams.delete("access_token");
 
-    // Remove OAuth-specific query params (since the login flow finishes with the
-    // browser being redirected back with OAuth2 query params (e.g. for 'code'
-    // and 'state'), and so if the user simply refreshes this page our
+    // Remove OAuth-specific query params (since the login flow finishes with
+    // the browser being redirected back with OAuth2 query params (e.g. for
+    // 'code' and 'state'), and so if the user simply refreshes this page our
     // authentication library will be called again with what are now invalid
     // query parameters!).
     window.history.replaceState(null, "", cleanedUpUrl.toString());
+
+    // Check if we have an ID Token in storage - if we do then we may be
+    // currently logged in, and the user has refreshed their browser page. In
+    // this case, it can be really useful to save the user's current browser
+    // location, so that we can restore that location after we complete the
+    // entire re-login-the-user-silently-flow (e.g., if the user was on a
+    // specific 'page' of a Single Page App, then presumably they'll expect to
+    // be brought back to exactly that same 'page' after the full refresh).
+    const sessionInfo = await this.sessionInfoManager.get(
+      redirectInfo.sessionId
+    );
+    if (sessionInfo?.idToken !== undefined) {
+      localStorage.setItem(KEY_CURRENT_URL, window.location.toString());
+    }
 
     return {
       isLoggedIn: redirectInfo.isLoggedIn,

--- a/packages/browser/src/login/oidc/oidcHandlers/AuthorizationCodeWithPkceOidcHandler.ts
+++ b/packages/browser/src/login/oidc/oidcHandlers/AuthorizationCodeWithPkceOidcHandler.ts
@@ -60,11 +60,11 @@ export default class AuthorizationCodeWithPkceOidcHandler
   async handle(oidcLoginOptions: IOidcOptions): Promise<LoginResult> {
     /* eslint-disable camelcase */
     const oidcOptions = {
-      authority: oidcLoginOptions.issuer?.toString(),
+      authority: oidcLoginOptions.issuer.toString(),
       client_id: oidcLoginOptions.client.clientId,
       client_secret: oidcLoginOptions.client.clientSecret,
-      redirect_uri: oidcLoginOptions.redirectUrl?.toString(),
-      post_logout_redirect_uri: oidcLoginOptions.redirectUrl?.toString(),
+      redirect_uri: oidcLoginOptions.redirectUrl.toString(),
+      post_logout_redirect_uri: oidcLoginOptions.redirectUrl.toString(),
       response_type: "code",
       // TODO: The 'webid' scope is still a spec discussion topic
       //  https://github.com/solid/specification/issues/203, i.e. the 'webid'

--- a/packages/browser/src/login/webid/WebIdLoginHandler.spec.ts
+++ b/packages/browser/src/login/webid/WebIdLoginHandler.spec.ts
@@ -19,36 +19,24 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-/**
- * @hidden
- * @packageDocumentation
- */
+import WebIdLoginHandler from "./WebIdLoginHandler";
 
-/**
- * Handles login if a user's webid was provided
- */
-import {
-  ILoginOptions,
-  ILoginHandler,
-  LoginResult,
-} from "@inrupt/solid-client-authn-core";
+describe("WebIdLoginHandler", () => {
+  it("should never handle", async () => {
+    await expect(
+      new WebIdLoginHandler().canHandle({
+        sessionId: "value doesn't matter",
+        tokenType: "DPoP",
+      })
+    ).resolves.toBeFalsy();
+  });
 
-/**
- * @hidden
- */
-export default class WebidLoginHandler implements ILoginHandler {
-  async canHandle(_loginOptions: ILoginOptions): Promise<boolean> {
-    return false;
-  }
-
-  /**
-   * Handles a given WebID by first dereferencing the WebId, then creating correct login options for
-   * a future login handler and triggering that login handler. For example, if a WebID contains an
-   * 'oidcIssuer' triple, it will create login credentials to match that
-   * @param loginOptions
-   */
-  async handle(_loginOptions: ILoginOptions): Promise<LoginResult> {
-    // TODO: implement
-    throw new Error("Not Implemented");
-  }
-}
+  it("should not be implement yet", async () => {
+    await expect(
+      new WebIdLoginHandler().handle({
+        sessionId: "value doesn't matter",
+        tokenType: "DPoP",
+      })
+    ).rejects.toThrow("Not implemented");
+  });
+});

--- a/packages/browser/src/login/webid/WebIdLoginHandler.ts
+++ b/packages/browser/src/login/webid/WebIdLoginHandler.ts
@@ -19,8 +19,37 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { SOLID_CLIENT_AUTHN_KEY_PREFIX } from "@inrupt/solid-client-authn-core";
+/**
+ * @hidden
+ * @packageDocumentation
+ */
 
-export const KEY_CURRENT_ISSUER = `${SOLID_CLIENT_AUTHN_KEY_PREFIX}currentIssuer`;
+/**
+ * Handles login if a user's WebID was provided.
+ */
+import {
+  ILoginOptions,
+  ILoginHandler,
+  LoginResult,
+} from "@inrupt/solid-client-authn-core";
 
-export const KEY_CURRENT_URL = `${SOLID_CLIENT_AUTHN_KEY_PREFIX}currentUrl`;
+/**
+ * @hidden
+ */
+export default class WebIdLoginHandler implements ILoginHandler {
+  async canHandle(_loginOptions: ILoginOptions): Promise<boolean> {
+    return false;
+  }
+
+  /**
+   * Handles a given WebID by first de-referencing that WebID, then creating
+   * correct login options for a future login handler and triggering that login
+   * handler. For example, if a WebID contains an 'oidcIssuer' triple, it will
+   * create login credentials to match that.
+   * @param loginOptions
+   */
+  async handle(_loginOptions: ILoginOptions): Promise<LoginResult> {
+    // TODO: implement
+    throw new Error("Not implemented");
+  }
+}

--- a/packages/browser/src/sessionInfo/SessionInfoManager.ts
+++ b/packages/browser/src/sessionInfo/SessionInfoManager.ts
@@ -125,9 +125,6 @@ export class SessionInfoManager implements ISessionInfoManager {
   async get(
     sessionId: string
   ): Promise<(ISessionInfo & ISessionInternalInfo) | undefined> {
-    const webId = await this.storageUtility.getForUser(sessionId, "webId", {
-      secure: true,
-    });
     const isLoggedIn = await this.storageUtility.getForUser(
       sessionId,
       "isLoggedIn",
@@ -135,6 +132,16 @@ export class SessionInfoManager implements ISessionInfoManager {
         secure: true,
       }
     );
+    if (isLoggedIn === undefined) {
+      return undefined;
+    }
+
+    const webId = await this.storageUtility.getForUser(sessionId, "webId", {
+      secure: true,
+    });
+    const idToken = await this.storageUtility.getForUser(sessionId, "idToken", {
+      secure: false,
+    });
     const refreshToken = await this.storageUtility.getForUser(
       sessionId,
       "refreshToken",
@@ -145,16 +152,15 @@ export class SessionInfoManager implements ISessionInfoManager {
     const issuer = await this.storageUtility.getForUser(sessionId, "issuer", {
       secure: true,
     });
-    if (isLoggedIn !== undefined) {
-      return {
-        sessionId,
-        webId,
-        isLoggedIn: isLoggedIn === "true",
-        refreshToken,
-        issuer,
-      };
-    }
-    return undefined;
+
+    return {
+      sessionId,
+      webId,
+      isLoggedIn: isLoggedIn === "true",
+      idToken,
+      refreshToken,
+      issuer,
+    };
   }
 
   // eslint-disable-next-line class-methods-use-this
@@ -177,7 +183,7 @@ export class SessionInfoManager implements ISessionInfoManager {
    * @param sessionId
    */
   async register(_sessionId: string): Promise<void> {
-    throw new Error("Unimplemented");
+    throw new Error("Not implemented");
   }
 
   /**
@@ -185,13 +191,13 @@ export class SessionInfoManager implements ISessionInfoManager {
    * returns additional session information.
    */
   async getRegisteredSessionIdAll(): Promise<string[]> {
-    throw new Error("Unimplemented");
+    throw new Error("Not implemented");
   }
 
   /**
    * Deletes all information about all sessions, including their registrations.
    */
   async clearAll(): Promise<void> {
-    throw new Error("Unimplemented");
+    throw new Error("Not implemented");
   }
 }

--- a/packages/browser/src/storage/BrowserStorage.spec.ts
+++ b/packages/browser/src/storage/BrowserStorage.spec.ts
@@ -19,8 +19,24 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { SOLID_CLIENT_AUTHN_KEY_PREFIX } from "@inrupt/solid-client-authn-core";
+import BrowserStorage from "./BrowserStorage";
 
-export const KEY_CURRENT_ISSUER = `${SOLID_CLIENT_AUTHN_KEY_PREFIX}currentIssuer`;
+describe("BrowserStorage", () => {
+  it("should get storage", () => {
+    expect(new BrowserStorage().storage).toBeDefined();
+  });
 
-export const KEY_CURRENT_URL = `${SOLID_CLIENT_AUTHN_KEY_PREFIX}currentUrl`;
+  it("should exercise operations - no need for separate tests", async () => {
+    const storage = new BrowserStorage();
+
+    const testKey = "some key";
+    await expect(storage.get(testKey)).resolves.toBeUndefined();
+
+    const testValue = "some value";
+    await storage.set(testKey, testValue);
+    await expect(storage.get(testKey)).resolves.toEqual(testValue);
+
+    await storage.delete(testKey);
+    await expect(storage.get(testKey)).resolves.toBeUndefined();
+  });
+});

--- a/packages/browser/src/util/urlPath.spec.ts
+++ b/packages/browser/src/util/urlPath.spec.ts
@@ -51,12 +51,4 @@ describe("urlPath", () => {
       "https://ex.com/a/test"
     );
   });
-
-  it("should throw a helpful error if URL is invalid", () => {
-    // Regular expression here simply says "match against 1st string, followed
-    // anywhere later by the second, followed anywhere later by the third".
-    expect(() => appendToUrlPathname("not an iri", "test ending")).toThrow(
-      /test ending.*not an iri.*Invalid URL/
-    );
-  });
 });

--- a/packages/core/src/sessionInfo/ISessionInfo.ts
+++ b/packages/core/src/sessionInfo/ISessionInfo.ts
@@ -55,7 +55,12 @@ export interface ISessionInfo {
  */
 export interface ISessionInternalInfo {
   /**
-   * The refresh token associated to the session (if any).
+   * The ID token associated with the session (if any).
+   */
+  idToken?: string;
+
+  /**
+   * The refresh token associated with the session (if any).
    */
   refreshToken?: string;
 


### PR DESCRIPTION
# New feature description
Store the current browser URL in local storage if we have a stored ID token - in the `handlerIncomingRedirect()` function.

Also raised test coverage to 100% (apart from files we know we want to remove, which we should do soon really).

# Checklist

- [X] All acceptance criteria are met.
- [X] Relevant documentation, if any, has been written/updated.
- [X] The changelog has been updated, if applicable.
- [X] New functions/types have been exported in `index.ts`, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

<!-- When cutting a release: -->

This PR bumps the version to <version number>.

# Checklist

- [ ] I used `lerna version <major|minor|patch> --no-push` to update the version number, first inspecting the CHANGELOG to determine if the release was major, minor or patch.
- [ ] The CHANGELOG has been updated to show version and release date - https://keepachangelog.com/en/1.0.0/.
- [ ] The **only** commits in this PR are:
  - the CHANGELOG update.
  - the version update.
- [ ] I will make sure **not** to squash these commits, but **rebase** instead.
- [ ] Once this PR is merged, I will push the tag created by `lerna version ...` (e.g. `git push origin vX.X.X`).
