### PR TITLE
Vvalidate ID token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased
 
+### Bugfixes
+
+#### browser
+
+- The ID token is now validated when asking for DPoP-bound tokens, and not only when asking for a Bearer token.
+
 The following sections document changes that have been released already:
 
 ### Bugfixes

--- a/packages/browser/__tests__/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
+++ b/packages/browser/__tests__/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
@@ -129,19 +129,27 @@ const mockLocalStorage = (stored: Record<string, string>) => {
   });
 };
 
+jest.mock("../../../../src/login/oidc/IssuerConfigFetcher", () => {
+  return {
+    getJwks: () => [mockJwk()],
+  };
+});
+
 jest.mock("@inrupt/oidc-client-ext");
 
 const defaultJwt = {
   sub: "https://some.webid",
 };
 
-function mockOidcClient(jwt: any = defaultJwt): any {
+// eslint-disable-next-line  @typescript-eslint/no-explicit-any
+function mockOidcClient(jwt: typeof defaultJwt = defaultJwt): any {
   const mockedOidcClient = jest.requireMock("@inrupt/oidc-client-ext");
   mockedOidcClient.generateJwkForDpop = jest.fn().mockResolvedValue(mockJwk());
   mockedOidcClient.createDpopHeader = jest.fn().mockResolvedValue("someToken");
   mockedOidcClient.decodeJwt = jest.fn().mockResolvedValue(jwt);
   mockedOidcClient.getDpopToken = mockTokenEndpointDpopResponse;
   mockedOidcClient.getBearerToken = mockTokenEndpointBearerResponse;
+  mockedOidcClient.validateIdToken = jest.fn().mockResolvedValue(true);
   return mockedOidcClient;
 }
 
@@ -305,7 +313,6 @@ describe("AuthCodeRedirectHandler", () => {
     /* eslint-disable @typescript-eslint/ban-ts-comment */
     it("returns an authenticated bearer fetch by default", async () => {
       mockOidcClient();
-      /* eslint-disable  @typescript-eslint/no-explicit-any */
       mockLocalStorage({});
 
       mockFetch(
@@ -347,7 +354,6 @@ describe("AuthCodeRedirectHandler", () => {
 
     it("returns an authenticated DPoP fetch if requested", async () => {
       mockOidcClient();
-      /* eslint-disable  @typescript-eslint/no-explicit-any */
       mockLocalStorage({});
 
       window.fetch = jest.fn().mockReturnValue(
@@ -392,7 +398,6 @@ describe("AuthCodeRedirectHandler", () => {
 
     it("saves session information in storage on successful login", async () => {
       mockOidcClient();
-      /* eslint-disable  @typescript-eslint/no-explicit-any */
       mockLocalStorage({});
 
       window.fetch = jest.fn().mockReturnValue(
@@ -442,7 +447,6 @@ describe("AuthCodeRedirectHandler", () => {
 
     it("preserves any query strings from the redirect URI", async () => {
       mockOidcClient();
-      /* eslint-disable  @typescript-eslint/no-explicit-any */
       mockLocalStorage({});
 
       window.fetch = jest.fn().mockReturnValue(
@@ -521,7 +525,6 @@ describe("AuthCodeRedirectHandler", () => {
 
   it("stores information about the resource server cookie in local storage on successful authentication", async () => {
     mockOidcClient();
-    /* eslint-disable  @typescript-eslint/no-explicit-any */
     mockLocalStorage({});
 
     // This mocks the fetch to the Resource Server session endpoint

--- a/packages/browser/__tests__/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
+++ b/packages/browser/__tests__/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
@@ -35,7 +35,6 @@ import { Response } from "cross-fetch";
 import {
   AuthCodeRedirectHandler,
   DEFAULT_LIFESPAN,
-  exchangeDpopToken,
 } from "../../../../src/login/oidc/redirectHandler/AuthCodeRedirectHandler";
 import { RedirectorMock } from "../../../../src/login/oidc/__mocks__/Redirector";
 import { SessionInfoManagerMock } from "../../../../src/sessionInfo/__mocks__/SessionInfoManager";
@@ -130,47 +129,21 @@ const mockLocalStorage = (stored: Record<string, string>) => {
   });
 };
 
-/**
- * TODO: FIXME: Suggested improvement from Nic - just recording here for future
- * reference:
+jest.mock("@inrupt/oidc-client-ext");
 
- I really don't like tests results depending on the value of a global variable,
- that may introduce many side-effects. Now that I'm more familiar with jest than
- when I wrote these tests, I think I would approach it this way: I'd replace the
- whole jest.mock("@inrupt/oidc-client-ext", () => {...}; block with:
-
- jest.mock("@inrupt/oidc-client-ext");
-
- const defaultJwt = {
+const defaultJwt = {
   sub: "https://some.webid",
 };
 
- function mockOidcClient(jwt: any = defaultJwt): void {
+function mockOidcClient(jwt: any = defaultJwt): any {
   const mockedOidcClient = jest.requireMock("@inrupt/oidc-client-ext");
-  mockedOidcClient.generateJwkForDpop = jest.fn().mockResolvedValue(mockJWK);
+  mockedOidcClient.generateJwkForDpop = jest.fn().mockResolvedValue(mockJwk());
   mockedOidcClient.createDpopHeader = jest.fn().mockResolvedValue("someToken");
   mockedOidcClient.decodeJwt = jest.fn().mockResolvedValue(jwt);
+  mockedOidcClient.getDpopToken = mockTokenEndpointDpopResponse;
+  mockedOidcClient.getBearerToken = mockTokenEndpointBearerResponse;
+  return mockedOidcClient;
 }
- ```,
- and add a call to `mockOidcClient()` at the beginning of each test. For the
- tests where a different JWT value must be mocked, it can be set this way:
- `mockOidcClient({})` e.g. for an empty JWT. It may be possible to reduce
- overhead by grouping all tests sharing a same `oidc-client` setupd in the same
- `describe` block, and set `jest.beforeEach` to call `mockOidcClient` there, but
- I had issues with this before to redefine the mocked values in the blocks where
- I needed to override the default, so I don't know if that would work in this
- case.
- */
-jest.mock("@inrupt/oidc-client-ext", () => {
-  const { createDpopHeader } = jest.requireActual("@inrupt/oidc-client-ext");
-  return {
-    getDpopToken: async (): Promise<TokenEndpointResponse> =>
-      mockTokenEndpointDpopResponse(),
-    getBearerToken: async (): Promise<TokenEndpointResponse> =>
-      mockTokenEndpointBearerResponse(),
-    createDpopHeader,
-  };
-});
 
 function mockIssuerConfigFetcher(config: IIssuerConfig): IIssuerConfigFetcher {
   return {
@@ -278,6 +251,7 @@ describe("AuthCodeRedirectHandler", () => {
     });
 
     it("retrieves the code verifier from memory", async () => {
+      mockOidcClient();
       mockFetch(
         new Response("", {
           status: 200,
@@ -311,6 +285,7 @@ describe("AuthCodeRedirectHandler", () => {
     });
 
     it("Fails if a session was not retrieved", async () => {
+      mockOidcClient();
       mockFetch(
         new Response("", {
           status: 200,
@@ -329,6 +304,7 @@ describe("AuthCodeRedirectHandler", () => {
     // We use ts-ignore comments here only to access mock call arguments
     /* eslint-disable @typescript-eslint/ban-ts-comment */
     it("returns an authenticated bearer fetch by default", async () => {
+      mockOidcClient();
       /* eslint-disable  @typescript-eslint/no-explicit-any */
       mockLocalStorage({});
 
@@ -370,6 +346,7 @@ describe("AuthCodeRedirectHandler", () => {
     });
 
     it("returns an authenticated DPoP fetch if requested", async () => {
+      mockOidcClient();
       /* eslint-disable  @typescript-eslint/no-explicit-any */
       mockLocalStorage({});
 
@@ -414,6 +391,7 @@ describe("AuthCodeRedirectHandler", () => {
     });
 
     it("saves session information in storage on successful login", async () => {
+      mockOidcClient();
       /* eslint-disable  @typescript-eslint/no-explicit-any */
       mockLocalStorage({});
 
@@ -463,6 +441,7 @@ describe("AuthCodeRedirectHandler", () => {
     });
 
     it("preserves any query strings from the redirect URI", async () => {
+      mockOidcClient();
       /* eslint-disable  @typescript-eslint/no-explicit-any */
       mockLocalStorage({});
 
@@ -507,6 +486,7 @@ describe("AuthCodeRedirectHandler", () => {
     });
 
     it("returns the expiration time normalised to the current time", async () => {
+      mockOidcClient();
       const MOCK_TIMESTAMP = 10000;
       Date.now = jest
         .fn()
@@ -540,6 +520,7 @@ describe("AuthCodeRedirectHandler", () => {
   });
 
   it("stores information about the resource server cookie in local storage on successful authentication", async () => {
+    mockOidcClient();
     /* eslint-disable  @typescript-eslint/no-explicit-any */
     mockLocalStorage({});
 
@@ -592,6 +573,7 @@ describe("AuthCodeRedirectHandler", () => {
   });
 
   it("does not look the session endpoint up if the ESS cookie workaround has been disabled", async () => {
+    mockOidcClient();
     mockLocalStorage({
       "tmp-resource-server-session-enabled": "false",
     });
@@ -638,6 +620,7 @@ describe("AuthCodeRedirectHandler", () => {
   });
 
   it("store nothing if the resource server has no session endpoint", async () => {
+    mockOidcClient();
     mockLocalStorage({});
     // This mocks the fetch to the Resource Server session endpoint
     // Note: Currently, the endpoint only returns the WebID in plain/text, it could
@@ -672,6 +655,7 @@ describe("AuthCodeRedirectHandler", () => {
   });
 
   it("swallows the exception if the fetch to the session endpoint fails", async () => {
+    mockOidcClient();
     mockLocalStorage({});
     window.fetch = jest
       .fn()
@@ -706,6 +690,7 @@ describe("AuthCodeRedirectHandler", () => {
   });
 
   it("store nothing if the resource server does not recognize the user", async () => {
+    mockOidcClient();
     mockLocalStorage({});
     // This mocks the fetch to the Resource Server session endpoint
     // Note: Currently, the endpoint only returns the WebID in plain/text, it could
@@ -737,25 +722,5 @@ describe("AuthCodeRedirectHandler", () => {
         (await mockedStorage.get("tmp-resource-server-session-info")) ?? "{}"
       )
     ).toEqual({});
-  });
-});
-
-describe("exchangeDpopToken", () => {
-  it("requests a key-bound token", async () => {
-    const mockedIssuer = mockIssuer();
-    const tokens = await exchangeDpopToken(
-      "mySession",
-      mockedIssuer.issuer,
-      mockIssuerConfigFetcher(mockedIssuer),
-      mockClientRegistrar(mockClient()),
-      "some code",
-      "some pkce token",
-      "https://my.app/redirect"
-    );
-    expect(tokens.accessToken).toEqual(
-      mockTokenEndpointDpopResponse().accessToken
-    );
-    expect(tokens.idToken).toEqual(mockTokenEndpointDpopResponse().idToken);
-    expect(tokens.dpopJwk).toEqual(mockTokenEndpointDpopResponse().dpopJwk);
   });
 });

--- a/packages/browser/src/ClientAuthentication.ts
+++ b/packages/browser/src/ClientAuthentication.ts
@@ -38,6 +38,7 @@ import {
 } from "@inrupt/solid-client-authn-core";
 import { removeOidcQueryParam, validateIdToken } from "@inrupt/oidc-client-ext";
 import { KEY_CURRENT_SESSION } from "./constant";
+import { getJwks } from "./login/oidc/IssuerConfigFetcher";
 
 // TMP: This ensures that the HTTP requests will include any relevant cookie
 // that could have been set by the resource server.
@@ -157,8 +158,7 @@ export default class ClientAuthentication {
     );
 
     try {
-      const issuerResponse = await fetch(issuerConfig.jwksUri);
-      const jwks = await issuerResponse.json();
+      const jwks = await getJwks(issuerConfig);
       if (
         await validateIdToken(
           sessionInfo.idToken,

--- a/packages/browser/src/login/oidc/IssuerConfigFetcher.ts
+++ b/packages/browser/src/login/oidc/IssuerConfigFetcher.ts
@@ -127,6 +127,11 @@ const issuerConfigKeyMap: Record<
 };
 /* eslint-enable camelcase */
 
+export async function getJwks(issuerConfig: IIssuerConfig) {
+  const issuerResponse = await fetch(issuerConfig.jwksUri);
+  return issuerResponse.json();
+}
+
 function processConfig(
   config: Record<string, string | string[]>
 ): IIssuerConfig {


### PR DESCRIPTION
When receiving an ID token from the token endpoint, it is validated
(e.g. the signature is checked, and the issuer and audience are matched
against expected values).

Validating the ID token is something the client app should do anyways in OIDC. Validation already happens in the library we are using when requesting a bearer token (and in the node library as well), so it was only missing when requesting a DPoP-bound access token in the browser code. Validating the ID token is even more important with client access control, because the ID token's audience (the client id) is also present as the `client_id` claim in the access token, and it is going to be matched against the `acp:client` predicate to validate access control, so if the IdP doesn't use the right client id, access control won't be enforced as expected.

Note for reviewers: some of the code in this PR is refactoring not directly related to the feature that's being implemented, but that helps to implement the tests. Also, open question: this is technically a bugfix, but can also be a breaking change if using an IdP that issues an invalid ID token. Should it be a major or a patch release ? I'm leaning towards the latter, but I prefer to call it out.


# Checklist

- [X] All acceptance criteria are met.
- [x] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).