### PR TITLE
Enable lerna-audit in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
           E2E_TEST_ESS_POD: ${{ secrets.E2E_TEST_ESS_POD }}
       - run: npx prettier --check "{packages/*/src,packages/*/__tests__}/**"
       - run: npm audit --audit-level=moderate
+      - run: npm run lerna-audit -- --audit-level=moderate
       - name: Archive code coverage results
         uses: actions/upload-artifact@v2.2.2
         continue-on-error: true

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "root",
   "private": true,
   "scripts": {
-    "audit": "lerna-audit",
     "demo-app": "cd packages/browser; npm run demo-app",
     "bootstrap": "lerna bootstrap",
     "e2e-test": "jest --config jest.e2e.config.js",
@@ -10,6 +9,7 @@
     "clean": "rm --recursive --force packages/*/dist/ packages/*/node_modules/ packages/*/coverage/ packages/*/umd/",
     "build-api-docs": "lerna run build-api-docs",
     "format-all": "prettier --write \"packages/*/src/**\" \"packages/*/__tests__/**\"",
+    "lerna-audit": "lerna-audit",
     "licenses-all": "license-checker --production --out license.csv --failOn \"AGPL-1.0-only; AGPL-1.0-or-later; AGPL-3.0-only; AGPL-3.0-or-later; Beerware; CC-BY-NC-1.0; CC-BY-NC-2.0; CC-BY-NC-2.5; CC-BY-NC-3.0; CC-BY-NC-4.0; CC-BY-NC-ND-1.0; CC-BY-NC-ND-2.0; CC-BY-NC-ND-2.5; CC-BY-NC-ND-3.0; CC-BY-NC-ND-4.0; CC-BY-NC-SA-1.0; CC-BY-NC-SA-2.0; CC-BY-NC-SA-2.5; CC-BY-NC-SA-3.0; CC-BY-NC-SA-4.0; CPAL-1.0; EUPL-1.0; EUPL-1.1; EUPL-1.1;  GPL-1.0-only; GPL-1.0-or-later; GPL-2.0-only;  GPL-2.0-or-later; GPL-3.0; GPL-3.0-only; GPL-3.0-or-later; SISSL;  SISSL-1.2; WTFPL\"",
     "lint": "lerna run lint",
     "prepare": "husky install",


### PR DESCRIPTION
lerna requires a specific audit configuration, enabled by the package
lerna-audit. It now runs in CI along with the regular `npm audit`.
The script is also now named `lerna-audit` instead of `audit` to avoid
the confusion with the `npm audit` command.
