### PR TITLE
Remove hash fragment in URL sanitation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 The following sections document changes that have been released already:
 
+### Bugfixes
+
+#### browser
+
+- Attempting to log in with a hash fragment in the redirect URL no longer throws, 
+the hash fragment is simply discarded.
+
 ## 1.7.1 - 2021-03-04
 
 ### Bugfixes

--- a/packages/oidc/src/cleanup/cleanup.spec.ts
+++ b/packages/oidc/src/cleanup/cleanup.spec.ts
@@ -48,6 +48,12 @@ describe("removeOidcQueryParam", () => {
     );
   });
 
+  it("removes the hash part of the IRI", () => {
+    expect(removeOidcQueryParam("https://some.url/#some-anchor")).toEqual(
+      "https://some.url/"
+    );
+  });
+
   it("returns an URL without query strings as is", () => {
     expect(removeOidcQueryParam("https://some.url/")).toEqual(
       "https://some.url/"

--- a/packages/oidc/src/cleanup/cleanup.ts
+++ b/packages/oidc/src/cleanup/cleanup.ts
@@ -22,7 +22,8 @@
 import { OidcClient, WebStorageStateStore } from "oidc-client";
 
 /**
- * Removes OIDC-specific query parameters from a given URL (state, code...)
+ * Removes OIDC-specific query parameters from a given URL (state, code...), and
+ * sanitizes the URL (e.g. removes the hash fragment).
  * @param redirectUrl The URL to clean up.
  * @returns A copy of the URL, without OIDC-specific query params.
  */
@@ -30,6 +31,9 @@ export function removeOidcQueryParam(redirectUrl: string): string {
   const cleanedUrl = new URL(redirectUrl);
   cleanedUrl.searchParams.delete("code");
   cleanedUrl.searchParams.delete("state");
+  // As per https://tools.ietf.org/html/rfc6749#section-3.1.2, the redirect URL
+  // must not include a hash fragment.
+  cleanedUrl.hash = "";
   return cleanedUrl.toString();
 }
 


### PR DESCRIPTION
The hash fragment in an URI is only meant to be useful client-side, and
it is forbidden in a redirect URI (see
https://tools.ietf.org/html/rfc6749#section-3.1.2). This adds a step in
the URI cleanup function to remove the hash fragment of the provided
URI.

- [X] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).