### PR TITLE
name Lerna version script more explicitly

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,7 +24,7 @@ This PR bumps the version to <version number>.
 
 # Checklist
 
-- [ ] I used `npm run version -- <major|minor|patch> --no-push` to update the version number, first inspecting the CHANGELOG to determine if the release was major, minor or patch.
+- [ ] I used `npm run lerna-version -- <major|minor|patch> --no-push` to update the version number, first inspecting the CHANGELOG to determine if the release was major, minor or patch.
 - [ ] The CHANGELOG has been updated to show version and release date - https://keepachangelog.com/en/1.0.0/.
 - [ ] The **only** commits in this PR are:
   - the CHANGELOG update.

--- a/.github/workflows/cd-preview.yml
+++ b/.github/workflows/cd-preview.yml
@@ -35,7 +35,9 @@ jobs:
           # we incorporate a timestamp in the prerelease version:
           TIMESTAMP=$(date --utc +%s)
           # Make sure the prerelease is tagged with the branch name, and that they are sorted by build:
-          npm run version -- prerelease --preid=$TAG_SLUG-$GITHUB_RUN_ID-$GITHUB_RUN_NUMBER-$TIMESTAMP --yes --no-push --exact
+          # Note: we run a Lerna-specific script to update the version (as
+          # opposed to running `lerna version ...` or `npm version ...`).
+          npm run lerna-version -- prerelease --preid=$TAG_SLUG-$GITHUB_RUN_ID-$GITHUB_RUN_NUMBER-$TIMESTAMP --yes --no-push --exact
           # Read the "version" key from one of our packages to determine the exact version nr
           # the prerelease was published under:
           VERSION_NR=$(cat packages/browser/package.json | npx json version)

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test": "lerna run test",
     "test-all": "npm run lint && npm run licenses-all && npm run test-unit-all",
     "test-unit-all": "jest --coverage --verbose",
-    "version": "lerna version",
+    "lerna-version": "lerna version",
     "install-sandbox": "npm ci && npm ci --prefix .codesandbox/sandbox",
     "build-sandbox": "npm run build && npm run build --prefix .codesandbox/sandbox",
     "build-docs-preview-site": "lerna run build-docs-preview-site; rm -r dist/website || true; lerna exec -- mkdir -p ../../dist/website/\\${PWD##*/}; lerna exec -- \"cp -r docs/api/build/html/. ../../dist/website/\\${PWD##*/}/ || true\"; echo 'API documentation: <a href=\"./browser/\">solid-client-authn-browser</a>, <a href=\"./node/\">solid-client-authn-node</a>, <a href=\"./core/\">solid-client-authn-core</a>, <a href=\"./demo/\">demo app</a>.' >> dist/website/index.html",


### PR DESCRIPTION
Internal change - just renaming the `package.json` script to run `lerna version...` to prevent the easy-to-make mistake of forgetting to add the 'run' keyword when running `npm run version...`.