### PR TITLE
Don't fail the build when coverage upload fails

### DIFF
--- a/.github/workflows/cd-preview.yml
+++ b/.github/workflows/cd-preview.yml
@@ -106,6 +106,7 @@ jobs:
         VERSION_NR: ${{ needs.dev-release-npm.outputs.version-nr }}
     - name: Archive Parcel build artifacts
       uses: actions/upload-artifact@v2.2.2
+      continue-on-error: true
       with:
         name: parcel-dist
         path: .github/workflows/cd-packaging-tests/bundler-parcel/dist
@@ -129,6 +130,7 @@ jobs:
         VERSION_NR: ${{ needs.dev-release-npm.outputs.version-nr }}
     - name: Archive Webpack build artifacts
       uses: actions/upload-artifact@v2.2.2
+      continue-on-error: true
       with:
         name: webpack-dist
         path: .github/workflows/cd-packaging-tests/bundler-webpack/dist

--- a/.github/workflows/cd-release.yml
+++ b/.github/workflows/cd-release.yml
@@ -143,6 +143,7 @@ jobs:
         npx parcel build index.ts
     - name: Archive Parcel build artifacts
       uses: actions/upload-artifact@v2.2.2
+      continue-on-error: true
       with:
         name: parcel-dist
         path: .github/workflows/cd-packaging-tests/bundler-parcel/dist
@@ -164,6 +165,7 @@ jobs:
         npx webpack --devtool source-map
     - name: Archive Webpack build artifacts
       uses: actions/upload-artifact@v2.2.2
+      continue-on-error: true
       with:
         name: webpack-dist
         path: .github/workflows/cd-packaging-tests/bundler-webpack/dist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
       - run: npm audit --audit-level=moderate
       - name: Archive code coverage results
         uses: actions/upload-artifact@v2.2.2
+        continue-on-error: true
         with:
           name: code-coverage-report
           path: ./packages/*/coverage/


### PR DESCRIPTION
The upload-artifact action is notoriously unreliable, but it is not
important enough to break the build when it fails. Rather, we can
just restart the build in the rare occasion that we do need those
artifacts and the upload fails.