### PR TITLE
Feat/restore url on redirect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,17 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - `validateIdToken`: A function to check that an ID token has been signed by the
 correct issuer, and that it contains some expected values.
 
+#### Browser
+
+- Added new `onSessionRestore` event to `Session` (and default session) to allow
+  the developer to register an event callback that will be called whenever a
+  session is restored (e.g., due to a browser page refresh). The callback is
+  given a URL parameter, which represents the current URL of the browser
+  *before* the session restoration (to allow the developer to restore their
+  app's state if needed, e.g., if the app is a Single Page App (SPA) and the
+  developer wishes to restore the users 'current page' to exactly where they
+  were before the refresh).
+
 ### Bugfix
 
 #### browser

--- a/packages/browser/__tests__/ClientAuthentication.spec.ts
+++ b/packages/browser/__tests__/ClientAuthentication.spec.ts
@@ -496,48 +496,7 @@ describe("ClientAuthentication", () => {
         sessionInfoManager: mockSessionInfoManager(mockedStorage),
       });
 
-<<<<<<< HEAD
       await expect(clientAuthn.getCurrentIssuer()).resolves.toBeNull();
-=======
-      try {
-        // eslint-disable-next-line no-restricted-globals
-        history.replaceState = jest.fn();
-
-        const clientAuthn = getClientAuthentication({
-          // Awkward here - we need to be logged in (which is state stored in
-          // 'secure' storage), and have an ID Token (which is stored in
-          // 'insecure' storage).
-          sessionInfoManager: mockSessionInfoManager(
-            new StorageUtility(
-              mockStorage({
-                "solidClientAuthenticationUser:global": {
-                  isLoggedIn: "true",
-                },
-              }),
-              mockStorage({
-                "solidClientAuthenticationUser:global": {
-                  idToken: "value doesn't matter",
-                },
-              })
-            )
-          ),
-        });
-
-        await clientAuthn.handleIncomingRedirect("https://ex.com/redirect");
-
-        // In unit tests, the window location will just be localhost. All we're
-        // really testing here is that a location was persisted (so we could
-        // change this assertion to just ensure a value exists and is non-empty.
-        expect(window.localStorage.getItem(KEY_CURRENT_URL)).toContain(
-          "http://localhost/"
-        );
-      } finally {
-        // Remove the mocked method:
-        Object.defineProperty(window, "localStorage", {
-          value: existingLocalStorage,
-        });
-      }
->>>>>>> added session restore event
     });
 
     it("returns null if the current issuer doesn't match the ID token's", async () => {

--- a/packages/browser/__tests__/ClientAuthentication.spec.ts
+++ b/packages/browser/__tests__/ClientAuthentication.spec.ts
@@ -383,7 +383,7 @@ describe("ClientAuthentication", () => {
     it("returns null no current session is in storage", async () => {
       const clientAuthn = getClientAuthentication({});
 
-      await expect(clientAuthn.getCurrentIssuer()).resolves.toBeNull();
+      await expect(clientAuthn.validateCurrentIssuer()).resolves.toBeNull();
     });
 
     it("returns null if the current session has no stored issuer", async () => {
@@ -409,7 +409,7 @@ describe("ClientAuthentication", () => {
         sessionInfoManager: mockSessionInfoManager(mockedStorage),
       });
 
-      await expect(clientAuthn.getCurrentIssuer()).resolves.toBeNull();
+      await expect(clientAuthn.validateCurrentIssuer()).resolves.toBeNull();
     });
 
     it("returns null if the current session has no stored ID token", async () => {
@@ -435,7 +435,7 @@ describe("ClientAuthentication", () => {
         sessionInfoManager: mockSessionInfoManager(mockedStorage),
       });
 
-      await expect(clientAuthn.getCurrentIssuer()).resolves.toBeNull();
+      await expect(clientAuthn.validateCurrentIssuer()).resolves.toBeNull();
     });
 
     it("returns null if the current session has no stored client ID", async () => {
@@ -460,7 +460,7 @@ describe("ClientAuthentication", () => {
         sessionInfoManager: mockSessionInfoManager(mockedStorage),
       });
 
-      await expect(clientAuthn.getCurrentIssuer()).resolves.toBeNull();
+      await expect(clientAuthn.validateCurrentIssuer()).resolves.toBeNull();
     });
 
     it("returns null if the issuer does not have a JWKS", async () => {
@@ -477,7 +477,7 @@ describe("ClientAuthentication", () => {
         sessionInfoManager: mockSessionInfoManager(mockedStorage),
       });
 
-      await expect(clientAuthn.getCurrentIssuer()).resolves.toBeNull();
+      await expect(clientAuthn.validateCurrentIssuer()).resolves.toBeNull();
     });
 
     it("returns null if the issuer's JWKS isn't available", async () => {
@@ -496,7 +496,7 @@ describe("ClientAuthentication", () => {
         sessionInfoManager: mockSessionInfoManager(mockedStorage),
       });
 
-      await expect(clientAuthn.getCurrentIssuer()).resolves.toBeNull();
+      await expect(clientAuthn.validateCurrentIssuer()).resolves.toBeNull();
     });
 
     it("returns null if the current issuer doesn't match the ID token's", async () => {
@@ -528,7 +528,7 @@ describe("ClientAuthentication", () => {
         sessionInfoManager: mockSessionInfoManager(mockedStorage),
       });
 
-      await expect(clientAuthn.getCurrentIssuer()).resolves.toBeNull();
+      await expect(clientAuthn.validateCurrentIssuer()).resolves.toBeNull();
     });
 
     it("returns null if the current client ID doesn't match the ID token audience", async () => {
@@ -560,7 +560,7 @@ describe("ClientAuthentication", () => {
         sessionInfoManager: mockSessionInfoManager(mockedStorage),
       });
 
-      await expect(clientAuthn.getCurrentIssuer()).resolves.toBeNull();
+      await expect(clientAuthn.validateCurrentIssuer()).resolves.toBeNull();
     });
 
     it("returns null if the ID token isn't signed with the keys of the issuer", async () => {
@@ -587,7 +587,7 @@ describe("ClientAuthentication", () => {
         sessionInfoManager: mockSessionInfoManager(mockedStorage),
       });
 
-      await expect(clientAuthn.getCurrentIssuer()).resolves.toBeNull();
+      await expect(clientAuthn.validateCurrentIssuer()).resolves.toBeNull();
     });
   });
 
@@ -614,7 +614,7 @@ describe("ClientAuthentication", () => {
       sessionInfoManager: mockSessionInfoManager(mockedStorage),
     });
 
-    await expect(clientAuthn.getCurrentIssuer()).resolves.toBe(
+    await expect(clientAuthn.validateCurrentIssuer()).resolves.toBe(
       "https://some.issuer"
     );
   });

--- a/packages/browser/__tests__/ClientAuthentication.spec.ts
+++ b/packages/browser/__tests__/ClientAuthentication.spec.ts
@@ -383,7 +383,7 @@ describe("ClientAuthentication", () => {
     it("returns null no current session is in storage", async () => {
       const clientAuthn = getClientAuthentication({});
 
-      await expect(clientAuthn.validateCurrentIssuer()).resolves.toBeNull();
+      await expect(clientAuthn.validateCurrentSession()).resolves.toBeNull();
     });
 
     it("returns null if the current session has no stored issuer", async () => {
@@ -409,7 +409,7 @@ describe("ClientAuthentication", () => {
         sessionInfoManager: mockSessionInfoManager(mockedStorage),
       });
 
-      await expect(clientAuthn.validateCurrentIssuer()).resolves.toBeNull();
+      await expect(clientAuthn.validateCurrentSession()).resolves.toBeNull();
     });
 
     it("returns null if the current session has no stored ID token", async () => {
@@ -435,7 +435,7 @@ describe("ClientAuthentication", () => {
         sessionInfoManager: mockSessionInfoManager(mockedStorage),
       });
 
-      await expect(clientAuthn.validateCurrentIssuer()).resolves.toBeNull();
+      await expect(clientAuthn.validateCurrentSession()).resolves.toBeNull();
     });
 
     it("returns null if the current session has no stored client ID", async () => {
@@ -460,7 +460,7 @@ describe("ClientAuthentication", () => {
         sessionInfoManager: mockSessionInfoManager(mockedStorage),
       });
 
-      await expect(clientAuthn.validateCurrentIssuer()).resolves.toBeNull();
+      await expect(clientAuthn.validateCurrentSession()).resolves.toBeNull();
     });
 
     it("returns null if the issuer does not have a JWKS", async () => {
@@ -477,7 +477,7 @@ describe("ClientAuthentication", () => {
         sessionInfoManager: mockSessionInfoManager(mockedStorage),
       });
 
-      await expect(clientAuthn.validateCurrentIssuer()).resolves.toBeNull();
+      await expect(clientAuthn.validateCurrentSession()).resolves.toBeNull();
     });
 
     it("returns null if the issuer's JWKS isn't available", async () => {
@@ -496,7 +496,7 @@ describe("ClientAuthentication", () => {
         sessionInfoManager: mockSessionInfoManager(mockedStorage),
       });
 
-      await expect(clientAuthn.validateCurrentIssuer()).resolves.toBeNull();
+      await expect(clientAuthn.validateCurrentSession()).resolves.toBeNull();
     });
 
     it("returns null if the current issuer doesn't match the ID token's", async () => {
@@ -528,7 +528,7 @@ describe("ClientAuthentication", () => {
         sessionInfoManager: mockSessionInfoManager(mockedStorage),
       });
 
-      await expect(clientAuthn.validateCurrentIssuer()).resolves.toBeNull();
+      await expect(clientAuthn.validateCurrentSession()).resolves.toBeNull();
     });
 
     it("returns null if the current client ID doesn't match the ID token audience", async () => {
@@ -560,7 +560,7 @@ describe("ClientAuthentication", () => {
         sessionInfoManager: mockSessionInfoManager(mockedStorage),
       });
 
-      await expect(clientAuthn.validateCurrentIssuer()).resolves.toBeNull();
+      await expect(clientAuthn.validateCurrentSession()).resolves.toBeNull();
     });
 
     it("returns null if the ID token isn't signed with the keys of the issuer", async () => {
@@ -587,7 +587,7 @@ describe("ClientAuthentication", () => {
         sessionInfoManager: mockSessionInfoManager(mockedStorage),
       });
 
-      await expect(clientAuthn.validateCurrentIssuer()).resolves.toBeNull();
+      await expect(clientAuthn.validateCurrentSession()).resolves.toBeNull();
     });
   });
 
@@ -614,8 +614,14 @@ describe("ClientAuthentication", () => {
       sessionInfoManager: mockSessionInfoManager(mockedStorage),
     });
 
-    await expect(clientAuthn.validateCurrentIssuer()).resolves.toBe(
-      "https://some.issuer"
+    await expect(clientAuthn.validateCurrentSession()).resolves.toStrictEqual(
+      expect.objectContaining({
+        issuer: "https://some.issuer",
+        clientAppId: "https://some.app/registration",
+        sessionId,
+        idToken: expect.anything(),
+        webId: "https://my.pod/profile#me",
+      })
     );
   });
 });

--- a/packages/browser/__tests__/ClientAuthentication.spec.ts
+++ b/packages/browser/__tests__/ClientAuthentication.spec.ts
@@ -307,9 +307,22 @@ describe("ClientAuthentication", () => {
       const url =
         "https://coolapp.com/redirect?state=userId&id_token=idToken&access_token=accessToken";
       const redirectInfo = await clientAuthn.handleIncomingRedirect(url);
-      expect(redirectInfo).toEqual({
-        ...RedirectHandlerResponse,
-      });
+
+      // Our injected mocked response may also contain internal-only data (for
+      // other tests), whereas our response from `handleIncomingRedirect()` can
+      // only contain publicly visible fields. So we need to explicitly check
+      // for individual fields (as opposed to just checking against
+      // entire-response-object-equality).
+      expect(redirectInfo?.sessionId).toEqual(
+        RedirectHandlerResponse.sessionId
+      );
+      expect(redirectInfo?.webId).toEqual(RedirectHandlerResponse.webId);
+      expect(redirectInfo?.isLoggedIn).toEqual(
+        RedirectHandlerResponse.isLoggedIn
+      );
+      expect(redirectInfo?.expirationDate).toEqual(
+        RedirectHandlerResponse.expirationDate
+      );
       expect(defaultMocks.redirectHandler.handle).toHaveBeenCalledWith(url);
 
       // Calling the redirect handler should have updated the fetch.

--- a/packages/browser/__tests__/ClientAuthentication.spec.ts
+++ b/packages/browser/__tests__/ClientAuthentication.spec.ts
@@ -496,7 +496,48 @@ describe("ClientAuthentication", () => {
         sessionInfoManager: mockSessionInfoManager(mockedStorage),
       });
 
+<<<<<<< HEAD
       await expect(clientAuthn.getCurrentIssuer()).resolves.toBeNull();
+=======
+      try {
+        // eslint-disable-next-line no-restricted-globals
+        history.replaceState = jest.fn();
+
+        const clientAuthn = getClientAuthentication({
+          // Awkward here - we need to be logged in (which is state stored in
+          // 'secure' storage), and have an ID Token (which is stored in
+          // 'insecure' storage).
+          sessionInfoManager: mockSessionInfoManager(
+            new StorageUtility(
+              mockStorage({
+                "solidClientAuthenticationUser:global": {
+                  isLoggedIn: "true",
+                },
+              }),
+              mockStorage({
+                "solidClientAuthenticationUser:global": {
+                  idToken: "value doesn't matter",
+                },
+              })
+            )
+          ),
+        });
+
+        await clientAuthn.handleIncomingRedirect("https://ex.com/redirect");
+
+        // In unit tests, the window location will just be localhost. All we're
+        // really testing here is that a location was persisted (so we could
+        // change this assertion to just ensure a value exists and is non-empty.
+        expect(window.localStorage.getItem(KEY_CURRENT_URL)).toContain(
+          "http://localhost/"
+        );
+      } finally {
+        // Remove the mocked method:
+        Object.defineProperty(window, "localStorage", {
+          value: existingLocalStorage,
+        });
+      }
+>>>>>>> added session restore event
     });
 
     it("returns null if the current issuer doesn't match the ID token's", async () => {

--- a/packages/browser/__tests__/Session.spec.ts
+++ b/packages/browser/__tests__/Session.spec.ts
@@ -611,14 +611,21 @@ describe("Session", () => {
         const mySession = new Session({
           clientAuthentication: mockClientAuthentication(),
         });
+        const sessionRestoreTrigger = jest.spyOn(
+          mySession,
+          "fireSessionRestoreEvent"
+        );
+
         mySession.onSessionRestore(myCallback);
 
         // Callback should not be called on initial login...
         await mySession.handleIncomingRedirect("https://not-relevant.com/");
+        expect(sessionRestoreTrigger).not.toHaveBeenCalled();
 
         // ...but should be called on a subsequent calls, i.e., on session
         // restore after a silent login.
         await mySession.handleIncomingRedirect("https://not-relevant.com/");
+        expect(sessionRestoreTrigger).toHaveBeenCalled();
       } finally {
         // Restore our 'window' state.
         window.location = location;

--- a/packages/browser/__tests__/Session.spec.ts
+++ b/packages/browser/__tests__/Session.spec.ts
@@ -403,7 +403,7 @@ describe("Session", () => {
       clientAuthentication.handleIncomingRedirect = jest
         .fn()
         .mockResolvedValue(undefined);
-      clientAuthentication.validateCurrentIssuer = jest
+      clientAuthentication.validateCurrentSession = jest
         .fn()
         .mockResolvedValue("https://some.issuer/");
 
@@ -456,21 +456,19 @@ describe("Session", () => {
             isLoggedIn: "true",
           },
         }),
-        mockStorage({
-          [`${USER_SESSION_PREFIX}:${sessionId}`]: {
-            idToken: "value doesn't matter",
-            redirectUrl: "https://some.redirect/url",
-            clientId: "some client ID",
-            clientSecret: "some client secret",
-          },
-        })
+        mockStorage({})
       );
       const clientAuthentication = mockClientAuthentication({
         sessionInfoManager: mockSessionInfoManager(mockedStorage),
       });
-      clientAuthentication.validateCurrentIssuer = jest
+      clientAuthentication.validateCurrentSession = jest
         .fn()
-        .mockResolvedValue("https://some.issuer");
+        .mockResolvedValue({
+          issuer: "https://some.issuer",
+          clientAppId: "some client ID",
+          clientAppSecret: "some client secret",
+          redirectUrl: "https://some.redirect/url",
+        });
       clientAuthentication.handleIncomingRedirect = jest
         .fn()
         .mockResolvedValue(undefined);

--- a/packages/browser/__tests__/Session.spec.ts
+++ b/packages/browser/__tests__/Session.spec.ts
@@ -403,7 +403,7 @@ describe("Session", () => {
       clientAuthentication.handleIncomingRedirect = jest
         .fn()
         .mockResolvedValue(undefined);
-      clientAuthentication.getCurrentIssuer = jest
+      clientAuthentication.validateCurrentIssuer = jest
         .fn()
         .mockResolvedValue("https://some.issuer/");
 
@@ -468,7 +468,7 @@ describe("Session", () => {
       const clientAuthentication = mockClientAuthentication({
         sessionInfoManager: mockSessionInfoManager(mockedStorage),
       });
-      clientAuthentication.getCurrentIssuer = jest
+      clientAuthentication.validateCurrentIssuer = jest
         .fn()
         .mockResolvedValue("https://some.issuer");
       clientAuthentication.handleIncomingRedirect = jest

--- a/packages/browser/__tests__/Session.spec.ts
+++ b/packages/browser/__tests__/Session.spec.ts
@@ -579,14 +579,14 @@ describe("Session", () => {
       const defaultLocation = "https://coolSite.com/resource";
       const currentLocation = "https://coolSite.com/redirect";
 
-      // This pretends we have previously triggerd silent authentication and stored
+      // This pretends we have previously triggered silent authentication and stored
       // the location.
       mockLocalStorage({
         [KEY_CURRENT_URL]: defaultLocation,
       });
       // This acts as the URL the user has been redirected to.
       mockLocation(currentLocation);
-      // This pretends the login is successful
+      // This pretends the login is successful.
       const clientAuthentication = mockClientAuthentication();
       clientAuthentication.handleIncomingRedirect = jest
         .fn()

--- a/packages/browser/__tests__/Session.spec.ts
+++ b/packages/browser/__tests__/Session.spec.ts
@@ -607,21 +607,14 @@ describe("Session", () => {
         const mySession = new Session({
           clientAuthentication: mockClientAuthentication(),
         });
-        const sessionRestoreTrigger = jest.spyOn(
-          mySession,
-          "fireSessionRestoreEvent"
-        );
-
         mySession.onSessionRestore(myCallback);
 
         // Callback should not be called on initial login...
         await mySession.handleIncomingRedirect("https://not-relevant.com/");
-        expect(sessionRestoreTrigger).not.toHaveBeenCalled();
 
         // ...but should be called on a subsequent calls, i.e., on session
         // restore after a silent login.
         await mySession.handleIncomingRedirect("https://not-relevant.com/");
-        expect(sessionRestoreTrigger).toHaveBeenCalled();
       } finally {
         // Restore our 'window' state.
         window.location = location;

--- a/packages/browser/__tests__/Session.spec.ts
+++ b/packages/browser/__tests__/Session.spec.ts
@@ -596,12 +596,8 @@ describe("Session", () => {
         // location and history aren't optional on window, which makes TS complain
         // (rightfully) when we delete them. However, they are deleted on purpose
         // here just for testing.
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        delete window.location;
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        delete window.history.replaceState;
+        delete (window as any).location;
+        delete (window as any).history.replaceState;
 
         window.location = {
           href: defaultLocation,

--- a/packages/browser/__tests__/defaultSession.spec.ts
+++ b/packages/browser/__tests__/defaultSession.spec.ts
@@ -27,6 +27,7 @@ import {
   login,
   logout,
   onLogin,
+  onSessionRestore,
   onLogout,
 } from "../src/defaultSession";
 import type * as SessionModuleType from "../src/Session";
@@ -59,6 +60,7 @@ it("re-uses the same Session when calling multiple methods", () => {
 
 it("all functions pass on their arguments to the default session", () => {
   const defaultSession = getDefaultSession();
+
   const fetchSpy = jest.fn();
   defaultSession.fetch = fetchSpy as typeof defaultSession.fetch;
   const loginSpy = jest.fn();
@@ -69,6 +71,7 @@ it("all functions pass on their arguments to the default session", () => {
   defaultSession.handleIncomingRedirect = handleIncomingRedirectSpy as typeof defaultSession.handleIncomingRedirect;
   const onLoginSpy = jest.spyOn(defaultSession, "onLogin");
   const onLogoutSpy = jest.spyOn(defaultSession, "onLogout");
+  const onSessionRestoreSpy = jest.spyOn(defaultSession, "onSessionRestore");
 
   expect(fetchSpy).not.toHaveBeenCalled();
   // eslint-disable-next-line @typescript-eslint/no-floating-promises
@@ -93,6 +96,10 @@ it("all functions pass on their arguments to the default session", () => {
   expect(onLoginSpy).not.toHaveBeenCalled();
   onLogin(jest.fn());
   expect(onLoginSpy).toHaveBeenCalledTimes(1);
+
+  expect(onSessionRestoreSpy).not.toHaveBeenCalled();
+  onSessionRestore(jest.fn());
+  expect(onSessionRestoreSpy).toHaveBeenCalledTimes(1);
 
   expect(onLogoutSpy).not.toHaveBeenCalled();
   onLogout(jest.fn());

--- a/packages/browser/src/ClientAuthentication.ts
+++ b/packages/browser/src/ClientAuthentication.ts
@@ -133,7 +133,9 @@ export default class ClientAuthentication {
     return this.sessionInfoManager.getAll();
   };
 
-  validateCurrentIssuer = async (): Promise<string | null> => {
+  validateCurrentSession = async (): Promise<
+    (ISessionInfo & ISessionInternalInfo) | null
+  > => {
     const currentSessionId = window.localStorage.getItem(KEY_CURRENT_SESSION);
     if (currentSessionId === null) {
       return null;
@@ -165,7 +167,7 @@ export default class ClientAuthentication {
           sessionInfo.clientAppId
         )
       ) {
-        return sessionInfo.issuer;
+        return sessionInfo;
       }
     } catch (e) {
       // If an error happens when fetching the keys, the issuer cannot be trusted.

--- a/packages/browser/src/ClientAuthentication.ts
+++ b/packages/browser/src/ClientAuthentication.ts
@@ -133,7 +133,7 @@ export default class ClientAuthentication {
     return this.sessionInfoManager.getAll();
   };
 
-  getCurrentIssuer = async (): Promise<string | null> => {
+  validateCurrentIssuer = async (): Promise<string | null> => {
     const currentSessionId = window.localStorage.getItem(KEY_CURRENT_SESSION);
     if (currentSessionId === null) {
       return null;

--- a/packages/browser/src/ClientAuthentication.ts
+++ b/packages/browser/src/ClientAuthentication.ts
@@ -102,7 +102,7 @@ export default class ClientAuthentication {
       clientName: options.clientName ?? options.clientId,
       popUp: options.popUp || false,
       handleRedirect: options.handleRedirect,
-      // Defaults to DPoP
+      // Defaults to DPoP.
       tokenType: options.tokenType ?? "DPoP",
       prompt: options.prompt,
     });

--- a/packages/browser/src/Session.ts
+++ b/packages/browser/src/Session.ts
@@ -206,7 +206,8 @@ export class Session extends EventEmitter {
         this.emit("login");
       } else {
         // If an URL is stored in local storage, we are being logged in after a
-        // silent authentication.
+        // silent authentication, so remove our currently stored URL location
+        // to clean up our state now that we are completing the re-login process.
         window.localStorage.removeItem(KEY_CURRENT_URL);
         this.emit("sessionRestore", currentUrl);
       }
@@ -259,7 +260,7 @@ export class Session extends EventEmitter {
    * Note: the callback will be called with the saved value of the 'current URL'
    * at the time the session was restored.
    *
-   * @param callback The function called when a user completes logout.
+   * @param callback The function called when a user's already logged-in session is restored, e.g., after a silent authentication is completed after a page refresh.
    */
   onSessionRestore(callback: (currentUrl: string) => unknown): void {
     this.on("sessionRestore", callback);

--- a/packages/browser/src/Session.ts
+++ b/packages/browser/src/Session.ts
@@ -175,6 +175,11 @@ export class Session extends EventEmitter {
     this.emit("logout");
   };
 
+  fireSessionRestoreEvent = (): void => {
+    const storedCurrentUrl = localStorage.getItem(KEY_CURRENT_URL);
+    this.emit("sessionRestore", storedCurrentUrl);
+  };
+
   /**
    * Completes the login process by processing the information provided by the
    * Solid identity provider through redirect.
@@ -188,6 +193,7 @@ export class Session extends EventEmitter {
     url: string = window.location.href
   ): Promise<ISessionInfo | undefined> => {
     if (this.info.isLoggedIn) {
+      this.fireSessionRestoreEvent();
       return this.info;
     }
 
@@ -248,5 +254,17 @@ export class Session extends EventEmitter {
    */
   onLogout(callback: () => unknown): void {
     this.on("logout", callback);
+  }
+
+  /**
+   * Register a callback function to be called when a session is restored.
+   *
+   * Note: the callback will be called with the saved value of the 'current URL'
+   * at the time the session was restored.
+   *
+   * @param callback The function called when a user completes logout.
+   */
+  onSessionRestore(callback: (currentUrl: string) => unknown): void {
+    this.on("sessionRestore", callback);
   }
 }

--- a/packages/browser/src/Session.ts
+++ b/packages/browser/src/Session.ts
@@ -58,11 +58,10 @@ async function silentlyAuthenticate(
 ) {
   // Check if we have an ID Token in storage - if we do then we may be
   // currently logged in, and the user has refreshed their browser page. The ID
-  // token is validated, and its issuer claim is extracted to know where silent
-  // authentication is possible.
-  const issuer = await clientAuthn.validateCurrentIssuer();
-  const storedSessionInfo = await clientAuthn.getSessionInfo(sessionId);
-  if (issuer !== null && storedSessionInfo !== undefined) {
+  // token is validated, and on success the current session information are returned,
+  // now that we know they have not been tampered with.
+  const storedSessionInfo = await clientAuthn.validateCurrentSession();
+  if (storedSessionInfo !== null) {
     // It can be really useful to save the user's current browser location,
     // so that we can restore it after completing the silent authentication
     // on incoming redirect. This way, the user is eventually redirected back
@@ -70,7 +69,7 @@ async function silentlyAuthenticate(
     window.localStorage.setItem(KEY_CURRENT_URL, window.location.href);
     await clientAuthn.login(sessionId, {
       prompt: "none",
-      oidcIssuer: issuer,
+      oidcIssuer: storedSessionInfo.issuer,
       redirectUrl: storedSessionInfo.redirectUrl,
       clientId: storedSessionInfo.clientAppId,
       clientSecret: storedSessionInfo.clientAppSecret,

--- a/packages/browser/src/Session.ts
+++ b/packages/browser/src/Session.ts
@@ -60,7 +60,7 @@ async function silentlyAuthenticate(
   // currently logged in, and the user has refreshed their browser page. The ID
   // token is validated, and its issuer claim is extracted to know where silent
   // authentication is possible.
-  const issuer = await clientAuthn.getCurrentIssuer();
+  const issuer = await clientAuthn.validateCurrentIssuer();
   const storedSessionInfo = await clientAuthn.getSessionInfo(sessionId);
   if (issuer !== null && storedSessionInfo !== undefined) {
     // It can be really useful to save the user's current browser location,

--- a/packages/browser/src/defaultSession.ts
+++ b/packages/browser/src/defaultSession.ts
@@ -112,3 +112,14 @@ export const onLogout: Session["onLogout"] = (...args) => {
   const session = getDefaultSession();
   return session.onLogout(...args);
 };
+
+/**
+ * Register a callback function to be called when a session is restored:
+ *
+ * @param callback The function called when a session is restored.
+ * @since 1.3.0
+ */
+export const onSessionRestore: Session["onSessionRestore"] = (...args) => {
+  const session = getDefaultSession();
+  return session.onSessionRestore(...args);
+};

--- a/packages/browser/src/sessionInfo/__mocks__/SessionInfoManager.ts
+++ b/packages/browser/src/sessionInfo/__mocks__/SessionInfoManager.ts
@@ -23,16 +23,22 @@ import {
   ISessionInfo,
   ISessionInfoManager,
   ISessionInfoManagerOptions,
+  ISessionInternalInfo,
   IStorageUtility,
 } from "@inrupt/solid-client-authn-core";
 import { SessionInfoManager } from "../SessionInfoManager";
 
-export const SessionCreatorCreateResponse: ISessionInfo = {
+export const SessionCreatorCreateResponse: ISessionInfo &
+  ISessionInternalInfo = {
   sessionId: "global",
   isLoggedIn: true,
   webId: "https://pod.com/profile/card#me",
+
+  // Internal info fields...
+  idToken: "test ID token",
 };
-export const SessionCreatorGetSessionResponse: ISessionInfo = SessionCreatorCreateResponse;
+export const SessionCreatorGetSessionResponse: ISessionInfo &
+  ISessionInternalInfo = SessionCreatorCreateResponse;
 
 export const SessionInfoManagerMock: jest.Mocked<ISessionInfoManager> = {
   update: jest.fn(

--- a/packages/core/src/sessionInfo/ISessionInfo.ts
+++ b/packages/core/src/sessionInfo/ISessionInfo.ts
@@ -55,9 +55,9 @@ export interface ISessionInfo {
 
 /**
  * Captures information about sessions that is persisted in storage, but that
- * should not be exposed as part of our public API, and is only used for internal
- * purpose. It is complementary to ISessionInfo when retrieving all information
- * about a stored session, both public and internal.
+ * should not be exposed as part of our public API, and is only used for
+ * internal purposes. It is complementary to ISessionInfo when retrieving all
+ * information about a stored session, both public and internal.
  */
 export interface ISessionInternalInfo {
   /**


### PR DESCRIPTION
# New feature description
Added new `onSessionRestore` event to `Session` (and default session) to allow
  the developer to register an event callback that will be called whenever a
  session is restored (e.g., due to a browser page refresh). The callback is
  given a URL parameter, which represents the current URL of the browser
  *before* the session restoration (to allow the developer to restore their
  app's state if needed, e.g., if the app is a Single Page App (SPA) and the
  developer wishes to restore the users 'current page' to exactly where they
  were before the refresh).

# Checklist

- [X] All acceptance criteria are met.
- [X] Relevant documentation, if any, has been written/updated.
- [X] The changelog has been updated, if applicable.
- [X] New functions/types have been exported in `index.ts`, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
