### PR TITLE
Discover support for solid-oidc in OIDC provider

### DIFF
--- a/packages/browser/__tests__/login/oidc/IssuerConfigFetcher.spec.ts
+++ b/packages/browser/__tests__/login/oidc/IssuerConfigFetcher.spec.ts
@@ -87,7 +87,7 @@ describe("IssuerConfigFetcher", () => {
         issuer: "https://example.com",
         // eslint-disable-next-line camelcase
         claim_types_supported: "oidc",
-        solid_oidc_supported: true,
+        solid_oidc_supported: "https://solidproject.org/TR/solid-oidc",
       })
     ) as unknown) as Response;
     const configFetcher = getIssuerConfigFetcher({
@@ -98,6 +98,8 @@ describe("IssuerConfigFetcher", () => {
     const fetchedConfig = await configFetcher.fetchConfig(
       "https://arbitrary.url"
     );
-    expect(fetchedConfig.solidOidcSupported).toBe(true);
+    expect(fetchedConfig.solidOidcSupported).toBe(
+      "https://solidproject.org/TR/solid-oidc"
+    );
   });
 });

--- a/packages/browser/__tests__/login/oidc/IssuerConfigFetcher.spec.ts
+++ b/packages/browser/__tests__/login/oidc/IssuerConfigFetcher.spec.ts
@@ -80,4 +80,24 @@ describe("IssuerConfigFetcher", () => {
       "[https://some.url] has an invalid configuration: Some error"
     );
   });
+
+  it("should return a config including the support for solid-oidc if present in the discovery profile", async () => {
+    const fetchResponse = (new NodeResponse(
+      JSON.stringify({
+        issuer: "https://example.com",
+        // eslint-disable-next-line camelcase
+        claim_types_supported: "oidc",
+        solid_oidc_supported: true,
+      })
+    ) as unknown) as Response;
+    const configFetcher = getIssuerConfigFetcher({
+      storageUtility: mockStorageUtility({}),
+    });
+    const mockFetch = jest.fn().mockResolvedValueOnce(fetchResponse);
+    window.fetch = mockFetch;
+    const fetchedConfig = await configFetcher.fetchConfig(
+      "https://arbitrary.url"
+    );
+    expect(fetchedConfig.solidOidcSupported).toBe(true);
+  });
 });

--- a/packages/browser/src/login/oidc/IssuerConfigFetcher.ts
+++ b/packages/browser/src/login/oidc/IssuerConfigFetcher.ts
@@ -124,6 +124,9 @@ const issuerConfigKeyMap: Record<
     toKey: "opTosUri",
     convertToUrl: true,
   },
+  solid_oidc_supported: {
+    toKey: "solidOidcSupported",
+  },
 };
 /* eslint-enable camelcase */
 

--- a/packages/core/src/login/oidc/IIssuerConfig.ts
+++ b/packages/core/src/login/oidc/IIssuerConfig.ts
@@ -67,4 +67,5 @@ export interface IIssuerConfig {
   requireRequestUriRegistration?: boolean;
   opPolicyUri?: string;
   opTosUri?: string;
+  solidOidcSupported?: string;
 }

--- a/packages/core/src/login/oidc/IIssuerConfig.ts
+++ b/packages/core/src/login/oidc/IIssuerConfig.ts
@@ -67,5 +67,5 @@ export interface IIssuerConfig {
   requireRequestUriRegistration?: boolean;
   opPolicyUri?: string;
   opTosUri?: string;
-  solidOidcSupported?: boolean;
+  solidOidcSupported?: "https://solidproject.org/TR/solid-oidc";
 }

--- a/packages/core/src/login/oidc/IIssuerConfig.ts
+++ b/packages/core/src/login/oidc/IIssuerConfig.ts
@@ -67,5 +67,5 @@ export interface IIssuerConfig {
   requireRequestUriRegistration?: boolean;
   opPolicyUri?: string;
   opTosUri?: string;
-  solidOidcSupported?: string;
+  solidOidcSupported?: boolean;
 }

--- a/packages/node/src/login/oidc/IssuerConfigFetcher.spec.ts
+++ b/packages/node/src/login/oidc/IssuerConfigFetcher.spec.ts
@@ -161,4 +161,20 @@ describe("IssuerConfigFetcher", () => {
       "Issuer metadata is missing supported subject types:"
     );
   });
+
+  it("should return a config including the support for solid-oidc if present in the discovery profile", async () => {
+    const { Issuer } = jest.requireMock("openid-client");
+    const mockedIssuerConfig = mockIssuerMetadata({
+      solid_oidc_supported: true,
+    });
+    Issuer.discover = jest.fn().mockResolvedValueOnce({
+      metadata: mockedIssuerConfig,
+    });
+
+    const configFetcher = getIssuerConfigFetcher({
+      storageUtility: mockStorageUtility({}),
+    });
+    const fetchedConfig = await configFetcher.fetchConfig("https://my.idp/");
+    expect(fetchedConfig.solidOidcSupported).toBe(true);
+  });
 });

--- a/packages/node/src/login/oidc/IssuerConfigFetcher.spec.ts
+++ b/packages/node/src/login/oidc/IssuerConfigFetcher.spec.ts
@@ -165,7 +165,7 @@ describe("IssuerConfigFetcher", () => {
   it("should return a config including the support for solid-oidc if present in the discovery profile", async () => {
     const { Issuer } = jest.requireMock("openid-client");
     const mockedIssuerConfig = mockIssuerMetadata({
-      solid_oidc_supported: true,
+      solid_oidc_supported: "https://solidproject.org/TR/solid-oidc",
     });
     Issuer.discover = jest.fn().mockResolvedValueOnce({
       metadata: mockedIssuerConfig,
@@ -175,6 +175,8 @@ describe("IssuerConfigFetcher", () => {
       storageUtility: mockStorageUtility({}),
     });
     const fetchedConfig = await configFetcher.fetchConfig("https://my.idp/");
-    expect(fetchedConfig.solidOidcSupported).toBe(true);
+    expect(fetchedConfig.solidOidcSupported).toBe(
+      "https://solidproject.org/TR/solid-oidc"
+    );
   });
 });

--- a/packages/node/src/login/oidc/IssuerConfigFetcher.ts
+++ b/packages/node/src/login/oidc/IssuerConfigFetcher.ts
@@ -102,7 +102,9 @@ export function configFromIssuerMetadata(
     responseTypesSupported: metadata.response_types_supported as
       | string[]
       | undefined,
-    solidOidcSupported: metadata.solid_oidc_supported as boolean | undefined,
+    solidOidcSupported: metadata.solid_oidc_supported as
+      | "https://solidproject.org/TR/solid-oidc"
+      | undefined,
   };
 }
 

--- a/packages/node/src/login/oidc/IssuerConfigFetcher.ts
+++ b/packages/node/src/login/oidc/IssuerConfigFetcher.ts
@@ -102,6 +102,7 @@ export function configFromIssuerMetadata(
     responseTypesSupported: metadata.response_types_supported as
       | string[]
       | undefined,
+    solidOidcSupported: metadata.solid_oidc_supported as string | undefined,
   };
 }
 

--- a/packages/node/src/login/oidc/IssuerConfigFetcher.ts
+++ b/packages/node/src/login/oidc/IssuerConfigFetcher.ts
@@ -102,7 +102,7 @@ export function configFromIssuerMetadata(
     responseTypesSupported: metadata.response_types_supported as
       | string[]
       | undefined,
-    solidOidcSupported: metadata.solid_oidc_supported as string | undefined,
+    solidOidcSupported: metadata.solid_oidc_supported as boolean | undefined,
   };
 }
 


### PR DESCRIPTION
This is the preliminary step to figure out how to interact with a Solid
Identity Provider: when fetching its description as part of the OIDC
discovery process (see
https://openid.net/specs/openid-connect-discovery-1_0.html for more
informaiton), support for Solid-OIDC is specified with the
`solid_oidc_supported` key, as specified in
https://solid.github.io/authentication-panel/solid-oidc/#discovery.

Additional PRs will take this configuration into account to perform DCR
or present a client WebID, the latter being only supported by Solid-OIDC
conformant OIDC providers.

# Checklist

- [X] All acceptance criteria are met.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).