### PR TITLE
Handle Solid-OIDC client WebID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ The following sections document changes that have been released already:
 
 ## 1.7.2 - 2021-03-10
 
+#### browser and node
+
+- A client WebID can now be provided as part of the `login` options. The library will
+check for compliance of the chosen Solid Identity Provider, and go use the provided 
+client WebID or go through Dynamic Client Registration accordingly.
+
 ### Bugfixes
 
 #### browser

--- a/packages/browser/__tests__/login/oidc/OidcLoginHandler.spec.ts
+++ b/packages/browser/__tests__/login/oidc/OidcLoginHandler.spec.ts
@@ -148,7 +148,7 @@ describe("OidcLoginHandler", () => {
       clientRegistrar: new ClientRegistrar(mockedEmptyStorage),
       issuerConfigFetcher: mockIssuerConfigFetcher({
         ...IssuerConfigFetcherFetchConfigResponse,
-        solidOidcSupported: false,
+        solidOidcSupported: undefined,
       }),
     });
 
@@ -199,7 +199,7 @@ describe("OidcLoginHandler", () => {
       clientRegistrar: new ClientRegistrar(mockedStorage),
       issuerConfigFetcher: mockIssuerConfigFetcher({
         ...IssuerConfigFetcherFetchConfigResponse,
-        solidOidcSupported: true,
+        solidOidcSupported: "https://solidproject.org/TR/solid-oidc",
       }),
     });
 

--- a/packages/browser/src/login/oidc/IssuerConfigFetcher.ts
+++ b/packages/browser/src/login/oidc/IssuerConfigFetcher.ts
@@ -130,7 +130,8 @@ const issuerConfigKeyMap: Record<
 };
 /* eslint-enable camelcase */
 
-export async function getJwks(issuerConfig: IIssuerConfig) {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export async function getJwks(issuerConfig: IIssuerConfig): Promise<any> {
   const issuerResponse = await fetch(issuerConfig.jwksUri);
   return issuerResponse.json();
 }

--- a/packages/browser/src/login/oidc/OidcLoginHandler.ts
+++ b/packages/browser/src/login/oidc/OidcLoginHandler.ts
@@ -64,7 +64,9 @@ async function handleRegistration(
 ): Promise<IClient> {
   if (
     options.clientId === undefined ||
-    (issuerConfig.solidOidcSupported === false && isValidUrl(options.clientId))
+    (issuerConfig.solidOidcSupported !==
+      "https://solidproject.org/TR/solid-oidc" &&
+      isValidUrl(options.clientId))
   ) {
     // If no client_id is provided, the client must go through DCR. Whether the
     // Identity Provider supports Solid-OIDC or not will only change the value

--- a/packages/browser/src/login/oidc/OidcLoginHandler.ts
+++ b/packages/browser/src/login/oidc/OidcLoginHandler.ts
@@ -40,70 +40,8 @@ import {
   IStorageUtility,
   ConfigurationError,
   LoginResult,
+  handleRegistration,
 } from "@inrupt/solid-client-authn-core";
-
-import { IClient } from "@inrupt/oidc-client-ext";
-
-function isValidUrl(url: string): boolean {
-  try {
-    // Here, the URL constructor is just called to parse the given string and
-    // verify if it is a well-formed IRI.
-    // eslint-disable-next-line no-new
-    new URL(url);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-async function handleRegistration(
-  options: ILoginOptions,
-  issuerConfig: IIssuerConfig,
-  storageUtility: IStorageUtility,
-  clientRegistrar: IClientRegistrar
-): Promise<IClient> {
-  if (
-    options.clientId === undefined ||
-    (issuerConfig.solidOidcSupported !==
-      "https://solidproject.org/TR/solid-oidc" &&
-      isValidUrl(options.clientId))
-  ) {
-    // If no client_id is provided, the client must go through DCR.
-    // If a client_id is provided and it looks like a URI, yet the Identity Provider
-    // does *not* support Solid-OIDC, then we also perform DCR (and discard the
-    // provided client_id).
-    return clientRegistrar.getClient(
-      {
-        sessionId: options.sessionId,
-        clientName: options.clientName,
-        redirectUrl: options.redirectUrl,
-      },
-      issuerConfig
-    );
-  }
-  // If a client_id was provided, and the Identity Provider is Solid-OIDC compliant,
-  // or it is not compliant but the client_id isn't an IRI (we assume it has already
-  // been registered with the IdP), then the client registration information needs
-  // to be stored so that it can be retrieved later after redirect.
-  await storageUtility.setForUser(options.sessionId, {
-    clientId: options.clientId,
-  });
-  if (options.clientSecret) {
-    await storageUtility.setForUser(options.sessionId, {
-      clientSecret: options.clientSecret,
-    });
-  }
-  if (options.clientName) {
-    await storageUtility.setForUser(options.sessionId, {
-      clientName: options.clientName,
-    });
-  }
-  return {
-    clientId: options.clientId,
-    clientSecret: options.clientSecret,
-    clientName: options.clientName,
-  };
-}
 
 function hasIssuer(
   options: ILoginOptions

--- a/packages/browser/src/login/oidc/OidcLoginHandler.ts
+++ b/packages/browser/src/login/oidc/OidcLoginHandler.ts
@@ -68,14 +68,10 @@ async function handleRegistration(
       "https://solidproject.org/TR/solid-oidc" &&
       isValidUrl(options.clientId))
   ) {
-    // If no client_id is provided, the client must go through DCR. Whether the
-    // Identity Provider supports Solid-OIDC or not will only change the value
-    // of the provided client_id.
-    // The tricky case is if a client WebID (here, a client_id looking like an IRI)
-    // is provided, but the Identity Provider does not support Solid-OIDC. In this
-    // case, we must discard the provided client_id, and still go through dynamic
-    // client registration, because the Identity Provider will not recognize the
-    // provided client_id.
+    // If no client_id is provided, the client must go through DCR.
+    // If a client_id is provided and it looks like a URI, yet the Identity Provider
+    // does *not* support Solid-OIDC, then we also perform DCR (and discard the
+    // provided client_id).
     return clientRegistrar.getClient(
       {
         sessionId: options.sessionId,
@@ -85,9 +81,10 @@ async function handleRegistration(
       issuerConfig
     );
   }
-  // If the Identity Provider is Solid-OIDC compliant, or if the client_id isn't
-  // an IRI and therefore has been previously registered to the IdP, the client
-  // registration information just need to be stored to be retrieved after redirect.
+  // If a client_id was provided, and the Identity Provider is Solid-OIDC compliant,
+  // or it is not compliant but the client_id isn't an IRI (we assume it has already
+  // been registered with the IdP), then the client registration information needs
+  // to be stored so that it can be retrieved later after redirect.
   await storageUtility.setForUser(options.sessionId, {
     clientId: options.clientId,
   });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -52,6 +52,7 @@ export { IIssuerConfig } from "./login/oidc/IIssuerConfig";
 export {
   IClientRegistrar,
   IClientRegistrarOptions,
+  handleRegistration,
 } from "./login/oidc/IClientRegistrar";
 export { IClient } from "./login/oidc/IClient";
 export { issuerConfigSchema } from "./login/oidc/issuerConfigSchema";

--- a/packages/core/src/login/oidc/IClientRegistrar.test.ts
+++ b/packages/core/src/login/oidc/IClientRegistrar.test.ts
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2021 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { it, describe, expect } from "@jest/globals";
+import { IIssuerConfig, ILoginOptions, IStorageUtility } from "../..";
+import { handleRegistration } from "./IClientRegistrar";
+
+describe("handleRegistration", () => {
+  it("should perform DCR if a client WebID is provided, but the target IdP does not support Solid-OIDC", async () => {
+    const options: ILoginOptions = {
+      clientId: "https://some.app/registration#app",
+      sessionId: "some session",
+      tokenType: "DPoP",
+    };
+    const clientRegistrar = {
+      getClient: jest.fn(),
+    };
+    await handleRegistration(
+      options,
+      { solidOidcSupported: undefined } as IIssuerConfig,
+      (jest.fn() as unknown) as IStorageUtility,
+      clientRegistrar
+    );
+    expect(clientRegistrar.getClient).toHaveBeenCalled();
+  });
+
+  it("should perform DCR if no client ID is provided", async () => {
+    const options: ILoginOptions = {
+      sessionId: "some session",
+      tokenType: "DPoP",
+    };
+    const clientRegistrar = {
+      getClient: jest.fn(),
+    };
+    await handleRegistration(
+      options,
+      { solidOidcSupported: undefined } as IIssuerConfig,
+      (jest.fn() as unknown) as IStorageUtility,
+      clientRegistrar
+    );
+    expect(clientRegistrar.getClient).toHaveBeenCalled();
+  });
+
+  it("should store provided client WebID if one provided and the Identity Provider supports Solid-OIDC", async () => {
+    const options: ILoginOptions = {
+      sessionId: "some session",
+      tokenType: "DPoP",
+      clientId: "https://my.app/registration#app",
+    };
+    const clientRegistrar = {
+      getClient: jest.fn(),
+    };
+    const storageUtility: IStorageUtility = ({
+      setForUser: jest.fn(),
+    } as unknown) as IStorageUtility;
+    await handleRegistration(
+      options,
+      {
+        solidOidcSupported: "https://solidproject.org/TR/solid-oidc",
+      } as IIssuerConfig,
+      storageUtility,
+      clientRegistrar
+    );
+    expect(clientRegistrar.getClient).not.toHaveBeenCalled();
+    expect(storageUtility.setForUser).toHaveBeenCalled();
+  });
+
+  it("should store provided client registration information when the client ID is not a WebID", async () => {
+    const options: ILoginOptions = {
+      sessionId: "some session",
+      tokenType: "DPoP",
+      clientId: "some statically registered client ID",
+      clientName: "some statically registered client name",
+      clientSecret: "some statically registered client secret",
+    };
+    const clientRegistrar = {
+      getClient: jest.fn(),
+    };
+    const storageUtility: IStorageUtility = ({
+      setForUser: jest.fn(),
+    } as unknown) as IStorageUtility;
+    await handleRegistration(
+      options,
+      {
+        solidOidcSupported: undefined,
+      } as IIssuerConfig,
+      storageUtility,
+      clientRegistrar
+    );
+    expect(clientRegistrar.getClient).not.toHaveBeenCalled();
+    expect(storageUtility.setForUser).toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/login/oidc/IClientRegistrar.ts
+++ b/packages/core/src/login/oidc/IClientRegistrar.ts
@@ -24,6 +24,8 @@
  * @packageDocumentation
  */
 
+import IStorageUtility from "../../storage/IStorageUtility";
+import ILoginOptions from "../ILoginOptions";
 import { IClient } from "./IClient";
 import { IIssuerConfig } from "./IIssuerConfig";
 
@@ -42,4 +44,65 @@ export interface IClientRegistrar {
     options: IClientRegistrarOptions,
     issuerConfig: IIssuerConfig
   ): Promise<IClient>;
+}
+
+function isValidUrl(url: string): boolean {
+  try {
+    // Here, the URL constructor is just called to parse the given string and
+    // verify if it is a well-formed IRI.
+    // eslint-disable-next-line no-new
+    new URL(url);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function handleRegistration(
+  options: ILoginOptions,
+  issuerConfig: IIssuerConfig,
+  storageUtility: IStorageUtility,
+  clientRegistrar: IClientRegistrar
+): Promise<IClient> {
+  if (
+    options.clientId === undefined ||
+    (issuerConfig.solidOidcSupported !==
+      "https://solidproject.org/TR/solid-oidc" &&
+      isValidUrl(options.clientId))
+  ) {
+    // If no client_id is provided, the client must go through DCR.
+    // If a client_id is provided and it looks like a URI, yet the Identity Provider
+    // does *not* support Solid-OIDC, then we also perform DCR (and discard the
+    // provided client_id).
+    return clientRegistrar.getClient(
+      {
+        sessionId: options.sessionId,
+        clientName: options.clientName,
+        redirectUrl: options.redirectUrl,
+      },
+      issuerConfig
+    );
+  }
+  // If a client_id was provided, and the Identity Provider is Solid-OIDC compliant,
+  // or it is not compliant but the client_id isn't an IRI (we assume it has already
+  // been registered with the IdP), then the client registration information needs
+  // to be stored so that it can be retrieved later after redirect.
+  await storageUtility.setForUser(options.sessionId, {
+    clientId: options.clientId,
+  });
+  if (options.clientSecret) {
+    await storageUtility.setForUser(options.sessionId, {
+      clientSecret: options.clientSecret,
+    });
+  }
+  if (options.clientName) {
+    await storageUtility.setForUser(options.sessionId, {
+      clientName: options.clientName,
+    });
+  }
+  return {
+    clientId: options.clientId,
+    clientSecret: options.clientSecret,
+    clientName: options.clientName,
+  };
 }

--- a/packages/node/src/login/oidc/OidcLoginHandler.ts
+++ b/packages/node/src/login/oidc/OidcLoginHandler.ts
@@ -40,6 +40,7 @@ import {
   IClient,
   IOidcOptions,
   LoginResult,
+  handleRegistration,
 } from "@inrupt/solid-client-authn-core";
 
 function hasIssuer(
@@ -92,31 +93,13 @@ export default class OidcLoginHandler implements ILoginHandler {
     const issuerConfig = await this.issuerConfigFetcher.fetchConfig(
       options.oidcIssuer
     );
-    let clientInfo: IClient;
-    if (options.clientId !== undefined) {
-      clientInfo = {
-        clientId: options.clientId,
-        clientSecret: options.clientSecret,
-        clientName: options.clientName,
-      };
-      await this.storageUtility.setForUser(options.sessionId, {
-        clientId: options.clientId,
-      });
-      if (options.clientSecret) {
-        await this.storageUtility.setForUser(options.sessionId, {
-          clientSecret: options.clientSecret,
-        });
-      }
-      if (options.clientName) {
-        await this.storageUtility.setForUser(options.sessionId, {
-          clientName: options.clientName,
-        });
-      }
-    } else {
-      // If 'client_id' and 'client_secret' aren't specified in the options,
-      // perform dynamic client registration.
-      clientInfo = await this.clientRegistrar.getClient(options, issuerConfig);
-    }
+
+    const clientInfo: IClient = await handleRegistration(
+      options,
+      issuerConfig,
+      this.storageUtility,
+      this.clientRegistrar
+    );
 
     // Construct OIDC Options
     const oidcOptions: IOidcOptions = {


### PR DESCRIPTION
This adds support for client WebID in the login process. There are a
certain number of configurations to consider: either the IdP supports
Solid-OIDC or not, and either the client provides a client_id or not.

If no client_id is provided, dynamic client registration is required,
regardless of the IdP. Most clients fall into this category today. If a
client ID is provided and it doesn't look like an IRI, or if it is an
IRI and the IdP supports Solid-OIDC, the client can be considered
already registered and there is no additional interaction required.

The library only has to be careful when the client provides a client
WebID, but the IdP soes not support Solid-OIDC.In that case, presenting
the client_id to the IdP would fail, because it would not look up the
app profile, but expect the given client_id to have previously been
registered. In that case, the client must go through DCR, and will be
considered like a public client by the resource server.

Note to reviewers: This PR overrides  https://github.com/inrupt/solid-client-authn-js/pull/1158 and moves the code that would have been duplicated in the core module.

# New feature description

# Checklist

- [X] All acceptance criteria are met.
- [X] Relevant documentation, if any, has been written/updated.
- [ ] The changelog has been updated, if applicable.
- [X] New functions/types have been exported in `index.ts`, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
