### PR TITLE
Fix typo in interface name

### DIFF
--- a/packages/browser/src/Session.ts
+++ b/packages/browser/src/Session.ts
@@ -53,7 +53,7 @@ export interface ISessionOptions {
   clientAuthentication: ClientAuthentication;
 }
 
-export interface IHandleIncomgingRedirectOptions {
+export interface IHandleIncomingRedirectOptions {
   /**
    * If the user has signed in before, setting this to `true` will automatically
    * redirect them to their Solid Identity Provider, which will then attempt to
@@ -213,10 +213,10 @@ export class Session extends EventEmitter {
    * Completes the login process by processing the information provided by the
    * Solid identity provider through redirect.
    *
-   * @param options See {@see IHandleIncomgingRedirectOptions}.
+   * @param options See {@see IHandleIncomingRedirectOptions}.
    */
   handleIncomingRedirect = async (
-    inputOptions: string | IHandleIncomgingRedirectOptions = {}
+    inputOptions: string | IHandleIncomingRedirectOptions = {}
   ): Promise<ISessionInfo | undefined> => {
     if (this.info.isLoggedIn) {
       return this.info;


### PR DESCRIPTION
Technically someone could be using the interface somewhere in the code and this would be breaking, but in practice I'm quite sure nobody does, so as far as I'm concerned we don't need to preserve the one with the typo. Happy to add it if you disagree though.

- [ ] I've added a unit test to test for potential regressions of this bug. N/A
- [x] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
