### PR TITLE
Removed duplication between redirectUr(i|l)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased
 
+### Bugfixes
+
+#### browser
+
+- Some components of the redirect URL are no longer lost after redirect, which
+prevents silent authentication from failing.
+
 The following sections document changes that have been released already:
 
 ## 1.6.1 - 2021-02-26

--- a/packages/browser/__tests__/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
+++ b/packages/browser/__tests__/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
@@ -278,7 +278,7 @@ describe("AuthCodeRedirectHandler", () => {
         },
         "solidClientAuthenticationUser:userId": {
           codeVerifier: "a",
-          redirectUri: "b",
+          redirectUrl: "b",
           issuer: "someIssuer",
           dpop: "true",
         },
@@ -383,7 +383,7 @@ describe("AuthCodeRedirectHandler", () => {
           dpop: "true",
           issuer: mockIssuer().issuer.toString(),
           codeVerifier: "some code verifier",
-          redirectUri: "https://some.redirect.uri",
+          redirectUrl: "https://some.redirect.uri",
         },
       });
 
@@ -427,7 +427,7 @@ describe("AuthCodeRedirectHandler", () => {
           dpop: "true",
           issuer: mockIssuer().issuer.toString(),
           codeVerifier: "some code verifier",
-          redirectUri: "https://some.redirect.uri",
+          redirectUrl: "https://some.redirect.uri",
         },
       });
 

--- a/packages/browser/src/login/oidc/oidcHandlers/AuthorizationCodeWithPkceOidcHandler.ts
+++ b/packages/browser/src/login/oidc/oidcHandlers/AuthorizationCodeWithPkceOidcHandler.ts
@@ -111,7 +111,7 @@ export default class AuthorizationCodeWithPkceOidcHandler
             // eslint-disable-next-line no-underscore-dangle
             codeVerifier: req.state._code_verifier,
             issuer: oidcLoginOptions.issuer.toString(),
-            redirectUri: oidcLoginOptions.redirectUrl.toString(),
+            redirectUrl: oidcLoginOptions.redirectUrl.toString(),
             dpop: oidcLoginOptions.dpop ? "true" : "false",
           }),
         ])

--- a/packages/browser/src/login/oidc/oidcHandlers/AuthorizationCodeWithPkceOidcHandler.ts
+++ b/packages/browser/src/login/oidc/oidcHandlers/AuthorizationCodeWithPkceOidcHandler.ts
@@ -111,7 +111,6 @@ export default class AuthorizationCodeWithPkceOidcHandler
             // eslint-disable-next-line no-underscore-dangle
             codeVerifier: req.state._code_verifier,
             issuer: oidcLoginOptions.issuer.toString(),
-            redirectUrl: oidcLoginOptions.redirectUrl.toString(),
             dpop: oidcLoginOptions.dpop ? "true" : "false",
           }),
         ])

--- a/packages/browser/src/login/oidc/oidcHandlers/AuthorizationCodeWithPkceOidcHandler.ts
+++ b/packages/browser/src/login/oidc/oidcHandlers/AuthorizationCodeWithPkceOidcHandler.ts
@@ -111,6 +111,8 @@ export default class AuthorizationCodeWithPkceOidcHandler
             // eslint-disable-next-line no-underscore-dangle
             codeVerifier: req.state._code_verifier,
             issuer: oidcLoginOptions.issuer.toString(),
+            // The redirect URL is read after redirect, so it must be stored now.
+            redirectUrl: oidcLoginOptions.redirectUrl,
             dpop: oidcLoginOptions.dpop ? "true" : "false",
           }),
         ])

--- a/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
+++ b/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
@@ -47,7 +47,6 @@ import {
   buildDpopFetch,
 } from "../../../authenticatedFetch/fetchFactory";
 import { KEY_CURRENT_SESSION } from "../../../constant";
-import { appendToUrlPathname } from "../../../util/urlPath";
 
 export async function exchangeDpopToken(
   sessionId: string,
@@ -242,10 +241,14 @@ export class AuthCodeRedirectHandler implements IRedirectHandler {
       },
       { secure: true }
     );
+    // Clear the code query param from the redirect URL before storing it, but
+    // preserve any state that my have been provided by the client and returned
+    // by the IdP.
+    url.searchParams.delete("code");
     await this.storageUtility.setForUser(
       storedSessionId,
       {
-        redirectUrl: appendToUrlPathname(url.origin, url.pathname),
+        redirectUrl: url.toString(),
         idToken: tokens.idToken,
       },
       {

--- a/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
+++ b/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
@@ -67,7 +67,7 @@ export async function exchangeDpopToken(
     grantType: "authorization_code",
     code,
     codeVerifier,
-    redirectUri: redirectUrl,
+    redirectUrl,
   });
 }
 
@@ -203,7 +203,7 @@ export class AuthCodeRedirectHandler implements IRedirectHandler {
 
       const storedRedirectIri = (await this.storageUtility.getForUser(
         storedSessionId,
-        "redirectUri",
+        "redirectUrl",
         { errorIfNull: true }
       )) as string;
 

--- a/packages/core/src/storage/StorageUtility.spec.ts
+++ b/packages/core/src/storage/StorageUtility.spec.ts
@@ -623,7 +623,7 @@ describe("loadOidcContextFromStorage", () => {
     const mockedStorage = mockStorageUtility({
       "solidClientAuthenticationUser:mySession": {
         codeVerifier: "some code verifier",
-        redirectUri: "https://my.app/redirect",
+        redirectUrl: "https://my.app/redirect",
         dpop: "true",
       },
     });
@@ -644,7 +644,7 @@ describe("loadOidcContextFromStorage", () => {
       "solidClientAuthenticationUser:mySession": {
         issuer: "https://my.idp/",
         codeVerifier: "some code verifier",
-        redirectUri: "https://my.app/redirect",
+        redirectUrl: "https://my.app/redirect",
       },
     });
 
@@ -664,7 +664,7 @@ describe("loadOidcContextFromStorage", () => {
       "solidClientAuthenticationUser:mySession": {
         issuer: "https://my.idp/",
         codeVerifier: "some code verifier",
-        redirectUri: "https://my.app/redirect",
+        redirectUrl: "https://my.app/redirect",
         dpop: "true",
       },
     });
@@ -678,7 +678,7 @@ describe("loadOidcContextFromStorage", () => {
     ).resolves.toEqual({
       issuerConfig: mockIssuerConfig(),
       codeVerifier: "some code verifier",
-      redirectUri: "https://my.app/redirect",
+      redirectUrl: "https://my.app/redirect",
       dpop: true,
     });
   });

--- a/packages/core/src/storage/StorageUtility.ts
+++ b/packages/core/src/storage/StorageUtility.ts
@@ -37,7 +37,7 @@ import { IIssuerConfigFetcher } from "../login/oidc/IIssuerConfigFetcher";
 export type OidcContext = {
   issuerConfig: IIssuerConfig;
   codeVerifier?: string;
-  redirectUri?: string;
+  redirectUrl?: string;
   dpop: boolean;
 };
 
@@ -72,7 +72,7 @@ export async function loadOidcContextFromStorage(
         errorIfNull: true,
       }),
       storageUtility.getForUser(sessionId, "codeVerifier"),
-      storageUtility.getForUser(sessionId, "redirectUri"),
+      storageUtility.getForUser(sessionId, "redirectUrl"),
       storageUtility.getForUser(sessionId, "dpop", { errorIfNull: true }),
     ]);
 
@@ -80,7 +80,7 @@ export async function loadOidcContextFromStorage(
     const issuerConfig = await configFetcher.fetchConfig(issuerIri as string);
     return {
       codeVerifier,
-      redirectUri: storedRedirectIri,
+      redirectUrl: storedRedirectIri,
       issuerConfig,
       dpop: dpop === "true",
     };

--- a/packages/node/src/login/oidc/oidcHandlers/AuthorizationCodeWithPkceOidcHandler.spec.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/AuthorizationCodeWithPkceOidcHandler.spec.ts
@@ -129,7 +129,7 @@ describe("AuthorizationCodeWithPkceOidcHandler", () => {
         mockedStorage.getForUser(oidcOptions.sessionId, "issuer")
       ).resolves.toEqual(oidcOptions.issuer);
       await expect(
-        mockedStorage.getForUser(oidcOptions.sessionId, "redirectUri")
+        mockedStorage.getForUser(oidcOptions.sessionId, "redirectUrl")
       ).resolves.toEqual(oidcOptions.redirectUrl);
       await expect(
         mockedStorage.getForUser(oidcOptions.sessionId, "dpop")

--- a/packages/node/src/login/oidc/oidcHandlers/AuthorizationCodeWithPkceOidcHandler.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/AuthorizationCodeWithPkceOidcHandler.ts
@@ -88,7 +88,7 @@ export default class AuthorizationCodeWithPkceOidcHandler
       this.storageUtility.setForUser(oidcLoginOptions.sessionId, {
         codeVerifier,
         issuer: oidcLoginOptions.issuer,
-        redirectUri: oidcLoginOptions.redirectUrl,
+        redirectUrl: oidcLoginOptions.redirectUrl,
         dpop: oidcLoginOptions.dpop ? "true" : "false",
       }),
     ]);

--- a/packages/node/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
+++ b/packages/node/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
@@ -191,7 +191,7 @@ describe("AuthCodeRedirectHandler", () => {
       "solidClientAuthenticationUser:mySession": {
         issuer: "https://my.idp/",
         codeVerifier: "some code verifier",
-        redirectUri: "https://my.app/redirect",
+        redirectUrl: "https://my.app/redirect",
         dpop: "true",
       },
     });

--- a/packages/node/src/login/oidc/refresh/TokenRefresher.spec.ts
+++ b/packages/node/src/login/oidc/refresh/TokenRefresher.spec.ts
@@ -119,7 +119,7 @@ const mockRefresherDefaultStorageUtility = () =>
     "solidClientAuthenticationUser:mySession": {
       issuer: "https://my.idp",
       codeVerifier: "some code verifier",
-      redirectUri: "https://my.app/redirect",
+      redirectUrl: "https://my.app/redirect",
       dpop: "true",
     },
   });
@@ -145,7 +145,7 @@ describe("TokenRefresher", () => {
     const mockedStorage = mockStorageUtility({
       "solidClientAuthenticationUser:mySession": {
         codeVerifier: "some code verifier",
-        redirectUri: "https://my.app/redirect",
+        redirectUrl: "https://my.app/redirect",
         dpop: "true",
       },
     });
@@ -230,7 +230,7 @@ describe("TokenRefresher", () => {
       "solidClientAuthenticationUser:mySession": {
         issuer: "https://my.idp",
         codeVerifier: "some code verifier",
-        redirectUri: "https://my.app/redirect",
+        redirectUrl: "https://my.app/redirect",
         dpop: "false",
       },
     });

--- a/packages/oidc/src/dpop/tokenExchange.spec.ts
+++ b/packages/oidc/src/dpop/tokenExchange.spec.ts
@@ -84,7 +84,7 @@ const mockEndpointInput = (): TokenEndpointInput => {
     grantType: "authorization_code",
     code: "some code",
     codeVerifier: "some pkce token",
-    redirectUri: "https://my.app/redirect",
+    redirectUrl: "https://my.app/redirect",
   };
 };
 
@@ -256,7 +256,7 @@ describe("getTokens", () => {
         grantType: "some_custom_grant",
         code: "some code",
         codeVerifier: "some pkce token",
-        redirectUri: "https://my.app/redirect",
+        redirectUrl: "https://my.app/redirect",
       },
       true
     );

--- a/packages/oidc/src/dpop/tokenExchange.ts
+++ b/packages/oidc/src/dpop/tokenExchange.ts
@@ -78,7 +78,7 @@ export type TokenEndpointDpopResponse = TokenEndpointResponse & {
 
 export type TokenEndpointInput = {
   grantType: string;
-  redirectUri: string;
+  redirectUrl: string;
   code: string;
   codeVerifier: string;
 };
@@ -259,7 +259,7 @@ export async function getTokens(
     body: formurlencoded({
       /* eslint-disable camelcase */
       grant_type: data.grantType,
-      redirect_uri: data.redirectUri,
+      redirect_uri: data.redirectUrl,
       code: data.code,
       code_verifier: data.codeVerifier,
       client_id: client.clientId,


### PR DESCRIPTION
Parts of the code reads and writes the redirect URI in storage with the key `redirectUri`, and some other parts with the key `redirectUrl`. This causes confusion, and ends up with potentially creating a bug when trying to use one in silent authentication when the other is the one that has been registered as valid by the Solid Identity Provider, leading to the user being displayed an `invalid_grant` screen instead of being redirected to the app.

Technically, either `redirectUrl` or `redirectUri` are valid choices.
`redirectUrl` has been picked because it is the name of the parameter in
the login options, so picking `redirectUri` woud need either breaking
change, or to keep some room for error by having to rename the field in
the JSON object at some point. Note that the actual OAuth parameter name
is `redirect_uri`, which isn't camel cased, so a renaming would be
necessary anyways.

- [x] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

