### PR TITLE
Client WebID support for the browser login

### DIFF
--- a/packages/browser/__tests__/login/oidc/IssuerConfigFetcher.spec.ts
+++ b/packages/browser/__tests__/login/oidc/IssuerConfigFetcher.spec.ts
@@ -87,7 +87,7 @@ describe("IssuerConfigFetcher", () => {
         issuer: "https://example.com",
         // eslint-disable-next-line camelcase
         claim_types_supported: "oidc",
-        solid_oidc_supported: true,
+        solid_oidc_supported: "https://solidproject.org/TR/solid-oidc",
       })
     ) as unknown) as Response;
     const configFetcher = getIssuerConfigFetcher({
@@ -98,6 +98,8 @@ describe("IssuerConfigFetcher", () => {
     const fetchedConfig = await configFetcher.fetchConfig(
       "https://arbitrary.url"
     );
-    expect(fetchedConfig.solidOidcSupported).toBe(true);
+    expect(fetchedConfig.solidOidcSupported).toBe(
+      "https://solidproject.org/TR/solid-oidc"
+    );
   });
 });

--- a/packages/browser/__tests__/login/oidc/IssuerConfigFetcher.spec.ts
+++ b/packages/browser/__tests__/login/oidc/IssuerConfigFetcher.spec.ts
@@ -80,4 +80,24 @@ describe("IssuerConfigFetcher", () => {
       "[https://some.url] has an invalid configuration: Some error"
     );
   });
+
+  it("should return a config including the support for solid-oidc if present in the discovery profile", async () => {
+    const fetchResponse = (new NodeResponse(
+      JSON.stringify({
+        issuer: "https://example.com",
+        // eslint-disable-next-line camelcase
+        claim_types_supported: "oidc",
+        solid_oidc_supported: true,
+      })
+    ) as unknown) as Response;
+    const configFetcher = getIssuerConfigFetcher({
+      storageUtility: mockStorageUtility({}),
+    });
+    const mockFetch = jest.fn().mockResolvedValueOnce(fetchResponse);
+    window.fetch = mockFetch;
+    const fetchedConfig = await configFetcher.fetchConfig(
+      "https://arbitrary.url"
+    );
+    expect(fetchedConfig.solidOidcSupported).toBe(true);
+  });
 });

--- a/packages/browser/__tests__/login/oidc/OidcLoginHandler.spec.ts
+++ b/packages/browser/__tests__/login/oidc/OidcLoginHandler.spec.ts
@@ -148,7 +148,7 @@ describe("OidcLoginHandler", () => {
       clientRegistrar: new ClientRegistrar(mockedEmptyStorage),
       issuerConfigFetcher: mockIssuerConfigFetcher({
         ...IssuerConfigFetcherFetchConfigResponse,
-        solidOidcSupported: false,
+        solidOidcSupported: undefined,
       }),
     });
 
@@ -199,7 +199,7 @@ describe("OidcLoginHandler", () => {
       clientRegistrar: new ClientRegistrar(mockedStorage),
       issuerConfigFetcher: mockIssuerConfigFetcher({
         ...IssuerConfigFetcherFetchConfigResponse,
-        solidOidcSupported: true,
+        solidOidcSupported: "https://solidproject.org/TR/solid-oidc",
       }),
     });
 

--- a/packages/browser/src/login/oidc/IssuerConfigFetcher.ts
+++ b/packages/browser/src/login/oidc/IssuerConfigFetcher.ts
@@ -124,6 +124,9 @@ const issuerConfigKeyMap: Record<
     toKey: "opTosUri",
     convertToUrl: true,
   },
+  solid_oidc_supported: {
+    toKey: "solidOidcSupported",
+  },
 };
 /* eslint-enable camelcase */
 

--- a/packages/browser/src/login/oidc/OidcLoginHandler.ts
+++ b/packages/browser/src/login/oidc/OidcLoginHandler.ts
@@ -64,7 +64,9 @@ async function handleRegistration(
 ): Promise<IClient> {
   if (
     options.clientId === undefined ||
-    (issuerConfig.solidOidcSupported === false && isValidUrl(options.clientId))
+    (issuerConfig.solidOidcSupported !==
+      "https://solidproject.org/TR/solid-oidc" &&
+      isValidUrl(options.clientId))
   ) {
     // If no client_id is provided, the client must go through DCR. Whether the
     // Identity Provider supports Solid-OIDC or not will only change the value

--- a/packages/browser/src/login/oidc/OidcLoginHandler.ts
+++ b/packages/browser/src/login/oidc/OidcLoginHandler.ts
@@ -68,14 +68,10 @@ async function handleRegistration(
       "https://solidproject.org/TR/solid-oidc" &&
       isValidUrl(options.clientId))
   ) {
-    // If no client_id is provided, the client must go through DCR. Whether the
-    // Identity Provider supports Solid-OIDC or not will only change the value
-    // of the provided client_id.
-    // The tricky case is if a client WebID (here, a client_id looking like an IRI)
-    // is provided, but the Identity Provider does not support Solid-OIDC. In this
-    // case, we must discard the provided client_id, and still go through dynamic
-    // client registration, because the Identity Provider will not recognize the
-    // provided client_id.
+    // If no client_id is provided, the client must go through DCR.
+    // If a client_id is provided and it looks like a URI, yet the Identity Provider
+    // does *not* support Solid-OIDC, then we also perform DCR (and discard the
+    // provided client_id).
     return clientRegistrar.getClient(
       {
         sessionId: options.sessionId,
@@ -85,9 +81,10 @@ async function handleRegistration(
       issuerConfig
     );
   }
-  // If the Identity Provider is Solid-OIDC compliant, or if the client_id isn't
-  // an IRI and therefore has been previously registered to the IdP, the client
-  // registration information just need to be stored to be retrieved after redirect.
+  // If a client_id was provided, and the Identity Provider is Solid-OIDC compliant,
+  // or it is not compliant but the client_id isn't an IRI (we assume it has already
+  // been registered with the IdP), then the client registration information needs
+  // to be stored so that it can be retrieved later after redirect.
   await storageUtility.setForUser(options.sessionId, {
     clientId: options.clientId,
   });

--- a/packages/core/src/login/oidc/IIssuerConfig.ts
+++ b/packages/core/src/login/oidc/IIssuerConfig.ts
@@ -67,4 +67,5 @@ export interface IIssuerConfig {
   requireRequestUriRegistration?: boolean;
   opPolicyUri?: string;
   opTosUri?: string;
+  solidOidcSupported?: string;
 }

--- a/packages/core/src/login/oidc/IIssuerConfig.ts
+++ b/packages/core/src/login/oidc/IIssuerConfig.ts
@@ -67,5 +67,5 @@ export interface IIssuerConfig {
   requireRequestUriRegistration?: boolean;
   opPolicyUri?: string;
   opTosUri?: string;
-  solidOidcSupported?: boolean;
+  solidOidcSupported?: "https://solidproject.org/TR/solid-oidc";
 }

--- a/packages/core/src/login/oidc/IIssuerConfig.ts
+++ b/packages/core/src/login/oidc/IIssuerConfig.ts
@@ -67,5 +67,5 @@ export interface IIssuerConfig {
   requireRequestUriRegistration?: boolean;
   opPolicyUri?: string;
   opTosUri?: string;
-  solidOidcSupported?: string;
+  solidOidcSupported?: boolean;
 }

--- a/packages/node/src/login/oidc/IssuerConfigFetcher.spec.ts
+++ b/packages/node/src/login/oidc/IssuerConfigFetcher.spec.ts
@@ -161,4 +161,20 @@ describe("IssuerConfigFetcher", () => {
       "Issuer metadata is missing supported subject types:"
     );
   });
+
+  it("should return a config including the support for solid-oidc if present in the discovery profile", async () => {
+    const { Issuer } = jest.requireMock("openid-client");
+    const mockedIssuerConfig = mockIssuerMetadata({
+      solid_oidc_supported: true,
+    });
+    Issuer.discover = jest.fn().mockResolvedValueOnce({
+      metadata: mockedIssuerConfig,
+    });
+
+    const configFetcher = getIssuerConfigFetcher({
+      storageUtility: mockStorageUtility({}),
+    });
+    const fetchedConfig = await configFetcher.fetchConfig("https://my.idp/");
+    expect(fetchedConfig.solidOidcSupported).toBe(true);
+  });
 });

--- a/packages/node/src/login/oidc/IssuerConfigFetcher.spec.ts
+++ b/packages/node/src/login/oidc/IssuerConfigFetcher.spec.ts
@@ -165,7 +165,7 @@ describe("IssuerConfigFetcher", () => {
   it("should return a config including the support for solid-oidc if present in the discovery profile", async () => {
     const { Issuer } = jest.requireMock("openid-client");
     const mockedIssuerConfig = mockIssuerMetadata({
-      solid_oidc_supported: true,
+      solid_oidc_supported: "https://solidproject.org/TR/solid-oidc",
     });
     Issuer.discover = jest.fn().mockResolvedValueOnce({
       metadata: mockedIssuerConfig,
@@ -175,6 +175,8 @@ describe("IssuerConfigFetcher", () => {
       storageUtility: mockStorageUtility({}),
     });
     const fetchedConfig = await configFetcher.fetchConfig("https://my.idp/");
-    expect(fetchedConfig.solidOidcSupported).toBe(true);
+    expect(fetchedConfig.solidOidcSupported).toBe(
+      "https://solidproject.org/TR/solid-oidc"
+    );
   });
 });

--- a/packages/node/src/login/oidc/IssuerConfigFetcher.ts
+++ b/packages/node/src/login/oidc/IssuerConfigFetcher.ts
@@ -102,7 +102,9 @@ export function configFromIssuerMetadata(
     responseTypesSupported: metadata.response_types_supported as
       | string[]
       | undefined,
-    solidOidcSupported: metadata.solid_oidc_supported as boolean | undefined,
+    solidOidcSupported: metadata.solid_oidc_supported as
+      | "https://solidproject.org/TR/solid-oidc"
+      | undefined,
   };
 }
 

--- a/packages/node/src/login/oidc/IssuerConfigFetcher.ts
+++ b/packages/node/src/login/oidc/IssuerConfigFetcher.ts
@@ -102,6 +102,7 @@ export function configFromIssuerMetadata(
     responseTypesSupported: metadata.response_types_supported as
       | string[]
       | undefined,
+    solidOidcSupported: metadata.solid_oidc_supported as string | undefined,
   };
 }
 

--- a/packages/node/src/login/oidc/IssuerConfigFetcher.ts
+++ b/packages/node/src/login/oidc/IssuerConfigFetcher.ts
@@ -102,7 +102,7 @@ export function configFromIssuerMetadata(
     responseTypesSupported: metadata.response_types_supported as
       | string[]
       | undefined,
-    solidOidcSupported: metadata.solid_oidc_supported as string | undefined,
+    solidOidcSupported: metadata.solid_oidc_supported as boolean | undefined,
   };
 }
 


### PR DESCRIPTION
This adds support for client WebID in the login process. There are a
certain number of configurations to consider: either the IdP supports
Solid-OIDC or not, and either the client provides a client_id or not.

If no client_id is provided, dynamic client registration is required,
regardless of the IdP. Most clients fall into this category today. If a
client ID is provided and it doesn't look like an IRI, or if it is an
IRI and the IdP supports Solid-OIDC, the client can be considered
already registered and there is no additional interaction required.

The library only has to be careful when the client provides a client
WebID, but the IdP soes not support Solid-OIDC.In that case, presenting
the client_id to the IdP would fail, because it would not look up the
app profile, but expect the given client_id to have previously been
registered. In that case, the client must go through DCR, and will be
considered like a public client by the resource server.

Note to reviewers: This commit only applies to `@inrupt/solid-client-authn-browser`.
The node equivalent code will be submitted in a subsequent commit.

# Checklist

- [X] All acceptance criteria are met.
- [ ] Relevant documentation, if any, has been written/updated.
- [ ] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).