### PR TITLE
DOCS: navbar ess -> ess/latest

### DIFF
--- a/packages/browser/docs/api/_templates/docs-navbar.html
+++ b/packages/browser/docs/api/_templates/docs-navbar.html
@@ -15,7 +15,7 @@
             <a class="nav-link" href="https://docs.inrupt.com/">Docs Home</a>
           </li>
           <li class="nav-item">
-             <a class="nav-link" href="{{theme_ess_docs}}">Enterprise Solid Server</a>
+             <a class="nav-link" href="{{theme_ess_docs}}latest/">Enterprise Solid Server</a>
           </li>
           <li class="nav-item"><a class="nav-link" href="#">Developer Tools</a>
                <ul class="nav-children">

--- a/packages/core/docs/api/_templates/docs-navbar.html
+++ b/packages/core/docs/api/_templates/docs-navbar.html
@@ -15,7 +15,7 @@
             <a class="nav-link" href="https://docs.inrupt.com/">Docs Home</a>
           </li>
           <li class="nav-item">
-             <a class="nav-link" href="{{theme_ess_docs}}">Enterprise Solid Server</a>
+             <a class="nav-link" href="{{theme_ess_docs}}latest/">Enterprise Solid Server</a>
           </li>
           <li class="nav-item"><a class="nav-link" href="#">Developer Tools</a>
                <ul class="nav-children">

--- a/packages/node/docs/api/_templates/docs-navbar.html
+++ b/packages/node/docs/api/_templates/docs-navbar.html
@@ -15,7 +15,7 @@
             <a class="nav-link" href="https://docs.inrupt.com/">Docs Home</a>
           </li>
           <li class="nav-item">
-             <a class="nav-link" href="{{theme_ess_docs}}">Enterprise Solid Server</a>
+             <a class="nav-link" href="{{theme_ess_docs}}latest/">Enterprise Solid Server</a>
           </li>
           <li class="nav-item"><a class="nav-link" href="#">Developer Tools</a>
                <ul class="nav-children">


### PR DESCRIPTION
Update API docs top navbar: Enterprise Solid Server link should go to docs.inrupt.com/ess/latest.
<img width="481" alt="Screen Shot 2021-02-22 at 7 46 56 PM" src="https://user-images.githubusercontent.com/2126636/108789184-b7b2ac80-7547-11eb-8bff-fa3ad6b32bbf.png">

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

Rendered: https://solid-client-authn-js-hzziuoflz-inrupt.vercel.app/core/
