### PR TITLE
Get issuer canonical IRI from its own config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ correct issuer, and that it contains some expected values.
   stored in storage, ready to be retrieved again from storage when the login
   flow redirects back to the client application (previously it was only being
   stored if DCR was invoked).
+- The issuer URL associated to the session is now necessarily the __canonical__
+  issuer's URL, instead of potentially including/missing a trailing slash.
 
 The following sections document changes that have been released already:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ correct issuer, and that it contains some expected values.
   stored in storage, ready to be retrieved again from storage when the login
   flow redirects back to the client application (previously it was only being
   stored if DCR was invoked).
-- The issuer URL associated to the session is now necessarily the __canonical__
+- The issuer URL associated with the session is now necessarily the __canonical__
   issuer's URL, instead of potentially including/missing a trailing slash.
 
 The following sections document changes that have been released already:

--- a/packages/browser/src/login/oidc/OidcLoginHandler.ts
+++ b/packages/browser/src/login/oidc/OidcLoginHandler.ts
@@ -127,6 +127,11 @@ export default class OidcLoginHandler implements ILoginHandler {
 
     // Construct OIDC Options
     const OidcOptions: IOidcOptions = {
+      // Note that here, the issuer is not the one from the received options, but
+      // from the issuer's config. This enforces the canonical URL is used and stored,
+      // which is also the one present in the ID token, so storing a technically
+      // valid, but different issuer URL (e.g. using a trailing slash or not) now
+      // could prevent from validating the ID token later.
       issuer: issuerConfig.issuer,
       // TODO: differentiate if DPoP should be true
       dpop: options.tokenType.toLowerCase() === "dpop",

--- a/packages/browser/src/login/oidc/OidcLoginHandler.ts
+++ b/packages/browser/src/login/oidc/OidcLoginHandler.ts
@@ -127,7 +127,7 @@ export default class OidcLoginHandler implements ILoginHandler {
 
     // Construct OIDC Options
     const OidcOptions: IOidcOptions = {
-      issuer: options.oidcIssuer,
+      issuer: issuerConfig.issuer,
       // TODO: differentiate if DPoP should be true
       dpop: options.tokenType.toLowerCase() === "dpop",
       redirectUrl: options.redirectUrl,

--- a/packages/node/src/login/oidc/OidcLoginHandler.ts
+++ b/packages/node/src/login/oidc/OidcLoginHandler.ts
@@ -120,7 +120,7 @@ export default class OidcLoginHandler implements ILoginHandler {
 
     // Construct OIDC Options
     const oidcOptions: IOidcOptions = {
-      issuer: options.oidcIssuer,
+      issuer: issuerConfig.issuer,
       // TODO: differentiate if DPoP should be true
       dpop: options.tokenType.toLowerCase() === "dpop",
       // TODO Cleanup to remove the type assertion


### PR DESCRIPTION
The user provides an issuer IRI, which allows discovering the issuer
configuration. So far, this user-provided IRI was stored on login, and
used to validate the ID token. However, this IRI may be correct, but
still differ from the issuer claim of the ID token, e.g. depending on
whether it includes a trailing slash or not. Now, the IRI that gets
stored is the canonical IRI obtained from the IdP's config, which
enforces it to be aligned with the ID token's issuer claim.

- [X] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).