### PR TITLE
R-enable running build script on install

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "format-all": "prettier --write \"packages/*/src/**\" \"packages/*/__tests__/**\"",
     "licenses-all": "license-checker --production --out license.csv --failOn \"AGPL-1.0-only; AGPL-1.0-or-later; AGPL-3.0-only; AGPL-3.0-or-later; Beerware; CC-BY-NC-1.0; CC-BY-NC-2.0; CC-BY-NC-2.5; CC-BY-NC-3.0; CC-BY-NC-4.0; CC-BY-NC-ND-1.0; CC-BY-NC-ND-2.0; CC-BY-NC-ND-2.5; CC-BY-NC-ND-3.0; CC-BY-NC-ND-4.0; CC-BY-NC-SA-1.0; CC-BY-NC-SA-2.0; CC-BY-NC-SA-2.5; CC-BY-NC-SA-3.0; CC-BY-NC-SA-4.0; CPAL-1.0; EUPL-1.0; EUPL-1.1; EUPL-1.1;  GPL-1.0-only; GPL-1.0-or-later; GPL-2.0-only;  GPL-2.0-or-later; GPL-3.0; GPL-3.0-only; GPL-3.0-or-later; SISSL;  SISSL-1.2; WTFPL\"",
     "lint": "lerna run lint",
-    "postinstall": "lerna bootstrap && husky install",
+    "postinstall": "lerna bootstrap && npm run build && husky install",
     "prepublishOnly": "npm run build && pinst --disable",
     "postpublish": "pinst --enable",
     "publish": "lerna publish",


### PR DESCRIPTION
When setting up husky v5, a behaviour of the build toolchain was
changed: the build script was no longer running when running the install
script. Because there are dependencies between the packages of the
monorepo, running this build script is actually useful, and this
re-enables this behaviour.
