### PR TITLE
Normalize redirect IRI in node package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,19 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased
 
+### New features
+
 ### Bugfixes
 
 #### browser
 
 - The ID token is now validated when asking for DPoP-bound tokens, and not only when asking for a Bearer token.
+
+#### node
+
+- The OIDC parameters added to the redirect IRI by the Solid Identity Provider 
+are no longer included in the redirect IRI provided at the token endpoint.
+- The provided redirect IRI is now normalized.
 
 The following sections document changes that have been released already:
 

--- a/packages/node/src/ClientAuthentication.spec.ts
+++ b/packages/node/src/ClientAuthentication.spec.ts
@@ -79,6 +79,20 @@ describe("ClientAuthentication", () => {
       });
     });
 
+    it("normalizes the redirect IRI", async () => {
+      const clientAuthn = getClientAuthentication();
+      await clientAuthn.login("mySession", {
+        clientId: "coolApp",
+        redirectUrl: "https://coolapp.com",
+        oidcIssuer: "https://idp.com",
+      });
+      expect(defaultMocks.loginHandler.handle).toHaveBeenCalledWith(
+        expect.objectContaining({
+          redirectUrl: "https://coolapp.com/",
+        })
+      );
+    });
+
     it("may return after login if no redirect is required", async () => {
       const mockedAuthFetch = jest.fn();
       const mockedLoginHandler: jest.Mocked<ILoginHandler> = {

--- a/packages/node/src/ClientAuthentication.ts
+++ b/packages/node/src/ClientAuthentication.ts
@@ -55,13 +55,14 @@ export default class ClientAuthentication {
     sessionId: string,
     options: ILoginInputOptions
   ): Promise<ISessionInfo | undefined> => {
-    const { redirectUrl } = options;
     // Keep track of the session ID
     await this.sessionInfoManager.register(sessionId);
     const loginReturn = await this.loginHandler.handle({
       sessionId,
       oidcIssuer: options.oidcIssuer,
-      redirectUrl,
+      redirectUrl: options.redirectUrl
+        ? new URL(options.redirectUrl).href
+        : undefined,
       clientId: options.clientId,
       clientSecret: options.clientSecret,
       clientName: options.clientName ?? options.clientId,

--- a/packages/node/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
+++ b/packages/node/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
@@ -311,6 +311,7 @@ describe("AuthCodeRedirectHandler", () => {
       expect(callback).toHaveBeenCalledWith(
         "https://my.app/redirect",
         { code: "someCode", state: "someState" },
+        // The code verifier comes from the mocked storage.
         { code_verifier: "some code verifier", state: "someState" },
         expect.anything()
       );

--- a/packages/node/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
+++ b/packages/node/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
@@ -196,7 +196,7 @@ describe("AuthCodeRedirectHandler", () => {
       },
     });
 
-  const setupOidcClientMock = (tokenSet: TokenSet) => {
+  const setupOidcClientMock = (tokenSet?: TokenSet, callback?: any) => {
     const { Issuer } = jest.requireMock("openid-client");
     function clientConstructor() {
       // this is untyped, which makes TS complain
@@ -209,18 +209,18 @@ describe("AuthCodeRedirectHandler", () => {
       // this is untyped, which makes TS complain
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
-      this.callback = jest.fn().mockResolvedValueOnce(tokenSet);
+      this.callback = callback ?? jest.fn().mockResolvedValueOnce(tokenSet);
     }
     const mockedIssuer = {
       metadata: mockDefaultIssuerConfig(),
       Client: clientConstructor,
     };
     Issuer.mockReturnValueOnce(mockedIssuer);
+    return mockedIssuer;
   };
 
-  const setupDefaultOidcClientMock = () => {
+  const setupDefaultOidcClientMock = () =>
     setupOidcClientMock(mockDpopTokens());
-  };
 
   describe("handle", () => {
     it("throws on non-redirect URL", async () => {
@@ -290,6 +290,29 @@ describe("AuthCodeRedirectHandler", () => {
       await result.fetch("https://some.url");
       expect(mockedFetch.mock.calls[0][1].headers.Authorization).toContain(
         "Bearer"
+      );
+    });
+
+    it("cleans up the redirect IRI from the OIDC parameters", async () => {
+      // This function represents the openid-client callback
+      const callback = jest.fn().mockResolvedValueOnce(mockDpopTokens());
+      setupOidcClientMock(undefined, callback);
+      const mockedStorage = mockDefaultRedirectStorage();
+
+      const authCodeRedirectHandler = getAuthCodeRedirectHandler({
+        storageUtility: mockedStorage,
+        sessionInfoManager: mockSessionInfoManager(mockedStorage),
+      });
+
+      await authCodeRedirectHandler.handle(
+        "https://my.app/redirect?code=someCode&state=someState"
+      );
+
+      expect(callback).toHaveBeenCalledWith(
+        "https://my.app/redirect",
+        { code: "someCode", state: "someState" },
+        { code_verifier: "some code verifier", state: "someState" },
+        expect.anything()
       );
     });
 

--- a/packages/node/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
+++ b/packages/node/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
@@ -113,6 +113,8 @@ export class AuthCodeRedirectHandler implements IRedirectHandler {
     const url = new URL(inputRedirectUrl);
     // The type assertion is ok, because we checked in canHandle for the presence of a state
     const oauthState = url.searchParams.get("state") as string;
+    url.searchParams.delete("code");
+    url.searchParams.delete("state");
 
     const sessionId = await getSessionIdFromOauthState(
       this.storageUtility,
@@ -150,13 +152,13 @@ export class AuthCodeRedirectHandler implements IRedirectHandler {
     if (oidcContext.dpop) {
       dpopKey = await JWK.generate("EC", "P-256");
       tokenSet = await client.callback(
-        inputRedirectUrl,
+        url.href,
         params,
         { code_verifier: oidcContext.codeVerifier, state: oauthState },
         { DPoP: dpopKey.toJWK(true) }
       );
     } else {
-      tokenSet = await client.callback(inputRedirectUrl, params, {
+      tokenSet = await client.callback(url.href, params, {
         code_verifier: oidcContext.codeVerifier,
         state: oauthState,
       });


### PR DESCRIPTION
- The IRI wasn't normalized on input
- The IRI parameters added by the Solid Identity Provider were not
removed from the redirect_iri specified at the token endpoint. This was causing a mismatch between the provided `redirect_iri` and the expected value, equal to the `redirect_iri` provided during registration.

These two bugs combined could cause the behaviour observed by @jeff-zucker in https://github.com/solid/node-solid-server/issues/1580.

- [X] I've added a unit test to test for potential regressions of this bug.
- [X] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).