### PR TITLE
Trigger silent authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ correct issuer, and that it contains some expected values.
 
 ### Bugfix
 
+#### browser
+
+- Refreshing the page no longer logs the session out, no matter what Resource Server
+the data is collected from. 
+
+### Bugfix
+
 #### Browser
 
 - When a session expires, the session is now marked as logged out, and a 

--- a/packages/browser/__tests__/ClientAuthentication.spec.ts
+++ b/packages/browser/__tests__/ClientAuthentication.spec.ts
@@ -107,7 +107,6 @@ const mockSessionStorage = async (
     mockStorage({
       [`${USER_SESSION_PREFIX}:${sessionId}`]: {
         isLoggedIn: "true",
-        issuer: options.issuer,
         webId: "https://my.pod/profile#me",
       },
     }),
@@ -117,6 +116,7 @@ const mockSessionStorage = async (
           algorithm: "ES256",
         }),
         clientId: options.clientId,
+        issuer: options.issuer,
       },
     })
   );

--- a/packages/browser/__tests__/sessionInfo/SessionInfoManager.spec.ts
+++ b/packages/browser/__tests__/sessionInfo/SessionInfoManager.spec.ts
@@ -108,6 +108,7 @@ describe("SessionInfoManager", () => {
         mockStorage({
           [`solidClientAuthenticationUser:${sessionId}`]: {
             clientId: "https://some.app/registration",
+            clientSecret: "some client secret",
             idToken: "some.id.token",
             redirectUrl: "https://some.redirect/url",
           },
@@ -123,6 +124,7 @@ describe("SessionInfoManager", () => {
         webId,
         isLoggedIn: true,
         clientAppId: "https://some.app/registration",
+        clientAppSecret: "some client secret",
         issuer: "https://some.issuer",
         idToken: "some.id.token",
         refreshToken: "some refresh token",
@@ -150,6 +152,7 @@ describe("SessionInfoManager", () => {
         webId: undefined,
         isLoggedIn: false,
         clientAppId: undefined,
+        clientAppSecret: undefined,
         issuer: undefined,
         idToken: undefined,
         refreshToken: undefined,

--- a/packages/browser/__tests__/sessionInfo/SessionInfoManager.spec.ts
+++ b/packages/browser/__tests__/sessionInfo/SessionInfoManager.spec.ts
@@ -102,7 +102,6 @@ describe("SessionInfoManager", () => {
             webId,
             isLoggedIn: "true",
             refreshToken: "some refresh token",
-            issuer: "https://some.issuer",
           },
         }),
         mockStorage({
@@ -111,6 +110,7 @@ describe("SessionInfoManager", () => {
             clientSecret: "some client secret",
             idToken: "some.id.token",
             redirectUrl: "https://some.redirect/url",
+            issuer: "https://some.issuer",
           },
         })
       );
@@ -173,16 +173,19 @@ describe("SessionInfoManager", () => {
 
       const webId = "https://zoomies.com/commanderCool#me";
 
-      const storageMock = mockStorageUtility(
-        {
+      const storageMock = new StorageUtility(
+        mockStorage({
           [`solidClientAuthenticationUser:${sessionId}`]: {
             webId,
             isLoggedIn: "true",
             refreshToken: "someToken",
+          },
+        }),
+        mockStorage({
+          [`solidClientAuthenticationUser:${sessionId}`]: {
             issuer: "https://my.idp",
           },
-        },
-        true
+        })
       );
 
       const sessionManager = getSessionInfoManager({

--- a/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
+++ b/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
@@ -233,7 +233,6 @@ export class AuthCodeRedirectHandler implements IRedirectHandler {
     await this.storageUtility.setForUser(
       storedSessionId,
       {
-        idToken: tokens.idToken,
         // TODO: We need a PR to oidc-client-js to add parsing of the
         //  refresh_token from the redirect URL.
         refreshToken:
@@ -247,6 +246,7 @@ export class AuthCodeRedirectHandler implements IRedirectHandler {
       storedSessionId,
       {
         redirectUrl: appendToUrlPathname(url.origin, url.pathname),
+        idToken: tokens.idToken,
       },
       {
         secure: false,

--- a/packages/browser/src/sessionInfo/SessionInfoManager.ts
+++ b/packages/browser/src/sessionInfo/SessionInfoManager.ts
@@ -132,13 +132,11 @@ export class SessionInfoManager implements ISessionInfoManager {
         secure: true,
       }
     );
-    if (isLoggedIn === undefined) {
-      return undefined;
-    }
 
     const webId = await this.storageUtility.getForUser(sessionId, "webId", {
       secure: true,
     });
+
     const clientId = await this.storageUtility.getForUser(
       sessionId,
       "clientId",
@@ -174,9 +172,20 @@ export class SessionInfoManager implements ISessionInfoManager {
         secure: true,
       }
     );
+
     const issuer = await this.storageUtility.getForUser(sessionId, "issuer", {
-      secure: true,
+      secure: false,
     });
+
+    if (
+      clientId === undefined &&
+      idToken === undefined &&
+      isLoggedIn === undefined &&
+      webId === undefined &&
+      refreshToken === undefined
+    ) {
+      return undefined;
+    }
 
     return {
       sessionId,

--- a/packages/browser/src/sessionInfo/SessionInfoManager.ts
+++ b/packages/browser/src/sessionInfo/SessionInfoManager.ts
@@ -146,6 +146,15 @@ export class SessionInfoManager implements ISessionInfoManager {
         secure: false,
       }
     );
+
+    const clientSecret = await this.storageUtility.getForUser(
+      sessionId,
+      "clientSecret",
+      {
+        secure: false,
+      }
+    );
+
     const idToken = await this.storageUtility.getForUser(sessionId, "idToken", {
       secure: false,
     });
@@ -178,6 +187,7 @@ export class SessionInfoManager implements ISessionInfoManager {
       refreshToken,
       issuer,
       clientAppId: clientId,
+      clientAppSecret: clientSecret,
     };
   }
 

--- a/packages/core/src/sessionInfo/ISessionInfo.ts
+++ b/packages/core/src/sessionInfo/ISessionInfo.ts
@@ -79,4 +79,10 @@ export interface ISessionInternalInfo {
    * The redirect URL registered when initially logging the session in.
    */
   redirectUrl?: string;
+
+  /**
+   * For public clients, and Solid Identity Providers that do not support Client
+   * WebIDs, the client secret is still required at the token endpoint.
+   */
+  clientAppSecret?: string;
 }

--- a/packages/oidc/src/dpop/dpop.spec.ts
+++ b/packages/oidc/src/dpop/dpop.spec.ts
@@ -198,7 +198,7 @@ describe("validateIdToken", () => {
     ).resolves.toBe(false);
   });
 
-  it("returns true if the ID token is valid", async () => {
+  it("returns true if the ID token is valid for an elliptic curve signature", async () => {
     const payload = {
       sub: "https://my.webid",
       iss: "https://some.issuer",
@@ -208,6 +208,27 @@ describe("validateIdToken", () => {
     };
     const idToken = await signJwt(payload, mockJwk(), {
       algorithm: "ES256",
+    });
+    await expect(
+      validateIdToken(
+        idToken,
+        { keys: [mockJwk()] },
+        "https://some.issuer",
+        "https://my.app/registration"
+      )
+    ).resolves.toBe(true);
+  });
+
+  it("returns true if the ID token is valid for an RSA signature", async () => {
+    const payload = {
+      sub: "https://my.webid",
+      iss: "https://some.issuer",
+      aud: "https://my.app/registration",
+      iat: 2551294137,
+      exp: 2551301337,
+    };
+    const idToken = await signJwt(payload, mockJwk(), {
+      algorithm: "RS256",
     });
     await expect(
       validateIdToken(

--- a/packages/oidc/src/dpop/dpop.ts
+++ b/packages/oidc/src/dpop/dpop.ts
@@ -47,7 +47,7 @@ export async function validateIdToken(
     JWT.verify(token, parsedKey.toPEM(false), {
       issuer,
       audience,
-      algorithms: ["ES256"],
+      algorithms: ["ES256", "RS256"],
     });
   } catch (e) {
     // If the verification throws, the token is invalid


### PR DESCRIPTION
This implements silent authentication e.g. after a refresh. To do so, it was necessary to retrieve client secrets with session information from storage, in order to provide them when calling `login` to trigger the silent flow. This includes a couple of fixes required for silent authentication to work, including validating ID tokens signed with RSA algorithms, and making sure that all relevant session information (in particular, the ID token) was stored in the permanent storage.

This simply redirects the user away from the page, and straight back from the Solid Identity Provider. The incoming redirect is identical to an incoming redirect for a regular login, which is why no dedicated code was added to that end.

# Checklist

- [X] All acceptance criteria are met.
- [X] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).