### PR TITLE
Changed GH actor to dependabot[bot]

### DIFF
--- a/.github/workflows/cd-preview.yml
+++ b/.github/workflows/cd-preview.yml
@@ -11,7 +11,7 @@ jobs:
     # Dependabot cannot access secrets, so it doesn't have a token to publish to NPM.
     # Since all the other jobs of this workflow depend on this one, skipping it should
     # skip the entire workflow.
-    if: ${{ github.actor != 'dependabot' }}
+    if: ${{ github.actor != 'dependabot[bot]' }}
     outputs:
       version-nr: ${{ steps.determine-npm-version.outputs.version-nr }}
     steps:

--- a/.github/workflows/cd-teardown.yml
+++ b/.github/workflows/cd-teardown.yml
@@ -10,7 +10,7 @@ jobs:
     # Dependabot cannot access secrets, so it doesn't have a token to publish to NPM.
     # Since all the other jobs of this workflow depend on this one, skipping it should
     # skip the entire workflow.
-    if: ${{github.event.ref_type == 'branch' && github.actor != 'dependabot'}} 
+    if: ${{github.event.ref_type == 'branch' && github.actor != 'dependabot[bot]'}} 
     steps:
     - name: Prepare for unpublication from npm
       uses: actions/setup-node@v2.1.5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - # Dependabot cannot access secrets, so it doesn't have a token to authenticate to ESS.
         # Since all the other jobs of this workflow depend on this one, skipping it should
         # skip the entire workflow.
-        if: ${{ github.actor != 'dependabot' }}
+        if: ${{ github.actor != 'dependabot[bot]' }}
         run: npm run e2e-test
         env: 
           E2E_TEST_REFRESH_TOKEN: ${{ secrets.E2E_TEST_REFRESH_TOKEN }}

--- a/.github/workflows/e2e-browser.yml
+++ b/.github/workflows/e2e-browser.yml
@@ -23,7 +23,7 @@ jobs:
         # Dependabot cannot access secrets, so it doesn't have a token to authenticate to ESS.
         # Since all the other jobs of this workflow depend on this one, skipping it should
         # skip the entire workflow.
-        if: ${{ github.actor != 'dependabot' }}
+        if: ${{ github.actor != 'dependabot[bot]' }}
         run: |
           cd e2e/browser;
           npm ci;


### PR DESCRIPTION
The current `'dependabot'` does not skip jobs as expected, and according to https://dev.to/github/conditional-workflows-and-failures-in-github-actions-2okk or https://github.com/marketplace/actions/auto-approve-dependabot it looks like the actor should actually be `dependabot[bot]`.