### PR TITLE
Renamed master branch to main

### DIFF
--- a/.github/publish-website.yml
+++ b/.github/publish-website.yml
@@ -3,7 +3,7 @@ name: Publish website
 on:
   push:
     branches:
-      - master
+      - main
 
 env:
   CI: true

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,7 +12,7 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches:
-    - master
+    - main
   schedule:
     - cron: '0 12 * * 6'
 

--- a/packages/browser/README.md
+++ b/packages/browser/README.md
@@ -16,7 +16,7 @@ be polyfilled by the bundler. Here is the list of modules that need to be polyfi
 
 Prior to Webpack version 5 these modules were polyfilled by default, but that is no longer the case.
 See
-[our Webpack configuration](https://github.com/inrupt/solid-client-authn-js/blob/master/packages/browser/webpack.common.js)
+[our Webpack configuration](https://github.com/inrupt/solid-client-authn-js/blob/main/packages/browser/webpack.common.js)
 for packages that can provide the necessary polyfills.
 
 ## Underlying libraries

--- a/packages/browser/docs/api/conf.py
+++ b/packages/browser/docs/api/conf.py
@@ -92,7 +92,7 @@ html_theme_options = {
     'github_editable': False,
     'github_org': 'inrupt',
     'github_repo': repo_name,
-    'github_branch': 'master',
+    'github_branch': 'main',
     'ess_docs': 'https://docs.inrupt.com/ess/',
     'clientlibjs_docs': 'https://docs.inrupt.com/developer-tools/javascript/client-libraries/',
     'reactsdk_docs': 'https://docs.inrupt.com/developer-tools/javascript/react-sdk',

--- a/packages/core/docs/api/conf.py
+++ b/packages/core/docs/api/conf.py
@@ -92,7 +92,7 @@ html_theme_options = {
     'github_editable': False,
     'github_org': 'inrupt',
     'github_repo': repo_name,
-    'github_branch': 'master',
+    'github_branch': 'main',
     'ess_docs': 'https://docs.inrupt.com/ess/',
     'clientlibjs_docs': 'https://docs.inrupt.com/developer-tools/javascript/client-libraries/',
     'reactsdk_docs': 'https://docs.inrupt.com/developer-tools/javascript/react-sdk',

--- a/packages/node/docs/api/conf.py
+++ b/packages/node/docs/api/conf.py
@@ -93,7 +93,7 @@ html_theme_options = {
     'github_editable': False,
     'github_org': 'inrupt',
     'github_repo': repo_name,
-    'github_branch': 'master',
+    'github_branch': 'main',
     'ess_docs': 'https://docs.inrupt.com/ess/',
     'clientlibjs_docs': 'https://docs.inrupt.com/developer-tools/javascript/client-libraries/',
     'reactsdk_docs': 'https://docs.inrupt.com/developer-tools/javascript/react-sdk',

--- a/packages/oidc/package.json
+++ b/packages/oidc/package.json
@@ -2,7 +2,7 @@
   "name": "@inrupt/oidc-client-ext",
   "version": "1.6.0",
   "description": "A module extending oidc-client-js with new features, such as dynamic client registration and DPoP support.",
-  "homepage": "https://github.com/inrupt/solid-client-authn-js/tree/master/packages/oidc/",
+  "homepage": "https://github.com/inrupt/solid-client-authn-js/tree/main/packages/oidc/",
   "bugs": "https://github.com/inrupt/solid-client-authn-js/issues",
   "main": "dist/index.js",
   "module": "dist/index.es.js",


### PR DESCRIPTION
This should replace all references to `master` in the codebase. Before merging this, I'll change the branch protection rules, and use GH's UI to rename the branch so that open PRs get migrated.