### PR TITLE
login handler now always stores client_id in storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,12 @@ correct issuer, and that it contains some expected values.
 
 #### Browser
 
-- When a session expires, the session is now marked as logged out, and a `logout` event is thrown.
+- When a session expires, the session is now marked as logged out, and a 
+  `logout` event is thrown.
+- The 'client_id' option, if specified as an option when logging in, is now
+  stored in storage, ready to be retrieved again from storage when the login
+  flow redirects back to the client application (previously it was only being
+  stored if DCR was invoked).
 
 The following sections document changes that have been released already:
 

--- a/packages/browser/__tests__/login/oidc/OidcLoginHandler.spec.ts
+++ b/packages/browser/__tests__/login/oidc/OidcLoginHandler.spec.ts
@@ -22,6 +22,7 @@
 // Required by TSyringe:
 import "reflect-metadata";
 import {
+  mockStorageUtility,
   StorageUtilityGetResponse,
   StorageUtilityMock,
 } from "@inrupt/solid-client-authn-core";
@@ -133,6 +134,29 @@ describe("OidcLoginHandler", () => {
     const registrarResult = await actualRegistrar.getClient.mock.results[0]
       .value;
     expect(registrarResult.clientId).toEqual(savedValue.clientId);
+  });
+
+  it("should save client ID if given one as an input option", async () => {
+    const actualStorage = mockStorageUtility({});
+    const handler = getInitialisedHandler({
+      storageUtility: actualStorage,
+    });
+
+    const inputClientId = "coolApp";
+
+    await handler.handle({
+      sessionId: "mySession",
+      oidcIssuer: "https://arbitrary.url",
+      redirectUrl: "https://app.com/redirect",
+      clientId: inputClientId,
+      tokenType: "DPoP",
+    });
+
+    const storedClientId = await actualStorage.getForUser(
+      "clientApplicationRegistrationInfo",
+      "clientId"
+    );
+    expect(storedClientId).toEqual(inputClientId);
   });
 
   it("should throw an error when called without an issuer", async () => {

--- a/packages/browser/__tests__/login/oidc/OidcLoginHandler.spec.ts
+++ b/packages/browser/__tests__/login/oidc/OidcLoginHandler.spec.ts
@@ -147,6 +147,48 @@ describe("OidcLoginHandler", () => {
     expect(storedClientId).toEqual(inputClientId);
   });
 
+  it("should save client ID, secret and name if given as input options", async () => {
+    const actualStorage = new StorageUtility(mockStorage({}), mockStorage({}));
+    const handler = getInitialisedHandler({
+      storageUtility: actualStorage,
+    });
+
+    const inputClientId = "coolApp";
+    const inputClientSecret = "Top Secret!";
+    const inputClientName = "The coolest app around";
+
+    await handler.handle({
+      sessionId: "mySession",
+      oidcIssuer: "https://arbitrary.url",
+      redirectUrl: "https://app.com/redirect",
+      clientId: inputClientId,
+      clientSecret: inputClientSecret,
+      clientName: inputClientName,
+      tokenType: "DPoP",
+    });
+
+    expect(
+      await actualStorage.getForUser(
+        "clientApplicationRegistrationInfo",
+        "clientId"
+      )
+    ).toEqual(inputClientId);
+
+    expect(
+      await actualStorage.getForUser(
+        "clientApplicationRegistrationInfo",
+        "clientSecret"
+      )
+    ).toEqual(inputClientSecret);
+
+    expect(
+      await actualStorage.getForUser(
+        "clientApplicationRegistrationInfo",
+        "clientName"
+      )
+    ).toEqual(inputClientName);
+  });
+
   it("should throw an error when called without an issuer", async () => {
     const handler = getInitialisedHandler();
     // TS Ignore because bad input is purposely given here for the purpose of testing

--- a/packages/browser/__tests__/login/oidc/OidcLoginHandler.spec.ts
+++ b/packages/browser/__tests__/login/oidc/OidcLoginHandler.spec.ts
@@ -141,7 +141,7 @@ describe("OidcLoginHandler", () => {
     });
 
     const storedClientId = await actualStorage.getForUser(
-      "clientApplicationRegistrationInfo",
+      "mySession",
       "clientId"
     );
     expect(storedClientId).toEqual(inputClientId);
@@ -167,26 +167,17 @@ describe("OidcLoginHandler", () => {
       tokenType: "DPoP",
     });
 
-    expect(
-      await actualStorage.getForUser(
-        "clientApplicationRegistrationInfo",
-        "clientId"
-      )
-    ).toEqual(inputClientId);
+    expect(await actualStorage.getForUser("mySession", "clientId")).toEqual(
+      inputClientId
+    );
 
-    expect(
-      await actualStorage.getForUser(
-        "clientApplicationRegistrationInfo",
-        "clientSecret"
-      )
-    ).toEqual(inputClientSecret);
+    expect(await actualStorage.getForUser("mySession", "clientSecret")).toEqual(
+      inputClientSecret
+    );
 
-    expect(
-      await actualStorage.getForUser(
-        "clientApplicationRegistrationInfo",
-        "clientName"
-      )
-    ).toEqual(inputClientName);
+    expect(await actualStorage.getForUser("mySession", "clientName")).toEqual(
+      inputClientName
+    );
   });
 
   it("should throw an error when called without an issuer", async () => {

--- a/packages/browser/__tests__/login/oidc/OidcLoginHandler.spec.ts
+++ b/packages/browser/__tests__/login/oidc/OidcLoginHandler.spec.ts
@@ -24,7 +24,6 @@ import "reflect-metadata";
 import {
   StorageUtility,
   StorageUtilityMock,
-  USER_SESSION_PREFIX,
 } from "@inrupt/solid-client-authn-core";
 import { mockStorage } from "@inrupt/solid-client-authn-core/dist/storage/__mocks__/StorageUtility";
 import { OidcHandlerMock } from "../../../src/login/oidc/__mocks__/IOidcHandler";
@@ -72,7 +71,7 @@ describe("OidcLoginHandler", () => {
     const mockedStorage = new StorageUtility(
       mockStorage({}),
       mockStorage({
-        [`${USER_SESSION_PREFIX}:mySession`]: {
+        "solidClientAuthenticationUser:mySession": {
           clientId: "https://some.app/registration",
         },
       })

--- a/packages/browser/src/login/oidc/ClientRegistrar.ts
+++ b/packages/browser/src/login/oidc/ClientRegistrar.ts
@@ -54,11 +54,9 @@ export default class ClientRegistrar implements IClientRegistrar {
       // storedClientName,
     ] = await Promise.all([
       this.storageUtility.getForUser(options.sessionId, "clientId", {
-        // FIXME: figure out how to persist secure storage at reload
         secure: false,
       }),
       this.storageUtility.getForUser(options.sessionId, "clientSecret", {
-        // FIXME: figure out how to persist secure storage at reload
         secure: false,
       }),
       // this.storageUtility.getForUser(options.sessionId, "clientName", {

--- a/packages/browser/src/login/oidc/OidcLoginHandler.ts
+++ b/packages/browser/src/login/oidc/OidcLoginHandler.ts
@@ -89,7 +89,7 @@ export default class OidcLoginHandler implements ILoginHandler {
       );
     }
 
-    // Fetch OpenId Config
+    // Fetch issuer config.
     const issuerConfig: IIssuerConfig = await this.issuerConfigFetcher.fetchConfig(
       options.oidcIssuer
     );
@@ -128,6 +128,7 @@ export default class OidcLoginHandler implements ILoginHandler {
     await this.storageUtility.setForUser("clientApplicationRegistrationInfo", {
       clientId: dynamicClientRegistration.clientId,
       clientSecret: dynamicClientRegistration.clientSecret as string,
+      clientName: dynamicClientRegistration.clientName as string,
     });
 
     // Construct OIDC Options

--- a/packages/browser/src/login/oidc/OidcLoginHandler.ts
+++ b/packages/browser/src/login/oidc/OidcLoginHandler.ts
@@ -125,16 +125,13 @@ export default class OidcLoginHandler implements ILoginHandler {
           },
           issuerConfig
         );
-
-        await this.storageUtility.setForUser(
-          "clientApplicationRegistrationInfo",
-          {
-            clientId: dynamicClientRegistration.clientId,
-            clientSecret: dynamicClientRegistration.clientSecret as string,
-          }
-        );
       }
     }
+
+    await this.storageUtility.setForUser("clientApplicationRegistrationInfo", {
+      clientId: dynamicClientRegistration.clientId,
+      clientSecret: dynamicClientRegistration.clientSecret as string,
+    });
 
     // Construct OIDC Options
     const OidcOptions: IOidcOptions = {

--- a/packages/browser/src/login/oidc/OidcLoginHandler.ts
+++ b/packages/browser/src/login/oidc/OidcLoginHandler.ts
@@ -101,31 +101,28 @@ export default class OidcLoginHandler implements ILoginHandler {
         clientSecret: options.clientSecret,
         clientName: options.clientName,
       };
-    } else {
-      const clientId = await this.storageUtility.getForUser(
-        "clientApplicationRegistrationInfo",
-        "clientId"
-      );
-
-      if (clientId) {
-        dynamicClientRegistration = {
-          clientId,
-          clientSecret: await this.storageUtility.getForUser(
-            "clientApplicationRegistrationInfo",
-            "clientSecret"
-          ),
-          clientName: options.clientName,
-        };
-      } else {
-        dynamicClientRegistration = await this.clientRegistrar.getClient(
-          {
-            sessionId: options.sessionId,
-            clientName: options.clientName,
-            redirectUrl: options.redirectUrl,
-          },
-          issuerConfig
-        );
+      await this.storageUtility.setForUser(options.sessionId, {
+        clientId: options.clientId,
+      });
+      if (options.clientSecret) {
+        await this.storageUtility.setForUser(options.sessionId, {
+          clientSecret: options.clientSecret,
+        });
       }
+      if (options.clientName) {
+        await this.storageUtility.setForUser(options.sessionId, {
+          clientName: options.clientName,
+        });
+      }
+    } else {
+      dynamicClientRegistration = await this.clientRegistrar.getClient(
+        {
+          sessionId: options.sessionId,
+          clientName: options.clientName,
+          redirectUrl: options.redirectUrl,
+        },
+        issuerConfig
+      );
     }
 
     await this.storageUtility.setForUser("clientApplicationRegistrationInfo", {

--- a/packages/browser/src/login/oidc/OidcLoginHandler.ts
+++ b/packages/browser/src/login/oidc/OidcLoginHandler.ts
@@ -125,12 +125,6 @@ export default class OidcLoginHandler implements ILoginHandler {
       );
     }
 
-    await this.storageUtility.setForUser("clientApplicationRegistrationInfo", {
-      clientId: dynamicClientRegistration.clientId,
-      clientSecret: dynamicClientRegistration.clientSecret as string,
-      clientName: dynamicClientRegistration.clientName as string,
-    });
-
     // Construct OIDC Options
     const OidcOptions: IOidcOptions = {
       issuer: options.oidcIssuer,

--- a/packages/browser/src/login/oidc/__mocks__/ClientRegistrar.ts
+++ b/packages/browser/src/login/oidc/__mocks__/ClientRegistrar.ts
@@ -37,16 +37,23 @@ export const PublicClientRegistrarResponse: IClient = {
 
 export const ClientRegistrarMock: jest.Mocked<IClientRegistrar> = {
   getClient: jest.fn(
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    (options: IClientRegistrarOptions, issuerConfig: IIssuerConfig) =>
+    (_options: IClientRegistrarOptions, _issuerConfig: IIssuerConfig) =>
       Promise.resolve(ClientRegistrarResponse)
   ),
 };
 
 export const PublicClientRegistrarMock: jest.Mocked<IClientRegistrar> = {
   getClient: jest.fn(
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    (options: IClientRegistrarOptions, issuerConfig: IIssuerConfig) =>
+    (_options: IClientRegistrarOptions, _issuerConfig: IIssuerConfig) =>
       Promise.resolve(PublicClientRegistrarResponse)
   ),
+};
+
+export const mockDefaultClientRegistrar = (): IClientRegistrar => {
+  return {
+    getClient: jest.fn(
+      (_options: IClientRegistrarOptions, _issuerConfig: IIssuerConfig) =>
+        Promise.resolve(ClientRegistrarResponse)
+    ),
+  };
 };


### PR DESCRIPTION
This PR fixes bug #.
The 'client_id' option, if specified as an option when logging in, is now  stored in storage, ready to be retrieved again from storage when the login  flow redirects back to the client application (previously it was only being stored if DCR was invoked).

- [X] I've added a unit test to test for potential regressions of this bug.
- [X] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
