### PR TITLE
Re-enable workaround with disabled silent refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,6 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased
 
-### Bugfixes
-
-#### browser
-
-- No longer send PKCE-related information during DCR, when they are irrelevant.
-
-The following sections document changes that have been released already:
-
 ### Deprecations
 
 #### browser
@@ -37,6 +29,9 @@ The following sections document changes that have been released already:
   `restorePreviousSession` boolean to `handleIncomingRedirect`, and listening
   for the `sessionRestore` event (or passing a callback to `onSessionRestore`)
   to restore your application state.
+- No longer send PKCE-related information during DCR, when they are irrelevant.
+
+The following sections document changes that have been released already:
 
 ## 1.6.0 - 2021-02-22
 

--- a/packages/browser/__tests__/Session.spec.ts
+++ b/packages/browser/__tests__/Session.spec.ts
@@ -358,6 +358,126 @@ describe("Session", () => {
       );
       expect(incomingRedirectHandler).toHaveBeenCalled();
     });
+
+    // This workaround will be removed after we've settled on an API that allows us to silently
+    // re-activate the user's session after a refresh:
+    describe("(using the temporary workaround for losing a session after refresh)", () => {
+      it("does not report the user to be logged in when the workaround cookie is not present, and just executes the redirect", async () => {
+        const clientAuthentication = mockClientAuthentication();
+        clientAuthentication.handleIncomingRedirect = jest.fn(
+          async (_url: string) => undefined
+        );
+        const mySession = new Session({ clientAuthentication });
+        await mySession.handleIncomingRedirect("https://some.url");
+        expect(mySession.info.isLoggedIn).toEqual(false);
+        expect(mySession.info.webId).toBeUndefined();
+        expect(
+          clientAuthentication.handleIncomingRedirect
+        ).toHaveBeenCalledTimes(1);
+      });
+
+      it("re-initialises the user's WebID without redirection if the proper cookie is set", async () => {
+        mockLocalStorage({
+          "tmp-resource-server-session-info": JSON.stringify({
+            webId: "https://my.pod/profile#me",
+            sessions: {
+              "https://my.pod/": { expiration: 9000000000000 },
+            },
+          }),
+        });
+        const clientAuthentication = mockClientAuthentication();
+        clientAuthentication.handleIncomingRedirect = jest.fn();
+        const mySession = new Session({ clientAuthentication });
+        await mySession.handleIncomingRedirect("https://some.url");
+        expect(mySession.info.isLoggedIn).toEqual(true);
+        expect(mySession.info.webId).toEqual("https://my.pod/profile#me");
+        expect(
+          clientAuthentication.handleIncomingRedirect
+        ).toHaveBeenCalledTimes(0);
+      });
+
+      it("does not attempt to use the workaround if the long-term solution (silent refresh) is enabled", async () => {
+        mockLocalStorage({
+          "tmp-resource-server-session-info": JSON.stringify({
+            webId: "https://my.pod/profile#me",
+            sessions: {
+              "https://my.pod/": { expiration: 9000000000000 },
+            },
+          }),
+        });
+        const clientAuthentication = mockClientAuthentication();
+        clientAuthentication.handleIncomingRedirect = jest.fn();
+        const mySession = new Session({ clientAuthentication });
+        await mySession.handleIncomingRedirect({
+          url: "https://some.url",
+          restorePreviousSession: true,
+        });
+        expect(mySession.info.isLoggedIn).toBe(false);
+        expect(mySession.info.webId).toBeUndefined();
+        expect(
+          clientAuthentication.handleIncomingRedirect
+        ).toHaveBeenCalledTimes(1);
+      });
+
+      it("does not mark an almost-expired session as logged in", async () => {
+        mockLocalStorage({
+          "tmp-resource-server-session-info": JSON.stringify({
+            webId: "https://my.pod/profile#me",
+            sessions: {
+              "https://my.pod/": { expiration: Date.now() + 10000 },
+            },
+          }),
+        });
+
+        const clientAuthentication = mockClientAuthentication();
+        clientAuthentication.handleIncomingRedirect = jest.fn();
+        const mySession = new Session({ clientAuthentication });
+        await mySession.handleIncomingRedirect("https://some.url");
+        expect(mySession.info.isLoggedIn).toEqual(false);
+        expect(mySession.info.webId).toBeUndefined();
+        expect(
+          clientAuthentication.handleIncomingRedirect
+        ).toHaveBeenCalledTimes(1);
+      });
+
+      it("logs you in even if your Solid Identity Provider is not your Resource server", async () => {
+        mockLocalStorage({
+          "tmp-resource-server-session-info": JSON.stringify({
+            webId: "https://my.pod/profile#me",
+            sessions: {
+              "https://not.my.pod/": { expiration: 9000000000000 },
+            },
+          }),
+        });
+        const clientAuthentication = mockClientAuthentication();
+        clientAuthentication.handleIncomingRedirect = jest.fn();
+        const mySession = new Session({ clientAuthentication });
+        await mySession.handleIncomingRedirect("https://some.url");
+        expect(mySession.info.isLoggedIn).toEqual(true);
+        expect(mySession.info.webId).toEqual("https://my.pod/profile#me");
+        expect(
+          clientAuthentication.handleIncomingRedirect
+        ).toHaveBeenCalledTimes(0);
+      });
+
+      it("does not log the user in if the data in the storage was invalid", async () => {
+        mockLocalStorage({
+          "tmp-resource-server-session-info": JSON.stringify({
+            webId: "https://my.pod/profile#me",
+            // `sessions` key is intentionally missing
+          }),
+        });
+        const clientAuthentication = mockClientAuthentication();
+        clientAuthentication.handleIncomingRedirect = jest.fn();
+        const mySession = new Session({ clientAuthentication });
+        await mySession.handleIncomingRedirect("https://some.url");
+        expect(mySession.info.isLoggedIn).toEqual(false);
+        expect(mySession.info.webId).toBeUndefined();
+        expect(
+          clientAuthentication.handleIncomingRedirect
+        ).toHaveBeenCalledTimes(1);
+      });
+    });
   });
 
   describe("silent authentication", () => {

--- a/packages/browser/__tests__/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
+++ b/packages/browser/__tests__/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
@@ -34,6 +34,7 @@ import { JSONWebKey } from "jose";
 import { Response } from "cross-fetch";
 import {
   AuthCodeRedirectHandler,
+  DEFAULT_LIFESPAN,
   exchangeDpopToken,
 } from "../../../../src/login/oidc/redirectHandler/AuthCodeRedirectHandler";
 import { RedirectorMock } from "../../../../src/login/oidc/__mocks__/Redirector";
@@ -479,6 +480,157 @@ describe("AuthCodeRedirectHandler", () => {
         MOCK_TIMESTAMP + MOCK_EXPIRE_TIME * 1000
       );
     });
+  });
+
+  it("stores information about the resource server cookie in local storage on successful authentication", async () => {
+    /* eslint-disable  @typescript-eslint/no-explicit-any */
+    (window as any).localStorage = new LocalStorageMock();
+
+    // This mocks the fetch to the Resource Server session endpoint
+    // Note: Currently, the endpoint only returns the webid in plain/text, it could
+    // be extended later to also provide the cookie expiration.
+    mockFetch(
+      new Response("https://my.webid", {
+        status: 200,
+      })
+    );
+
+    const MOCK_TIMESTAMP = 10000;
+    Date.now = jest
+      .fn()
+      // Date.now is called twice: once to be able to calculate the auth token expiry time,
+      // and once to set the cookie expiry. We only care about the second in this test.
+      .mockReturnValueOnce(MOCK_TIMESTAMP)
+      .mockReturnValueOnce(MOCK_TIMESTAMP);
+
+    const testIssuer = "some test Issuer";
+    const mockedStorage = mockStorageUtility({
+      "solidClientAuthenticationUser:mySession": {
+        issuer: testIssuer,
+      },
+      "solidClientAuthenticationUser:oauth2_state_value": {
+        sessionId: "mySession",
+      },
+    });
+
+    const authCodeRedirectHandler = getAuthCodeRedirectHandler({
+      storageUtility: mockedStorage,
+    });
+
+    await authCodeRedirectHandler.handle(
+      "https://coolsite.com/?code=someCode&state=oauth2_state_value"
+    );
+    expect(
+      JSON.parse(
+        (await mockedStorage.get("tmp-resource-server-session-info")) ?? "{}"
+      )
+    ).toEqual({
+      webId: "https://my.webid",
+      sessions: {
+        "https://my.webid": {
+          expiration: MOCK_TIMESTAMP + DEFAULT_LIFESPAN,
+        },
+      },
+    });
+  });
+
+  it("store nothing if the resource server has no session endpoint", async () => {
+    // This mocks the fetch to the Resource Server session endpoint
+    // Note: Currently, the endpoint only returns the WebID in plain/text, it could
+    // be extended later to also provide the cookie expiration.
+    mockFetch(
+      new Response("", {
+        status: 404,
+      })
+    );
+
+    const mockedStorage = mockStorageUtility({
+      "solidClientAuthenticationUser:mySession": {
+        issuer: "some dummy test Issuer",
+      },
+      "solidClientAuthenticationUser:oauth2_state_value": {
+        sessionId: "mySession",
+      },
+    });
+
+    const authCodeRedirectHandler = getAuthCodeRedirectHandler({
+      storageUtility: mockedStorage,
+    });
+
+    await authCodeRedirectHandler.handle(
+      "https://coolsite.com/?code=someCode&state=oauth2_state_value"
+    );
+    expect(
+      JSON.parse(
+        (await mockedStorage.get("tmp-resource-server-session-info")) ?? "{}"
+      )
+    ).toEqual({});
+  });
+
+  it("swallows the exception if the fetch to the session endpoint fails", async () => {
+    window.fetch = jest
+      .fn()
+      .mockResolvedValueOnce(
+        new Response("https://my.webid", {
+          status: 200,
+        })
+      )
+      .mockRejectedValueOnce("Some error");
+
+    const mockedStorage = mockStorageUtility({
+      "solidClientAuthenticationUser:mySession": {
+        issuer: "some dummy test Issuer",
+      },
+      "solidClientAuthenticationUser:oauth2_state_value": {
+        sessionId: "mySession",
+      },
+    });
+
+    const authCodeRedirectHandler = getAuthCodeRedirectHandler({
+      storageUtility: mockedStorage,
+    });
+
+    await authCodeRedirectHandler.handle(
+      "https://coolsite.com/?code=someCode&state=oauth2_state_value"
+    );
+    expect(
+      JSON.parse(
+        (await mockedStorage.get("tmp-resource-server-session-info")) ?? "{}"
+      )
+    ).toEqual({});
+  });
+
+  it("store nothing if the resource server does not recognize the user", async () => {
+    // This mocks the fetch to the Resource Server session endpoint
+    // Note: Currently, the endpoint only returns the WebID in plain/text, it could
+    // be extended later to also provide the cookie expiration.
+    mockFetch(
+      new Response("", {
+        status: 401,
+      })
+    );
+
+    const mockedStorage = mockStorageUtility({
+      "solidClientAuthenticationUser:mySession": {
+        issuer: "some dummy test Issuer",
+      },
+      "solidClientAuthenticationUser:oauth2_state_value": {
+        sessionId: "mySession",
+      },
+    });
+
+    const authCodeRedirectHandler = getAuthCodeRedirectHandler({
+      storageUtility: mockedStorage,
+    });
+
+    await authCodeRedirectHandler.handle(
+      "https://coolsite.com/?code=someCode&state=oauth2_state_value"
+    );
+    expect(
+      JSON.parse(
+        (await mockedStorage.get("tmp-resource-server-session-info")) ?? "{}"
+      )
+    ).toEqual({});
   });
 });
 

--- a/packages/browser/__tests__/sessionInfo/SessionInfoManager.spec.ts
+++ b/packages/browser/__tests__/sessionInfo/SessionInfoManager.spec.ts
@@ -246,6 +246,33 @@ describe("SessionInfoManager", () => {
         await mockedStorage.getForUser("mySession", "key", { secure: false })
       ).toBeUndefined();
     });
+
+    it("clears resource server session info from local storage", async () => {
+      const mockedStorage = mockStorageUtility(
+        {
+          "solidClientAuthenticationUser:mySession": {
+            webId: "https://my.pod/profile#me",
+          },
+        },
+        true
+      );
+      await mockedStorage.storeResourceServerSessionInfo(
+        "https://my.pod/profile#me",
+        "https://my.pod",
+        10000
+      );
+      const sessionManager = getSessionInfoManager({
+        storageUtility: mockedStorage,
+      });
+      await sessionManager.clear("mySession");
+      expect(
+        JSON.parse(
+          (await mockedStorage.get("tmp-resource-server-session-info", {
+            secure: false,
+          })) ?? ""
+        )
+      ).toEqual({});
+    });
   });
 
   describe("getAll", () => {

--- a/packages/browser/src/Session.ts
+++ b/packages/browser/src/Session.ts
@@ -27,6 +27,7 @@ import {
   ILoginInputOptions,
   ISessionInfo,
   IStorage,
+  ResourceServerSession,
 } from "@inrupt/solid-client-authn-core";
 import { v4 } from "uuid";
 import ClientAuthentication from "./ClientAuthentication";
@@ -209,6 +210,65 @@ export class Session extends EventEmitter {
     const options =
       typeof inputOptions === "string" ? { url: inputOptions } : inputOptions;
     const url = options.url ?? window.location.href;
+
+    // Unfortunately, regular sessions are lost when the user refreshes the page or opens a new tab.
+    // While we're figuring out the API for a longer-term solution, as a temporary workaround some
+    // *resource* servers set a cookie that keeps the user logged in after authenticated requests,
+    // and expose the fact that they set it on a special endpoint.
+    // After login, we store that fact in LocalStorage. This means that we can now look for that
+    // data, and if present, indicate that the user is already logged in.
+    // Note that there are a lot of edge cases that won't work well with this approach, so it willl
+    // be removed in due time.
+    const storedSessionCookieReference = window.localStorage.getItem(
+      "tmp-resource-server-session-info"
+    );
+    if (
+      typeof storedSessionCookieReference === "string" &&
+      options.restorePreviousSession !== true
+    ) {
+      // TOOD: Re-use the type used when writing this data:
+      // https://github.com/inrupt/solid-client-authn-js/pull/920/files#diff-659ac87dfd3711f4cfcea3c7bf6970980f4740fd59df45f04c7977bffaa23e98R118
+      // To keep temporary code together
+      // eslint-disable-next-line no-inner-declarations
+      function isValidSessionCookieReference(
+        reference: Record<string, unknown>
+      ): reference is ResourceServerSession {
+        const resourceServers = Object.keys(
+          (reference as ResourceServerSession).sessions ?? {}
+        );
+        return (
+          typeof (reference as ResourceServerSession).webId === "string" &&
+          resourceServers.length > 0 &&
+          typeof (reference as ResourceServerSession).sessions[
+            resourceServers[0]
+          ].expiration === "number"
+        );
+      }
+      const reference = JSON.parse(storedSessionCookieReference);
+      if (isValidSessionCookieReference(reference)) {
+        const resourceServers = Object.keys(reference.sessions);
+        const webIdOrigin = new URL(reference.webId).hostname;
+        const ownResourceServer = resourceServers.find((resourceServer) => {
+          return new URL(resourceServer).hostname === webIdOrigin;
+        });
+        // Usually the user's WebID is also a Resource server for them,
+        // so we pick the expiration time for that. If it doesn't exist,
+        // we just pick the first (and probably only) one:
+        const relevantServer = ownResourceServer ?? resourceServers[0];
+        // If the cookie is valid for fewer than five minutes,
+        // pretend it's not valid anymore already, to avoid small misalignments
+        // resulting in invalid states:
+        if (
+          reference.sessions[relevantServer].expiration - Date.now() >
+          5 * 60 * 1000
+        ) {
+          this.info.isLoggedIn = true;
+          this.info.webId = reference.webId;
+          return this.info;
+        }
+      }
+    }
+    // end of temporary workaround.
 
     this.tokenRequestInProgress = true;
     const sessionInfo = await this.clientAuthentication.handleIncomingRedirect(

--- a/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
+++ b/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
@@ -71,6 +71,62 @@ export async function exchangeDpopToken(
   });
 }
 
+// A lifespan of 30 minutes is ESS's default. This could be removed if we
+// configure the server to return the remaining lifespan of the cookie.
+export const DEFAULT_LIFESPAN = 30 * 60 * 1000;
+
+/**
+ * Stores the resource server session information in local storage, so that they
+ * can be used on refresh.
+ * @param webId
+ * @param authenticatedFetch
+ * @param storageUtility
+ */
+async function setupResourceServerSession(
+  webId: string,
+  authenticatedFetch: typeof fetch,
+  storageUtility: IStorageUtility
+): Promise<void> {
+  const webIdAsUrl = new URL(webId);
+  const resourceServerIri = webIdAsUrl.origin;
+  // Querying the /session endpoint does not set the cookie, but issuing an
+  // authenticated request to any actual resource (even public ones) does,
+  // so we fetch the user's WebID before checking the /session endpoint.
+  await authenticatedFetch(webId);
+  try {
+    const resourceServerResponse = await authenticatedFetch(
+      `${resourceServerIri}/session`
+    );
+
+    if (resourceServerResponse.status === 200) {
+      await storageUtility.storeResourceServerSessionInfo(
+        webId,
+        resourceServerIri,
+        // Note that here, if the lifespan of the cookie was returned by the
+        // server, we'd expect a relative value (the remaining time of validity)
+        // rather than an absolute one (the moment when the cookie expires).
+        Date.now() + DEFAULT_LIFESPAN
+      );
+      return;
+    }
+    // In this case, the resource server either:
+    // - does not have the expected endpoint, or
+    // - does not recognize the user
+    // Either way, no cookie is expected to be set there, and any existing
+    // session information should be cleared.
+    await storageUtility.clearResourceServerSessionInfo(resourceServerIri);
+  } catch (_e) {
+    // Setting the `credentials=include` option on fetch, which is required in
+    // the current approach based on a RS cookie, may result in an error if
+    // attempting to access an URL, depending on the CORS policies.
+    // Since this internal fetch is necessary, and out of control of the
+    // calling library, there is no other solution but to swallow the exception.
+    // This may happen depending on how the target RS handles a request to the
+    // /session endpoint.
+    await storageUtility.clearResourceServerSessionInfo(resourceServerIri);
+  }
+}
+
 /**
  * @hidden
  */
@@ -195,6 +251,12 @@ export class AuthCodeRedirectHandler implements IRedirectHandler {
       {
         secure: false,
       }
+    );
+
+    await setupResourceServerSession(
+      tokens.webId,
+      authFetch,
+      this.storageUtility
     );
 
     const sessionInfo = await this.sessionInfoManager.get(storedSessionId);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -69,6 +69,7 @@ export {
   loadOidcContextFromStorage,
   saveSessionInfoToStorage,
   getSessionIdFromOauthState,
+  ResourceServerSession,
 } from "./storage/StorageUtility";
 export { default as InMemoryStorage } from "./storage/InMemoryStorage";
 

--- a/packages/core/src/storage/IStorageUtility.ts
+++ b/packages/core/src/storage/IStorageUtility.ts
@@ -54,6 +54,24 @@ export default interface IStorageUtility {
     userId: string,
     options?: { secure?: boolean }
   ): Promise<void>;
+  /**
+   * Register a new session for a given WebID against a given Resource Server.
+   * @param webId
+   * @param resourceServerIri
+   * @param sessionExpires
+   */
+  storeResourceServerSessionInfo(
+    webId: string,
+    resourceServerIri: string,
+    sessionExpires: number
+  ): Promise<void>;
+  /**
+   * Removes session information for a given WebID and a given Resource Server.
+   * Note that if the WebID has no associated session, nothing happens.
+   * @param webId
+   * @param resourceServerIri
+   */
+  clearResourceServerSessionInfo(resourceServerIri: string): Promise<void>;
 
   /**
    * Retrieve from local storage

--- a/packages/core/src/storage/StorageUtility.spec.ts
+++ b/packages/core/src/storage/StorageUtility.spec.ts
@@ -341,6 +341,167 @@ describe("StorageUtility", () => {
     });
   });
 
+  describe("storeResourceServerSessionInfo", () => {
+    it("stores session information for a new WebID", async () => {
+      const storageUtility = getStorageUtility({
+        insecureStorage: mockStorage({}),
+      });
+      await storageUtility.storeResourceServerSessionInfo(
+        "https://some.pod/profile#me",
+        "https://some-resource.provider/",
+        1610026667
+      );
+      expect(
+        JSON.parse(
+          (await storageUtility.get("tmp-resource-server-session-info")) ?? "{}"
+        )
+      ).toEqual({
+        webId: "https://some.pod/profile#me",
+        sessions: {
+          "https://some-resource.provider/": {
+            expiration: 1610026667,
+          },
+        },
+      });
+    });
+
+    it("adds a new resource server to a WebID that is already registered", async () => {
+      const storageUtility = getStorageUtility({
+        insecureStorage: mockStorage({
+          "tmp-resource-server-session-info": JSON.stringify({
+            webId: "https://some.pod/profile#me",
+            sessions: {
+              "https://some-other-resource.provider/": {
+                expiration: 1610026667,
+              },
+            },
+          }),
+        }),
+      });
+
+      await storageUtility.storeResourceServerSessionInfo(
+        "https://some.pod/profile#me",
+        "https://some-resource.provider/",
+        1610026667
+      );
+      await expect(
+        storageUtility.get("tmp-resource-server-session-info")
+      ).resolves.toEqual(
+        JSON.stringify({
+          webId: "https://some.pod/profile#me",
+          sessions: {
+            "https://some-other-resource.provider/": {
+              expiration: 1610026667,
+            },
+            "https://some-resource.provider/": {
+              expiration: 1610026667,
+            },
+          },
+        })
+      );
+    });
+
+    it("overwrites existing sessions when storing a session for a new WebID", async () => {
+      const storageUtility = getStorageUtility({
+        insecureStorage: mockStorage({
+          "tmp-resource-server-session-info": JSON.stringify({
+            webId: "https://some-other.pod/profile#me",
+            sessions: {
+              "https://some-other-resource.provider/": {
+                expiration: 1610026667,
+              },
+            },
+          }),
+        }),
+      });
+
+      await storageUtility.storeResourceServerSessionInfo(
+        "https://some.pod/profile#me",
+        "https://some-resource.provider/",
+        1610026667
+      );
+      await expect(
+        storageUtility.get("tmp-resource-server-session-info")
+      ).resolves.toEqual(
+        JSON.stringify({
+          webId: "https://some.pod/profile#me",
+          sessions: {
+            "https://some-resource.provider/": {
+              expiration: 1610026667,
+            },
+          },
+        })
+      );
+    });
+  });
+
+  describe("clearResourceServerSessionInfo", () => {
+    it("doesn't not fail if the WebID does not exist", async () => {
+      const storageUtility = getStorageUtility({
+        insecureStorage: mockStorage({}),
+      });
+      await storageUtility.clearResourceServerSessionInfo(
+        "https://some-resource.provider/"
+      );
+      await expect(
+        storageUtility.get("tmp-resource-server-session-info")
+      ).resolves.toBeUndefined();
+    });
+
+    it("clears the session info object if no session is active", async () => {
+      const storageUtility = getStorageUtility({
+        insecureStorage: mockStorage({
+          "tmp-resource-server-session-info": JSON.stringify({
+            webId: "https://some.pod/profile#me",
+            sessions: {
+              "https://some-resource.provider/": {
+                expiration: 1610026667,
+              },
+            },
+          }),
+        }),
+      });
+
+      await storageUtility.clearResourceServerSessionInfo(
+        "https://some-resource.provider/"
+      );
+      await expect(
+        storageUtility.get("tmp-resource-server-session-info")
+      ).resolves.toEqual(JSON.stringify({}));
+    });
+
+    it("removes the given resource server session info", async () => {
+      const storageUtility = getStorageUtility({
+        insecureStorage: mockStorage({
+          "tmp-resource-server-session-info": JSON.stringify({
+            webId: "https://some.pod/profile#me",
+            sessions: {
+              "https://some-resource.provider/": {
+                expiration: 1610026667,
+              },
+            },
+          }),
+        }),
+      });
+
+      await storageUtility.clearResourceServerSessionInfo(
+        "https://some-other-resource.provider/"
+      );
+      await expect(
+        storageUtility.get("tmp-resource-server-session-info")
+      ).resolves.toEqual(
+        JSON.stringify({
+          webId: "https://some.pod/profile#me",
+          sessions: {
+            "https://some-resource.provider/": {
+              expiration: 1610026667,
+            },
+          },
+        })
+      );
+    });
+  });
+
   describe("safeGet", () => {
     it("should correctly retrieve valid data from the given storage", async () => {
       const storageUtility = getStorageUtility({

--- a/packages/core/src/storage/StorageUtility.ts
+++ b/packages/core/src/storage/StorageUtility.ts
@@ -115,6 +115,16 @@ export async function saveSessionInfoToStorage(
   }
 }
 
+export type ResourceServerSession = {
+  webId: string;
+  sessions: Record<
+    string,
+    {
+      expiration: number;
+    }
+  >;
+};
+
 // TOTEST: this does not handle all possible bad inputs for example what if it's not proper JSON
 /**
  * @hidden
@@ -128,6 +138,9 @@ export default class StorageUtility implements IStorageUtility {
   private getKey(userId: string): string {
     return `solidClientAuthenticationUser:${userId}`;
   }
+
+  private RESOURCE_SERVER_SESSION_INFORMATION_KEY =
+    "tmp-resource-server-session-info";
 
   private async getUserData(
     userId: string,
@@ -247,6 +260,56 @@ export default class StorageUtility implements IStorageUtility {
     await (options?.secure ? this.secureStorage : this.insecureStorage).delete(
       this.getKey(userId)
     );
+  }
+
+  async storeResourceServerSessionInfo(
+    webId: string,
+    resourceServerIri: string,
+    expiration: number
+  ): Promise<void> {
+    const sessions: ResourceServerSession = JSON.parse(
+      (await this.insecureStorage.get(
+        this.RESOURCE_SERVER_SESSION_INFORMATION_KEY
+      )) ?? "{}"
+    );
+    if (sessions.webId !== webId) {
+      // Clear all previously active sessions.
+      sessions.sessions = {};
+    }
+    sessions.webId = webId;
+    sessions.sessions[resourceServerIri] = {
+      expiration,
+    };
+    await this.insecureStorage.set(
+      this.RESOURCE_SERVER_SESSION_INFORMATION_KEY,
+      JSON.stringify(sessions)
+    );
+  }
+
+  async clearResourceServerSessionInfo(
+    resourceServerIri: string
+  ): Promise<void> {
+    const sessions: ResourceServerSession = JSON.parse(
+      (await this.insecureStorage.get(
+        this.RESOURCE_SERVER_SESSION_INFORMATION_KEY
+      )) ?? "{}"
+    );
+    if (sessions.sessions !== undefined) {
+      delete sessions.sessions[resourceServerIri];
+
+      if (Object.keys(sessions.sessions).length === 0) {
+        // If there aren't any active sessions left, the whole object is cleared.
+        await this.insecureStorage.set(
+          this.RESOURCE_SERVER_SESSION_INFORMATION_KEY,
+          "{}"
+        );
+      } else {
+        await this.insecureStorage.set(
+          this.RESOURCE_SERVER_SESSION_INFORMATION_KEY,
+          JSON.stringify(sessions)
+        );
+      }
+    }
   }
 
   /**

--- a/packages/core/src/storage/__mocks__/StorageUtility.ts
+++ b/packages/core/src/storage/__mocks__/StorageUtility.ts
@@ -69,6 +69,19 @@ export const StorageUtilityMock: IStorageUtility = {
       userId?: string;
     }>
   ) => StorageUtilitySafeGetResponse,
+  /* eslint-enable @typescript-eslint/no-unused-vars */
+  storeResourceServerSessionInfo: async (
+    _webId: string,
+    _resourceServerIri: string,
+    _sessionExpires: number
+  ): Promise<void> => {
+    // Do nothing
+  },
+  clearResourceServerSessionInfo: async (
+    _resourceServerIri: string
+  ): Promise<void> => {
+    // Do nothing
+  },
 };
 
 export const mockStorage = (


### PR DESCRIPTION
This reverts d7332cf00317a7a3bc1f3684c01916bd21f89ace, but adds
that the Resource Server cookie-based workaround is only enabled
when silent token refresh is not enabled, to ensure that that is a
non-breaking bugfix.

This means I only added a single test (Session "does not attempt to use the workaround if the long-term solution (silent refresh) is enabled") and the second condition in

```js
    if (
      typeof storedSessionCookieReference === "string" &&
      options.restorePreviousSession !== true
    ) {
```

- [x] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
