### PR TITLE
Verify ID token when looking up current issuer 

### DIFF
--- a/packages/browser/__tests__/ClientAuthentication.spec.ts
+++ b/packages/browser/__tests__/ClientAuthentication.spec.ts
@@ -89,12 +89,6 @@ const mockIdTokenPayload = (
   };
 };
 
-// mockIdTokenPayload(
-//   "https://my.pod/profile#me",
-//   "https://some.issuer",
-//   "https://some.app/registration"
-// ),
-
 const mockSessionStorage = async (
   sessionId: string,
   idTokenPayload: Record<string, string | number> = {}

--- a/packages/browser/__tests__/ClientAuthentication.spec.ts
+++ b/packages/browser/__tests__/ClientAuthentication.spec.ts
@@ -26,8 +26,9 @@ import {
   mockStorageUtility,
   StorageUtility,
   USER_SESSION_PREFIX,
+  mockStorage,
 } from "@inrupt/solid-client-authn-core";
-import { mockStorage } from "@inrupt/solid-client-authn-core";
+
 import { Response } from "cross-fetch";
 import { JSONWebKey } from "jose";
 import { signJwt } from "@inrupt/oidc-client-ext";

--- a/packages/browser/__tests__/ClientAuthentication.spec.ts
+++ b/packages/browser/__tests__/ClientAuthentication.spec.ts
@@ -398,19 +398,19 @@ describe("ClientAuthentication", () => {
   });
 
   describe("getCurrentIssuer", () => {
+    // In the following describe block, (window as any) is used
+    // multiple types to override the window type definition and
+    // allow localStorage to be written.
+    /* eslint-disable @typescript-eslint/no-explicit-any */
     it("returns null no current session is in storage", async () => {
       const clientAuthn = getClientAuthentication({});
 
       await expect(clientAuthn.getCurrentIssuer()).resolves.toBeNull();
     });
 
-    // ts-ignore is used to mock out local storage.
-    /* eslint-disable @typescript-eslint/ban-ts-comment */
-
     it("returns null if the current session has no stored issuer", async () => {
       const sessionId = "mySession";
-      // @ts-ignore
-      window.localStorage = new LocalStorageMock({
+      (window as any).localStorage = new LocalStorageMock({
         [KEY_CURRENT_SESSION]: sessionId,
       });
 
@@ -436,8 +436,7 @@ describe("ClientAuthentication", () => {
 
     it("returns null if the current session has no stored ID token", async () => {
       const sessionId = "mySession";
-      // @ts-ignore
-      window.localStorage = new LocalStorageMock({
+      (window as any).localStorage = new LocalStorageMock({
         [KEY_CURRENT_SESSION]: sessionId,
       });
 
@@ -463,8 +462,7 @@ describe("ClientAuthentication", () => {
 
     it("returns null if the current session has no stored client ID", async () => {
       const sessionId = "mySession";
-      // @ts-ignore
-      window.localStorage = new LocalStorageMock({
+      (window as any).localStorage = new LocalStorageMock({
         [KEY_CURRENT_SESSION]: sessionId,
       });
       const mockedStorage = new StorageUtility(
@@ -489,8 +487,7 @@ describe("ClientAuthentication", () => {
 
     it("returns null if the issuer does not have a JWKS", async () => {
       const sessionId = "mySession";
-      // @ts-ignore
-      window.localStorage = new LocalStorageMock({
+      (window as any).localStorage = new LocalStorageMock({
         [KEY_CURRENT_SESSION]: sessionId,
       });
       const mockedIssuerConfig = mockIssuerConfigFetcher({} as IIssuerConfig);
@@ -507,8 +504,7 @@ describe("ClientAuthentication", () => {
 
     it("returns null if the issuer's JWKS isn't available", async () => {
       const sessionId = "mySession";
-      // @ts-ignore
-      window.localStorage = new LocalStorageMock({
+      (window as any).localStorage = new LocalStorageMock({
         [KEY_CURRENT_SESSION]: sessionId,
       });
       const mockedIssuerConfig = mockIssuerConfigFetcher({
@@ -527,8 +523,7 @@ describe("ClientAuthentication", () => {
 
     it("returns null if the current issuer doesn't match the ID token's", async () => {
       const sessionId = "mySession";
-      // @ts-ignore
-      window.localStorage = new LocalStorageMock({
+      (window as any).localStorage = new LocalStorageMock({
         [KEY_CURRENT_SESSION]: sessionId,
       });
       const mockedIssuerConfig = mockIssuerConfigFetcher({
@@ -554,8 +549,7 @@ describe("ClientAuthentication", () => {
 
     it("returns null if the current client ID doesn't match the ID token audience", async () => {
       const sessionId = "mySession";
-      // @ts-ignore
-      window.localStorage = new LocalStorageMock({
+      (window as any).localStorage = new LocalStorageMock({
         [KEY_CURRENT_SESSION]: sessionId,
       });
       const mockedIssuerConfig = mockIssuerConfigFetcher({
@@ -581,8 +575,7 @@ describe("ClientAuthentication", () => {
 
     it("returns null if the ID token signature cannot be verified", async () => {
       const sessionId = "mySession";
-      // @ts-ignore
-      window.localStorage = new LocalStorageMock({
+      (window as any).localStorage = new LocalStorageMock({
         [KEY_CURRENT_SESSION]: sessionId,
       });
       const mockedIssuerConfig = mockIssuerConfigFetcher({
@@ -609,8 +602,7 @@ describe("ClientAuthentication", () => {
 
   it("returns the issuer if the ID token is verified", async () => {
     const sessionId = "mySession";
-    // @ts-ignore
-    window.localStorage = new LocalStorageMock({
+    (window as any).localStorage = new LocalStorageMock({
       [KEY_CURRENT_SESSION]: sessionId,
     });
     const mockedIssuerConfig = mockIssuerConfigFetcher({

--- a/packages/browser/__tests__/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
+++ b/packages/browser/__tests__/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
@@ -38,7 +38,7 @@ import {
 } from "../../../../src/login/oidc/redirectHandler/AuthCodeRedirectHandler";
 import { RedirectorMock } from "../../../../src/login/oidc/__mocks__/Redirector";
 import { SessionInfoManagerMock } from "../../../../src/sessionInfo/__mocks__/SessionInfoManager";
-import { KEY_CURRENT_ISSUER } from "../../../../dist/constant";
+import { KEY_CURRENT_SESSION } from "../../../../src/constant";
 
 class LocalStorageMock {
   public store: {
@@ -352,8 +352,8 @@ describe("AuthCodeRedirectHandler", () => {
 
       // Also check that our issuer was stored correctly (specifically in
       // 'localStorage').
-      expect(window.localStorage.getItem(KEY_CURRENT_ISSUER)).toEqual(
-        testIssuer
+      expect(window.localStorage.getItem(KEY_CURRENT_SESSION)).toEqual(
+        "mySession"
       );
     });
 
@@ -399,11 +399,10 @@ describe("AuthCodeRedirectHandler", () => {
         // @ts-ignore
         header
       ).toMatch(/^DPoP .+$/);
-
       // Also check that our issuer was stored correctly (specifically in
       // 'localStorage').
-      expect(window.localStorage.getItem(KEY_CURRENT_ISSUER)).toEqual(
-        mockIssuer().issuer.toString()
+      expect(window.localStorage.getItem(KEY_CURRENT_SESSION)).toEqual(
+        "mySession"
       );
     });
 
@@ -493,7 +492,9 @@ describe("AuthCodeRedirectHandler", () => {
 
     // Also check that our issuer was stored correctly (specifically in
     // 'localStorage').
-    expect(window.localStorage.getItem(KEY_CURRENT_ISSUER)).toEqual(testIssuer);
+    expect(window.localStorage.getItem(KEY_CURRENT_SESSION)).toEqual(
+      "mySession"
+    );
   });
 
   it("store nothing if the resource server has no session endpoint", async () => {

--- a/packages/browser/__tests__/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
+++ b/packages/browser/__tests__/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
@@ -39,32 +39,7 @@ import {
 import { RedirectorMock } from "../../../../src/login/oidc/__mocks__/Redirector";
 import { SessionInfoManagerMock } from "../../../../src/sessionInfo/__mocks__/SessionInfoManager";
 import { KEY_CURRENT_SESSION } from "../../../../src/constant";
-
-class LocalStorageMock {
-  public store: {
-    [key: string]: string;
-  };
-
-  constructor() {
-    this.store = {};
-  }
-
-  public clear() {
-    this.store = {};
-  }
-
-  public getItem(key: string) {
-    return this.store[key] || undefined;
-  }
-
-  public setItem(key: string, value: string) {
-    this.store[key] = value.toString();
-  }
-
-  public removeItem(key: string) {
-    delete this.store[key];
-  }
-}
+import { LocalStorageMock } from "../../../../src/storage/__mocks__/LocalStorage";
 
 const mockJwk = (): JSONWebKey => {
   return {

--- a/packages/browser/__tests__/sessionInfo/SessionInfoManager.spec.ts
+++ b/packages/browser/__tests__/sessionInfo/SessionInfoManager.spec.ts
@@ -23,8 +23,9 @@ import "reflect-metadata";
 import {
   mockStorageUtility,
   StorageUtility,
+  mockStorage,
 } from "@inrupt/solid-client-authn-core";
-import { mockStorage } from "@inrupt/solid-client-authn-core/dist/storage/__mocks__/StorageUtility";
+
 import { UuidGeneratorMock } from "../../src/util/__mocks__/UuidGenerator";
 import { LogoutHandlerMock } from "../../src/logout/__mocks__/LogoutHandler";
 import { SessionInfoManager } from "../../src/sessionInfo/SessionInfoManager";

--- a/packages/browser/src/ClientAuthentication.ts
+++ b/packages/browser/src/ClientAuthentication.ts
@@ -33,9 +33,10 @@ import {
   IRedirectHandler,
   ISessionInfo,
   ISessionInfoManager,
+  IIssuerConfigFetcher,
 } from "@inrupt/solid-client-authn-core";
-import { removeOidcQueryParam } from "@inrupt/oidc-client-ext";
-import { KEY_CURRENT_URL } from "./constant";
+import { removeOidcQueryParam, validateIdToken } from "@inrupt/oidc-client-ext";
+import { KEY_CURRENT_SESSION, KEY_CURRENT_URL } from "./constant";
 
 // TMP: This ensures that the HTTP requests will include any relevant cookie
 // that could have been set by the resource server.
@@ -60,7 +61,9 @@ export default class ClientAuthentication {
     @inject("redirectHandler") private redirectHandler: IRedirectHandler,
     @inject("logoutHandler") private logoutHandler: ILogoutHandler,
     @inject("sessionInfoManager")
-    private sessionInfoManager: ISessionInfoManager
+    private sessionInfoManager: ISessionInfoManager,
+    @inject("issuerConfigFetcher")
+    private issuerConfigFetcher: IIssuerConfigFetcher
   ) {}
 
   // Define these functions as properties so that they don't get accidentally re-bound.
@@ -121,6 +124,47 @@ export default class ClientAuthentication {
 
   getAllSessionInfo = async (): Promise<ISessionInfo[]> => {
     return this.sessionInfoManager.getAll();
+  };
+
+  getCurrentIssuer = async (): Promise<string | null> => {
+    const currentSessionId = window.localStorage.getItem(KEY_CURRENT_SESSION);
+    if (currentSessionId === null) {
+      return null;
+    }
+    const sessionInfo = await this.sessionInfoManager.get(currentSessionId);
+    // Several session information are required in order to validate that the ID
+    // token in storage hasn't been tampered with, and has actually been issued
+    // by the issuer present in storage.
+    if (
+      sessionInfo === undefined ||
+      sessionInfo.idToken === undefined ||
+      sessionInfo.clientAppId === undefined ||
+      sessionInfo.issuer === undefined
+    ) {
+      return null;
+    }
+    const issuerConfig = await this.issuerConfigFetcher.fetchConfig(
+      sessionInfo.issuer
+    );
+
+    try {
+      const issuerResponse = await fetch(issuerConfig.jwksUri);
+      const jwks = await issuerResponse.json();
+      if (
+        await validateIdToken(
+          sessionInfo.idToken,
+          jwks,
+          sessionInfo.issuer,
+          sessionInfo.clientAppId
+        )
+      ) {
+        return sessionInfo.issuer;
+      }
+    } catch (e) {
+      // If an error happens when fetching the keys, the issuer cannot be trusted.
+      // The error is swallowed, and `null` is eventually returned.
+    }
+    return null;
   };
 
   handleIncomingRedirect = async (

--- a/packages/browser/src/ClientAuthentication.ts
+++ b/packages/browser/src/ClientAuthentication.ts
@@ -132,7 +132,7 @@ export default class ClientAuthentication {
       return null;
     }
     const sessionInfo = await this.sessionInfoManager.get(currentSessionId);
-    // Several session information are required in order to validate that the ID
+    // Several types of session data are required in order to validate that the ID
     // token in storage hasn't been tampered with, and has actually been issued
     // by the issuer present in storage.
     if (

--- a/packages/browser/src/__mocks__/ClientAuthentication.ts
+++ b/packages/browser/src/__mocks__/ClientAuthentication.ts
@@ -21,6 +21,7 @@
 
 import ClientAuthentication from "../ClientAuthentication";
 import { RedirectHandlerMock } from "../login/oidc/redirectHandler/__mocks__/RedirectHandler";
+import { IssuerConfigFetcherMock } from "../login/oidc/__mocks__/IssuerConfigFetcher";
 import { LoginHandlerMock } from "../login/__mocks__/LoginHandler";
 import { LogoutHandlerMock } from "../logout/__mocks__/LogoutHandler";
 import { SessionInfoManagerMock } from "../sessionInfo/__mocks__/SessionInfoManager";
@@ -30,5 +31,6 @@ export const mockClientAuthentication = (): ClientAuthentication =>
     LoginHandlerMock,
     RedirectHandlerMock,
     LogoutHandlerMock,
-    SessionInfoManagerMock
+    SessionInfoManagerMock,
+    IssuerConfigFetcherMock
   );

--- a/packages/browser/src/constant.ts
+++ b/packages/browser/src/constant.ts
@@ -21,6 +21,6 @@
 
 import { SOLID_CLIENT_AUTHN_KEY_PREFIX } from "@inrupt/solid-client-authn-core";
 
-export const KEY_CURRENT_ISSUER = `${SOLID_CLIENT_AUTHN_KEY_PREFIX}currentIssuer`;
+export const KEY_CURRENT_SESSION = `${SOLID_CLIENT_AUTHN_KEY_PREFIX}currentSession`;
 
 export const KEY_CURRENT_URL = `${SOLID_CLIENT_AUTHN_KEY_PREFIX}currentUrl`;

--- a/packages/browser/src/login/oidc/__mocks__/IssuerConfigFetcher.ts
+++ b/packages/browser/src/login/oidc/__mocks__/IssuerConfigFetcher.ts
@@ -40,3 +40,19 @@ export const IssuerConfigFetcherMock: jest.Mocked<IIssuerConfigFetcher> = {
     Promise.resolve(IssuerConfigFetcherFetchConfigResponse)
   ),
 };
+
+export const mockDefaultIssuerConfigFetcher = (): IIssuerConfigFetcher => {
+  return {
+    fetchConfig: jest
+      .fn()
+      .mockResolvedValue(IssuerConfigFetcherFetchConfigResponse),
+  };
+};
+
+export const mockIssuerConfigFetcher = (
+  config: IIssuerConfig
+): IIssuerConfigFetcher => {
+  return {
+    fetchConfig: jest.fn().mockResolvedValue(config),
+  };
+};

--- a/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
+++ b/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
@@ -46,7 +46,7 @@ import {
   buildBearerFetch,
   buildDpopFetch,
 } from "../../../authenticatedFetch/fetchFactory";
-import { KEY_CURRENT_ISSUER } from "../../../constant";
+import { KEY_CURRENT_SESSION } from "../../../constant";
 
 export async function exchangeDpopToken(
   sessionId: string,
@@ -184,10 +184,10 @@ export class AuthCodeRedirectHandler implements IRedirectHandler {
       { errorIfNull: true }
     )) as string;
 
-    // Store our current Issuer specifically in 'localStorage' (i.e., not using
+    // Store the current session ID specifically in 'localStorage' (i.e., not using
     // any other storage mechanism), as we don't deem this information to be
     // sensitive, and we want to ensure it survives a browser tab refresh.
-    window.localStorage.setItem(KEY_CURRENT_ISSUER, issuer);
+    window.localStorage.setItem(KEY_CURRENT_SESSION, storedSessionId);
 
     let tokens: TokenEndpointResponse | TokenEndpointDpopResponse;
     let authFetch: typeof fetch;

--- a/packages/browser/src/sessionInfo/SessionInfoManager.ts
+++ b/packages/browser/src/sessionInfo/SessionInfoManager.ts
@@ -139,9 +139,17 @@ export class SessionInfoManager implements ISessionInfoManager {
     const webId = await this.storageUtility.getForUser(sessionId, "webId", {
       secure: true,
     });
+    const clientId = await this.storageUtility.getForUser(
+      sessionId,
+      "clientId",
+      {
+        secure: false,
+      }
+    );
     const idToken = await this.storageUtility.getForUser(sessionId, "idToken", {
       secure: false,
     });
+
     const refreshToken = await this.storageUtility.getForUser(
       sessionId,
       "refreshToken",
@@ -160,6 +168,7 @@ export class SessionInfoManager implements ISessionInfoManager {
       idToken,
       refreshToken,
       issuer,
+      clientAppId: clientId,
     };
   }
 

--- a/packages/browser/src/storage/__mocks__/LocalStorage.ts
+++ b/packages/browser/src/storage/__mocks__/LocalStorage.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+export class LocalStorageMock {
+  public store: {
+    [key: string]: string;
+  };
+
+  constructor(store?: Record<string, string>) {
+    this.store = store ?? {};
+  }
+
+  public clear(): void {
+    this.store = {};
+  }
+
+  public getItem(key: string): string | null {
+    return this.store[key] || null;
+  }
+
+  public setItem(key: string, value: string): void {
+    this.store[key] = value.toString();
+  }
+
+  public removeItem(key: string): void {
+    delete this.store[key];
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -44,6 +44,7 @@ export { ISessionInfo, ISessionInternalInfo } from "./sessionInfo/ISessionInfo";
 export {
   ISessionInfoManager,
   ISessionInfoManagerOptions,
+  USER_SESSION_PREFIX,
 } from "./sessionInfo/ISessionInfoManager";
 
 export { IIssuerConfigFetcher } from "./login/oidc/IIssuerConfigFetcher";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -78,6 +78,7 @@ export { default as NotImplementedError } from "./errors/NotImplementedError";
 
 // Mocks.
 export {
+  mockStorage,
   mockStorageUtility,
   StorageUtilityMock,
   StorageUtilityGetResponse,

--- a/packages/core/src/sessionInfo/ISessionInfo.ts
+++ b/packages/core/src/sessionInfo/ISessionInfo.ts
@@ -36,6 +36,12 @@ export interface ISessionInfo {
   webId?: string;
 
   /**
+   * The WebID of the app, or a "Public app" WebID if the app does not provide its own.
+   * undefined until the session is logged in and the app WebID has been verified.
+   */
+  clientAppId?: string;
+
+  /**
    * A unique identifier for the session.
    */
   sessionId: string;

--- a/packages/core/src/sessionInfo/ISessionInfoManager.ts
+++ b/packages/core/src/sessionInfo/ISessionInfoManager.ts
@@ -70,3 +70,5 @@ export interface ISessionInfoManager {
    */
   clearAll(): Promise<void>;
 }
+
+export const USER_SESSION_PREFIX = "solidClientAuthenticationUser";


### PR DESCRIPTION
This adds the method `getCurrentIssuer` to the ClientAuthentication class.
Based on the current session ID in storage, the associated ID token is
validated, before returning its issuer to the caller. This way, we ensure
that the ID token hasn't been tampered with, that its audience is the
client associated to the current session, and that the issuer hasn't
been changed in storage either.

# Checklist

- [X] All acceptance criteria are met.
- [X] New functions/types have been exported in `index.ts`, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).