### PR TITLE
Skip e2e browser tests for dependabot

### DIFF
--- a/.github/workflows/e2e-browser.yml
+++ b/.github/workflows/e2e-browser.yml
@@ -7,7 +7,7 @@ env:
 jobs:
   test:
     runs-on: ubuntu-20.04
-    if: github.event.deployment_status.state == 'success'
+    if: ${{github.event.deployment_status.state == 'success' && github.actor != 'dependabot[bot]'}}
     steps:
       - uses: actions/checkout@v2.3.4
       - name: Use Node.js 12.x


### PR DESCRIPTION
Skipping the event that triggers the deployment hangs the event waiting
fot the deployment instead of skipping it too. Now, the browser e2e test
are skipped for dependabot too.