### PR TITLE
Add internal support for silent authentication

### DIFF
--- a/packages/browser/__tests__/login/oidc/oidcHandlers/AuthorizationCodeWithPkceOidcHandler.spec.ts
+++ b/packages/browser/__tests__/login/oidc/oidcHandlers/AuthorizationCodeWithPkceOidcHandler.spec.ts
@@ -133,7 +133,7 @@ describe("AuthorizationCodeWithPkceOidcHandler", () => {
       );
     });
 
-    it("supports silent authentication", async () => {
+    it("passes our the 'prompt' option down to our OIDC client library implementation", async () => {
       const oidcModule = mockOidcModule();
       const authorizationCodeWithPkceOidcHandler = getAuthorizationCodeWithPkceOidcHandler();
       const oidcOptions: IOidcOptions = {

--- a/packages/browser/src/ClientAuthentication.ts
+++ b/packages/browser/src/ClientAuthentication.ts
@@ -72,7 +72,7 @@ export default class ClientAuthentication {
     sessionId: string,
     options: ILoginInputOptions & {
       // TODO: the 'prompt' parameter shouldn't be exposed as part of the public API.
-      // This classe's login should take the internal IOidcOptions type as an
+      // This login function should take the internal IOidcOptions type as an
       // input, will be fixed later.
       prompt?: string;
     }

--- a/packages/browser/src/ClientAuthentication.ts
+++ b/packages/browser/src/ClientAuthentication.ts
@@ -70,7 +70,12 @@ export default class ClientAuthentication {
   // Isn't Javascript fun?
   login = async (
     sessionId: string,
-    options: ILoginInputOptions
+    options: ILoginInputOptions & {
+      // TODO: the 'prompt' parameter shouldn't be exposed as part of the public API.
+      // This classe's login should take the internal IOidcOptions type as an
+      // input, will be fixed later.
+      prompt?: string;
+    }
   ): Promise<void> => {
     // In order to get a clean start, make sure that the session is logged out
     // on login.
@@ -98,6 +103,7 @@ export default class ClientAuthentication {
       handleRedirect: options.handleRedirect,
       // Defaults to DPoP
       tokenType: options.tokenType ?? "DPoP",
+      prompt: options.prompt,
     });
   };
 

--- a/packages/browser/src/login/oidc/OidcLoginHandler.ts
+++ b/packages/browser/src/login/oidc/OidcLoginHandler.ts
@@ -135,6 +135,7 @@ export default class OidcLoginHandler implements ILoginHandler {
       client: dynamicClientRegistration,
       sessionId: options.sessionId,
       handleRedirect: options.handleRedirect,
+      prompt: options.prompt,
     };
 
     // Call proper OIDC Handler

--- a/packages/browser/src/login/oidc/oidcHandlers/AuthorizationCodeWithPkceOidcHandler.ts
+++ b/packages/browser/src/login/oidc/oidcHandlers/AuthorizationCodeWithPkceOidcHandler.ts
@@ -70,13 +70,14 @@ export default class AuthorizationCodeWithPkceOidcHandler
       //  https://github.com/solid/specification/issues/203, i.e. the 'webid'
       //  scope does not yet appear in the Solid specification (it's not even
       //  mentioned in the WebID-OIDC spec).
-      scope: "openid webid offline_access",
+      scope: "openid webid",
       filterProtocolClaims: true,
       // The userinfo endpoint on NSS fails, so disable this for now
       // Note that in Solid, information should be retrieved from the
       // profile referenced by the WebId.
       loadUserInfo: false,
       code_verifier: true,
+      prompt: oidcLoginOptions.prompt,
     };
     /* eslint-enable camelcase */
 

--- a/packages/core/src/login/ILoginOptions.ts
+++ b/packages/core/src/login/ILoginOptions.ts
@@ -38,7 +38,10 @@ export default interface ILoginOptions extends ILoginInputOptions {
   // 'bundling' into this options interface), but it wouldn't be a significant
   // improvement really...
   sessionId: string;
-
+  /**
+   * Specify wether the Solid Identity Provider may or may interact with the user.
+   */
+  prompt?: string;
   // Force the token type to be required (i.e. no longer optional).
   tokenType: "DPoP" | "Bearer";
 }

--- a/packages/core/src/login/ILoginOptions.ts
+++ b/packages/core/src/login/ILoginOptions.ts
@@ -39,7 +39,10 @@ export default interface ILoginOptions extends ILoginInputOptions {
   // improvement really...
   sessionId: string;
   /**
-   * Specify wether the Solid Identity Provider may or may interact with the user.
+   * Specify whether the Solid Identity Provider may, or may not, interact with the user (for example,
+   * the normal login process **_requires_** human interaction for them to enter their credentials,
+   * but if a user simply refreshes the current page in their browser, we'll want to log them in again
+   * automatically, i.e., without prompting them to manually provide their credentials again).
    */
   prompt?: string;
   // Force the token type to be required (i.e. no longer optional).

--- a/packages/core/src/login/oidc/IOidcOptions.ts
+++ b/packages/core/src/login/oidc/IOidcOptions.ts
@@ -33,28 +33,31 @@ import { IClient } from "./IClient";
 /**
  * @hidden
  */
-export interface ICoreOidcOptions {
+export interface IOidcOptions {
+  /**
+   * The URL of the Solid Identity Provider.
+   */
   issuer: string;
+  /**
+   * The openid-configuration of the issuer.
+   */
   issuerConfiguration: IIssuerConfig;
   client: IClient;
   sessionId: string;
   refreshToken?: string;
-}
-
-/**
- * @hidden
- */
-export interface IAccessTokenOidcOptions extends ICoreOidcOptions {
+  /**
+   * Specify wether the Solid Identity Provider may or may interact with the user.
+   */
+  prompt?: string;
+  /**
+   * True if a dpop compatible auth_token should be requested.
+   */
   dpop: boolean;
+  /**
+   * The URL to which the user should be redirected after authorizing.
+   */
   redirectUrl: string;
   handleRedirect?: (url: string) => unknown;
 }
 
-/**
- * @issuer The URL of the IDP
- * @dpop True if a dpop compatible auth_token should be fetched
- * @redirectUrl The URL to which the user should be redirected after authorizing
- * @issuerConfiguration The openid-configuration of the issuer
- */
-type IOidcOptions = IAccessTokenOidcOptions;
 export default IOidcOptions;

--- a/packages/core/src/login/oidc/IOidcOptions.ts
+++ b/packages/core/src/login/oidc/IOidcOptions.ts
@@ -46,7 +46,10 @@ export interface IOidcOptions {
   sessionId: string;
   refreshToken?: string;
   /**
-   * Specify wether the Solid Identity Provider may or may interact with the user.
+   * Specify whether the Solid Identity Provider may, or may not, interact with the user (for example,
+   * the normal login process **_requires_** human interaction for them to enter their credentials,
+   * but if a user simply refreshes the current page in their browser, we'll want to log them in again
+   * automatically, i.e., without prompting them to manually provide their credentials again).
    */
   prompt?: string;
   /**
@@ -54,7 +57,8 @@ export interface IOidcOptions {
    */
   dpop: boolean;
   /**
-   * The URL to which the user should be redirected after authorizing.
+   * The URL to which the user should be redirected after logging in the Solid
+   * Identity Provider and authorizing the app to access data in their stead.
    */
   redirectUrl: string;
   handleRedirect?: (url: string) => unknown;

--- a/packages/core/src/login/oidc/IOidcOptions.ts
+++ b/packages/core/src/login/oidc/IOidcOptions.ts
@@ -50,7 +50,7 @@ export interface IOidcOptions {
    */
   prompt?: string;
   /**
-   * True if a dpop compatible auth_token should be requested.
+   * True if a DPoP compatible auth_token should be requested.
    */
   dpop: boolean;
   /**


### PR DESCRIPTION
This enables to specify the "prompt" option from our own internal API
all the way down to the OIDC library we are using. The "prompt" option,
when set to 'none', prevents the Identity Provider to display any screen
or to have any sort of user interaction, which is what we want for
silent authentication.

Note that the "prompt" option was not added to
the external API, because there is no reason for the calling library to
decide it needs to go through silent authentication: we make this call
entierly based on internal state. The code to implement this logic of
whether we want or not to go through silent authentication is not part
of this PR.

# Checklist

- [X] All acceptance criteria are met.
- [X] Relevant documentation, if any, has been written/updated.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).