### PR TITLE
Add redirectUrl to stored session info

### DIFF
--- a/packages/browser/__tests__/sessionInfo/SessionInfoManager.spec.ts
+++ b/packages/browser/__tests__/sessionInfo/SessionInfoManager.spec.ts
@@ -109,6 +109,7 @@ describe("SessionInfoManager", () => {
           [`solidClientAuthenticationUser:${sessionId}`]: {
             clientId: "https://some.app/registration",
             idToken: "some.id.token",
+            redirectUrl: "https://some.redirect/url",
           },
         })
       );
@@ -125,6 +126,7 @@ describe("SessionInfoManager", () => {
         issuer: "https://some.issuer",
         idToken: "some.id.token",
         refreshToken: "some refresh token",
+        redirectUrl: "https://some.redirect/url",
       });
     });
 
@@ -151,6 +153,7 @@ describe("SessionInfoManager", () => {
         issuer: undefined,
         idToken: undefined,
         refreshToken: undefined,
+        redirectUrl: undefined,
       });
     });
 

--- a/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
+++ b/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
@@ -47,6 +47,7 @@ import {
   buildDpopFetch,
 } from "../../../authenticatedFetch/fetchFactory";
 import { KEY_CURRENT_SESSION } from "../../../constant";
+import { appendToUrlPathname } from "../../../util/urlPath";
 
 export async function exchangeDpopToken(
   sessionId: string,
@@ -241,6 +242,15 @@ export class AuthCodeRedirectHandler implements IRedirectHandler {
         isLoggedIn: "true",
       },
       { secure: true }
+    );
+    await this.storageUtility.setForUser(
+      storedSessionId,
+      {
+        redirectUrl: appendToUrlPathname(url.origin, url.pathname),
+      },
+      {
+        secure: false,
+      }
     );
 
     await setupResourceServerSession(

--- a/packages/browser/src/sessionInfo/SessionInfoManager.ts
+++ b/packages/browser/src/sessionInfo/SessionInfoManager.ts
@@ -150,6 +150,14 @@ export class SessionInfoManager implements ISessionInfoManager {
       secure: false,
     });
 
+    const redirectUrl = await this.storageUtility.getForUser(
+      sessionId,
+      "redirectUrl",
+      {
+        secure: false,
+      }
+    );
+
     const refreshToken = await this.storageUtility.getForUser(
       sessionId,
       "refreshToken",
@@ -165,6 +173,7 @@ export class SessionInfoManager implements ISessionInfoManager {
       sessionId,
       webId,
       isLoggedIn: isLoggedIn === "true",
+      redirectUrl,
       idToken,
       refreshToken,
       issuer,

--- a/packages/core/src/sessionInfo/ISessionInfo.ts
+++ b/packages/core/src/sessionInfo/ISessionInfo.ts
@@ -76,7 +76,7 @@ export interface ISessionInternalInfo {
   issuer?: string;
 
   /**
-   * The redirect IRI registered when initially logging the session in.
+   * The redirect URL registered when initially logging the session in.
    */
   redirectUrl?: string;
 }

--- a/packages/core/src/sessionInfo/ISessionInfo.ts
+++ b/packages/core/src/sessionInfo/ISessionInfo.ts
@@ -74,4 +74,9 @@ export interface ISessionInternalInfo {
    * The OIDC issuer that issued the tokens authenticating the session.
    */
   issuer?: string;
+
+  /**
+   * The redirect IRI registered when initially logging the session in.
+   */
+  redirectUrl?: string;
 }


### PR DESCRIPTION
In order to do silent authentication, one must provide a redirect URL
(like for regular login). In order to do so, on successful login, the
redirect URL is stored with the session information, so that it can be
retrieved after refresh and be used to trigger silent authentication.

Note to reviewers: even if this is related to the same feature as #1076 , these two PRs are independant from each other and can be reviewed in any order.

# New feature description

# Checklist

- [X] All acceptance criteria are met.
- [X] Relevant documentation, if any, has been written/updated.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).