### PR TITLE
Change the version command in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,7 +24,7 @@ This PR bumps the version to <version number>.
 
 # Checklist
 
-- [ ] I used `lerna version <major|minor|patch> --no-push` to update the version number, first inspecting the CHANGELOG to determine if the release was major, minor or patch.
+- [ ] I used `npm run version -- <major|minor|patch> --no-push` to update the version number, first inspecting the CHANGELOG to determine if the release was major, minor or patch.
 - [ ] The CHANGELOG has been updated to show version and release date - https://keepachangelog.com/en/1.0.0/.
 - [ ] The **only** commits in this PR are:
   - the CHANGELOG update.


### PR DESCRIPTION
The command currently suggested (namely `lerna version <major|minor|patch> --no-push`) modifies some files before commit, which fails the operation, since uncommited changes are present. For some reason, running the same command in an NPM script prevents the issue from happening.