### PR TITLE
Pin parcel version

### DIFF
--- a/.github/workflows/cd-preview.yml
+++ b/.github/workflows/cd-preview.yml
@@ -101,7 +101,7 @@ jobs:
       run: |
         cd .github/workflows/cd-packaging-tests/bundler-parcel
         npm install @inrupt/solid-client-authn-browser@$VERSION_NR
-        npx parcel build index.ts
+        npx parcel@1.12.3 build index.ts
       env:
         VERSION_NR: ${{ needs.dev-release-npm.outputs.version-nr }}
     - name: Archive Parcel build artifacts

--- a/.github/workflows/cd-release.yml
+++ b/.github/workflows/cd-release.yml
@@ -140,7 +140,7 @@ jobs:
       run: |
         cd .github/workflows/cd-packaging-tests/bundler-parcel
         npm install @inrupt/solid-client-authn-browser
-        npx parcel build index.ts
+        npx parcel@1.12.3 build index.ts
     - name: Archive Parcel build artifacts
       uses: actions/upload-artifact@v2.2.2
       continue-on-error: true


### PR DESCRIPTION
Due to https://github.com/parcel-bundler/parcel/issues/5943, using the
latest parcel version (1.12.4 at the time of writing) breaks the build.
This pins the parcel version for the CD to work again, until the
upstream bug is resolved.
