### PR TITLE
Store current IRI before silent authentication

### DIFF
--- a/packages/browser/src/ClientAuthentication.ts
+++ b/packages/browser/src/ClientAuthentication.ts
@@ -34,9 +34,10 @@ import {
   ISessionInfo,
   ISessionInfoManager,
   IIssuerConfigFetcher,
+  ISessionInternalInfo,
 } from "@inrupt/solid-client-authn-core";
 import { removeOidcQueryParam, validateIdToken } from "@inrupt/oidc-client-ext";
-import { KEY_CURRENT_SESSION, KEY_CURRENT_URL } from "./constant";
+import { KEY_CURRENT_SESSION } from "./constant";
 
 // TMP: This ensures that the HTTP requests will include any relevant cookie
 // that could have been set by the resource server.
@@ -117,7 +118,7 @@ export default class ClientAuthentication {
 
   getSessionInfo = async (
     sessionId: string
-  ): Promise<ISessionInfo | undefined> => {
+  ): Promise<(ISessionInfo & ISessionInternalInfo) | undefined> => {
     // TODO complete
     return this.sessionInfoManager.get(sessionId);
   };
@@ -188,20 +189,6 @@ export default class ClientAuthentication {
     // authentication library will be called again with what are now invalid
     // query parameters!).
     window.history.replaceState(null, "", cleanedUpUrl.toString());
-
-    // Check if we have an ID Token in storage - if we do then we may be
-    // currently logged in, and the user has refreshed their browser page. In
-    // this case, it can be really useful to save the user's current browser
-    // location, so that we can restore that location after we complete the
-    // entire re-login-the-user-silently-flow (e.g., if the user was on a
-    // specific 'page' of a Single Page App, then presumably they'll expect to
-    // be brought back to exactly that same 'page' after the full refresh).
-    const sessionInfo = await this.sessionInfoManager.get(
-      redirectInfo.sessionId
-    );
-    if (sessionInfo?.idToken !== undefined) {
-      localStorage.setItem(KEY_CURRENT_URL, window.location.toString());
-    }
 
     return {
       isLoggedIn: redirectInfo.isLoggedIn,

--- a/packages/browser/src/__mocks__/ClientAuthentication.ts
+++ b/packages/browser/src/__mocks__/ClientAuthentication.ts
@@ -19,6 +19,13 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+import {
+  IIssuerConfigFetcher,
+  ILoginHandler,
+  ILogoutHandler,
+  IRedirectHandler,
+  ISessionInfoManager,
+} from "@inrupt/solid-client-authn-core";
 import ClientAuthentication from "../ClientAuthentication";
 import { RedirectHandlerMock } from "../login/oidc/redirectHandler/__mocks__/RedirectHandler";
 import { IssuerConfigFetcherMock } from "../login/oidc/__mocks__/IssuerConfigFetcher";
@@ -26,11 +33,21 @@ import { LoginHandlerMock } from "../login/__mocks__/LoginHandler";
 import { LogoutHandlerMock } from "../logout/__mocks__/LogoutHandler";
 import { SessionInfoManagerMock } from "../sessionInfo/__mocks__/SessionInfoManager";
 
-export const mockClientAuthentication = (): ClientAuthentication =>
+type ClientAuthnDependencies = {
+  loginhandler: ILoginHandler;
+  redirectHandler: IRedirectHandler;
+  logoutHandler: ILogoutHandler;
+  sessionInfoManager: ISessionInfoManager;
+  issuerConfigFetcher: IIssuerConfigFetcher;
+};
+
+export const mockClientAuthentication = (
+  dependencies?: Partial<ClientAuthnDependencies>
+): ClientAuthentication =>
   new ClientAuthentication(
-    LoginHandlerMock,
-    RedirectHandlerMock,
-    LogoutHandlerMock,
-    SessionInfoManagerMock,
-    IssuerConfigFetcherMock
+    dependencies?.loginhandler ?? LoginHandlerMock,
+    dependencies?.redirectHandler ?? RedirectHandlerMock,
+    dependencies?.logoutHandler ?? LogoutHandlerMock,
+    dependencies?.sessionInfoManager ?? SessionInfoManagerMock,
+    dependencies?.issuerConfigFetcher ?? IssuerConfigFetcherMock
   );


### PR DESCRIPTION
This refactors code introduced in
1b4357f6b02327cf03ecf6d478392fdafc59e5ea. In the original design, the
current IRI was stored after successful login, while actually it makes
more sense to only store it during the silent authentication process,
right before silently redirecting the user away from the app, in case
client-side navigation happened and the user refreshes a page that is no
longer the one he logged in to.

For context, this is the first step to silent authentication: after a
refresh, the access token is no longer available. To log back in, the
use must be redirected to the IdP, and storing the current IRI before
redirecting makes it easier to restore it after the user is logged back
in.

# Checklist

- [X] All acceptance criteria are met.
- [x] Relevant documentation, if any, has been written/updated.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).