### PR TITLE
Enable ESS cookie auth opt out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### New features
 
-- New options `useEssSession` for `session.handleIncomingRedirect`: If set to false, 
-the `/session` endpoint isn't looked up, and cookie-based auth is disabled. The 
+- New option `useEssSession` for `session.handleIncomingRedirect`: Control to 
+enable and disble the behaviour introduced in 1.4.0. If set to false, the
+`/session` endpoint isn't looked up, and cookie-based auth is disabled. The 
 behaviour is similar when `restorePreviousSession` is true.
 
 ### Bugfixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased
 
+### New features
+
+- New options `useEssSession` for `session.handleIncomingRedirect`: If set to false, 
+the `/session` endpoint isn't looked up, and cookie-based auth is disabled. The 
+behaviour is similar when `restorePreviousSession` is true.
+
 ### Bugfixes
 
 #### browser

--- a/packages/browser/__tests__/Session.spec.ts
+++ b/packages/browser/__tests__/Session.spec.ts
@@ -419,6 +419,29 @@ describe("Session", () => {
         ).toHaveBeenCalledTimes(1);
       });
 
+      it("does not attempt to use the workaround if it is explicitly disabled", async () => {
+        mockLocalStorage({
+          "tmp-resource-server-session-info": JSON.stringify({
+            webId: "https://my.pod/profile#me",
+            sessions: {
+              "https://my.pod/": { expiration: 9000000000000 },
+            },
+          }),
+        });
+        const clientAuthentication = mockClientAuthentication();
+        clientAuthentication.handleIncomingRedirect = jest.fn();
+        const mySession = new Session({ clientAuthentication });
+        await mySession.handleIncomingRedirect({
+          url: "https://some.url",
+          useEssSession: false,
+        });
+        expect(mySession.info.isLoggedIn).toBe(false);
+        expect(mySession.info.webId).toBeUndefined();
+        expect(
+          clientAuthentication.handleIncomingRedirect
+        ).toHaveBeenCalledTimes(1);
+      });
+
       it("does not mark an almost-expired session as logged in", async () => {
         mockLocalStorage({
           "tmp-resource-server-session-info": JSON.stringify({

--- a/packages/browser/__tests__/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
+++ b/packages/browser/__tests__/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
@@ -119,6 +119,17 @@ const mockTokenEndpointDpopResponse = (): TokenEndpointResponse => {
   };
 };
 
+const mockLocalStorage = (stored: Record<string, string>) => {
+  // Kinda weird: `(window as any).localStorage = new LocalStorageMock(stored)` does
+  // not work as intended unless the following snippet is present in the test suite.
+  // On the other hand, only ever mocking localstorage with the following snippet
+  // works well.
+  Object.defineProperty(window, "localStorage", {
+    value: new LocalStorageMock(stored),
+    writable: true,
+  });
+};
+
 /**
  * TODO: FIXME: Suggested improvement from Nic - just recording here for future
  * reference:
@@ -319,7 +330,7 @@ describe("AuthCodeRedirectHandler", () => {
     /* eslint-disable @typescript-eslint/ban-ts-comment */
     it("returns an authenticated bearer fetch by default", async () => {
       /* eslint-disable  @typescript-eslint/no-explicit-any */
-      (window as any).localStorage = new LocalStorageMock();
+      mockLocalStorage({});
 
       mockFetch(
         new Response("", {
@@ -360,7 +371,7 @@ describe("AuthCodeRedirectHandler", () => {
 
     it("returns an authenticated DPoP fetch if requested", async () => {
       /* eslint-disable  @typescript-eslint/no-explicit-any */
-      (window as any).localStorage = new LocalStorageMock();
+      mockLocalStorage({});
 
       window.fetch = jest.fn().mockReturnValue(
         new Promise((resolve) => {
@@ -404,7 +415,7 @@ describe("AuthCodeRedirectHandler", () => {
 
     it("saves session information in storage on successful login", async () => {
       /* eslint-disable  @typescript-eslint/no-explicit-any */
-      (window as any).localStorage = new LocalStorageMock();
+      mockLocalStorage({});
 
       window.fetch = jest.fn().mockReturnValue(
         new Promise((resolve) => {
@@ -453,7 +464,7 @@ describe("AuthCodeRedirectHandler", () => {
 
     it("preserves any query strings from the redirect URI", async () => {
       /* eslint-disable  @typescript-eslint/no-explicit-any */
-      (window as any).localStorage = new LocalStorageMock();
+      mockLocalStorage({});
 
       window.fetch = jest.fn().mockReturnValue(
         new Promise((resolve) => {
@@ -530,7 +541,7 @@ describe("AuthCodeRedirectHandler", () => {
 
   it("stores information about the resource server cookie in local storage on successful authentication", async () => {
     /* eslint-disable  @typescript-eslint/no-explicit-any */
-    (window as any).localStorage = new LocalStorageMock();
+    mockLocalStorage({});
 
     // This mocks the fetch to the Resource Server session endpoint
     // Note: Currently, the endpoint only returns the webid in plain/text, it could
@@ -580,7 +591,54 @@ describe("AuthCodeRedirectHandler", () => {
     });
   });
 
+  it("does not look the session endpoint up if the ESS cookie workaround has been disabled", async () => {
+    mockLocalStorage({
+      "tmp-resource-server-session-enabled": "false",
+    });
+
+    // This mocks the fetch to the Resource Server session endpoint
+    // Note: Currently, the endpoint only returns the webid in plain/text, it could
+    // be extended later to also provide the cookie expiration.
+    mockFetch(
+      new Response("https://my.webid", {
+        status: 200,
+      })
+    );
+
+    const MOCK_TIMESTAMP = 10000;
+    Date.now = jest
+      .fn()
+      // Date.now is called twice: once to be able to calculate the auth token expiry time,
+      // and once to set the cookie expiry. We only care about the second in this test.
+      .mockReturnValueOnce(MOCK_TIMESTAMP)
+      .mockReturnValueOnce(MOCK_TIMESTAMP);
+
+    const testIssuer = "some test Issuer";
+    const mockedStorage = mockStorageUtility({
+      "solidClientAuthenticationUser:mySession": {
+        issuer: testIssuer,
+      },
+      "solidClientAuthenticationUser:oauth2_state_value": {
+        sessionId: "mySession",
+      },
+    });
+
+    const authCodeRedirectHandler = getAuthCodeRedirectHandler({
+      storageUtility: mockedStorage,
+    });
+
+    await authCodeRedirectHandler.handle(
+      "https://coolsite.com/?code=someCode&state=oauth2_state_value"
+    );
+    expect(
+      JSON.parse(
+        (await mockedStorage.get("tmp-resource-server-session-info")) ?? "{}"
+      )
+    ).toEqual({});
+  });
+
   it("store nothing if the resource server has no session endpoint", async () => {
+    mockLocalStorage({});
     // This mocks the fetch to the Resource Server session endpoint
     // Note: Currently, the endpoint only returns the WebID in plain/text, it could
     // be extended later to also provide the cookie expiration.
@@ -614,6 +672,7 @@ describe("AuthCodeRedirectHandler", () => {
   });
 
   it("swallows the exception if the fetch to the session endpoint fails", async () => {
+    mockLocalStorage({});
     window.fetch = jest
       .fn()
       .mockResolvedValueOnce(
@@ -647,6 +706,7 @@ describe("AuthCodeRedirectHandler", () => {
   });
 
   it("store nothing if the resource server does not recognize the user", async () => {
+    mockLocalStorage({});
     // This mocks the fetch to the Resource Server session endpoint
     // Note: Currently, the endpoint only returns the WebID in plain/text, it could
     // be extended later to also provide the cookie expiration.

--- a/packages/browser/examples/single/bundle/src/App.js
+++ b/packages/browser/examples/single/bundle/src/App.js
@@ -42,7 +42,9 @@ export default function App() {
   // is redirected to the page after logging in the identity provider.
   useEffect(() => {
     // After redirect, the current URL contains login information.
-    handleIncomingRedirect(window.location.href).then((info) => {
+    handleIncomingRedirect({
+      restorePreviousSession: true,
+    }).then((info) => {
       setWebId(info.webId);
       setResource(webId);
     });

--- a/packages/browser/src/Session.ts
+++ b/packages/browser/src/Session.ts
@@ -65,6 +65,17 @@ export interface IHandleIncomgingRedirectOptions {
    * {@see onSessionRestore}
    */
   restorePreviousSession?: boolean;
+
+  /**
+   * Inrupt's Enterprise Solid Server sets a cookie to allow the browser to
+   * access private resources on a Pod. In order to mitigate the logout-on-refresh
+   * issue on the short term, the server also implemented a session endpoint
+   * enabling the client app to know whether the cookie is set. If your app
+   * supports the newest session restore approach, or if you want to prevent
+   * your app to look up the session endpoint on your resource server, this
+   * option may be set to false. It defaults to true for backward compatibility.
+   */
+  useEssSession?: boolean;
   /**
    * The URL of the page handling the redirect, including the query
    * parameters — these contain the information to process the login.
@@ -219,12 +230,27 @@ export class Session extends EventEmitter {
     // data, and if present, indicate that the user is already logged in.
     // Note that there are a lot of edge cases that won't work well with this approach, so it willl
     // be removed in due time.
+    if (
+      options.useEssSession === false ||
+      options.restorePreviousSession === true
+    ) {
+      window.localStorage.setItem(
+        "tmp-resource-server-session-enabled",
+        "false"
+      );
+    } else {
+      window.localStorage.setItem(
+        "tmp-resource-server-session-enabled",
+        "true"
+      );
+    }
     const storedSessionCookieReference = window.localStorage.getItem(
       "tmp-resource-server-session-info"
     );
     if (
       typeof storedSessionCookieReference === "string" &&
-      options.restorePreviousSession !== true
+      options.restorePreviousSession !== true &&
+      options.useEssSession !== false
     ) {
       // TOOD: Re-use the type used when writing this data:
       // https://github.com/inrupt/solid-client-authn-js/pull/920/files#diff-659ac87dfd3711f4cfcea3c7bf6970980f4740fd59df45f04c7977bffaa23e98R118

--- a/packages/browser/src/Session.ts
+++ b/packages/browser/src/Session.ts
@@ -70,10 +70,17 @@ export interface IHandleIncomgingRedirectOptions {
    * Inrupt's Enterprise Solid Server sets a cookie to allow the browser to
    * access private resources on a Pod. In order to mitigate the logout-on-refresh
    * issue on the short term, the server also implemented a session endpoint
-   * enabling the client app to know whether the cookie is set. If your app
-   * supports the newest session restore approach, or if you want to prevent
-   * your app to look up the session endpoint on your resource server, this
-   * option may be set to false. It defaults to true for backward compatibility.
+   * enabling the client app to know whether the cookie is set.
+   *
+   * If you want to prevent your app to look up the session endpoint on your
+   * resource server, this option may be set to false, which without any additional
+   * configuration will have the app logged out on refresh.
+   *
+   * If your app supports the newest session restore approach, and `restorePreviousSession`
+   * is set to true, this option is automatically set to false, but your app will
+   * not be logged out when reloaded.
+   *
+   * `useEssSession` defaults to true for backward compatibility.
    */
   useEssSession?: boolean;
   /**

--- a/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
+++ b/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
@@ -255,12 +255,18 @@ export class AuthCodeRedirectHandler implements IRedirectHandler {
         secure: false,
       }
     );
-
-    await setupResourceServerSession(
-      tokens.webId,
-      authFetch,
-      this.storageUtility
-    );
+    // TODO: This is a temporary workaround. When deprecating the cookie-based auth,
+    // this should be all cleared.
+    const essWorkaroundDisabled =
+      window.localStorage.getItem("tmp-resource-server-session-enabled") ===
+      "false";
+    if (!essWorkaroundDisabled) {
+      await setupResourceServerSession(
+        tokens.webId,
+        authFetch,
+        this.storageUtility
+      );
+    }
 
     const sessionInfo = await this.sessionInfoManager.get(storedSessionId);
     if (!sessionInfo) {


### PR DESCRIPTION
So far, logging in to any Identity Provider would lead to the Resource
Server hosting the WebID being looked up for a `/session` endpoint. This
causes several issues:
- It makes additional, non-required requests if the server does not have
a session endpoint, or if the app supports silent authentication
- It has caused annoying issues when looking up the missing endpoint for
some servers
- It's a solution we want to deprecate anyways.

To resolve this, both the endpoint lookup and the cookie-based auth can
be disabled by specifying an additional option to
`handleIncomingRedirect`, `useEssSession`. It defaults to true (for
backward-compatibility), but it is considered false if silent
authentication is enabled.

Note that this uses an entry in local storage to share the state between
the Session where the option is specified and the RedirectHandler where
the session lookup actually happens. This isn't ideal, but it prevents
from changing internal APIs, only to change them back when this isn't
supported anymore.

- [X] All acceptance criteria are met.
- [X] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).