### PR TITLE
Do not trigger browser e2e test for dependabot

### DIFF
--- a/.github/workflows/e2e-browser.yml
+++ b/.github/workflows/e2e-browser.yml
@@ -1,13 +1,17 @@
 name: End-to-end tests (browser)
 
-on: [deployment_status]
+on: 
+  deployment_status:
+    branches-ignore:
+      - 'dependabot/npm_and_yarn/**'
+  workflow_dispatch:
 
 env:
   CI: true
 jobs:
   test:
     runs-on: ubuntu-20.04
-    if: ${{github.event.deployment_status.state == 'success' && github.actor != 'dependabot[bot]'}}
+    if: ${{github.event.deployment_status.state == 'success'}}
     steps:
       - uses: actions/checkout@v2.3.4
       - name: Use Node.js 12.x


### PR DESCRIPTION
This applies a different trigger to the e2e browser tests to skip the
workflow altogether for dependabot PRs, because dependabot does not have
access to GH secrets (also, the tests are flaky, and don't add value to most dependabot PRs). It should still be possible to manually run the
tests.
