### PR TITLE
Prevent race condition on login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 #### browser
 
 - Building the browser package is now possible on Windows, thanks to more portable scripts.
+- Asynchronous calls that lead to a redirection when restoring a session are now
+  blocking, to prevent any race condition. 
 
 The following sections document changes that have been released already:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 - Building the browser package is now possible on Windows, thanks to more portable scripts.
 - Asynchronous calls that lead to a redirection when restoring a session are now
-  blocking, to prevent any race condition. 
+  blocking, to prevent the error associated to the message `Field [sessionId] for user [...] is not stored`
+  that gets thrown when the user is redirected back from the identity provider.
 
 The following sections document changes that have been released already:
 

--- a/packages/browser/__tests__/Session.spec.ts
+++ b/packages/browser/__tests__/Session.spec.ts
@@ -545,6 +545,10 @@ describe("Session", () => {
   });
 
   describe("silent authentication", () => {
+    beforeEach(() => {
+      jest.useRealTimers();
+    });
+
     it("does nothing if no previous session is available", async () => {
       mockLocalStorage({});
       mockLocation("https://mock.current/location");
@@ -559,9 +563,15 @@ describe("Session", () => {
         .fn()
         .mockResolvedValue(undefined);
       const mySession = new Session({ clientAuthentication });
-      await mySession.handleIncomingRedirect({
+      // eslint-disable-next-line no-void
+      void mySession.handleIncomingRedirect({
         url: "https://some.redirect/url",
         restorePreviousSession: true,
+      });
+      // We know that handleincomingRedirect is never going to return, so just
+      // wait some time for the async calls to complete.
+      await new Promise((resolve) => {
+        setTimeout(resolve, 500);
       });
       expect(window.localStorage.getItem(KEY_CURRENT_URL)).toBeNull();
     });
@@ -595,11 +605,16 @@ describe("Session", () => {
         .mockResolvedValue("https://some.issuer/");
 
       const mySession = new Session({ clientAuthentication });
-      await mySession.handleIncomingRedirect({
+      // eslint-disable-next-line no-void
+      void mySession.handleIncomingRedirect({
         url: "https://some.redirect/url",
         restorePreviousSession: true,
       });
-
+      // We know that handleincomingRedirect is never going to return, so just
+      // wait some time for the async calls to complete.
+      await new Promise((resolve) => {
+        setTimeout(resolve, 500);
+      });
       expect(window.localStorage.getItem(KEY_CURRENT_URL)).toEqual(
         "https://mock.current/location"
       );
@@ -630,9 +645,15 @@ describe("Session", () => {
         .fn()
         .mockResolvedValue(undefined);
       const mySession = new Session({ clientAuthentication });
-      await mySession.handleIncomingRedirect({
+      // eslint-disable-next-line no-void
+      void mySession.handleIncomingRedirect({
         url: "https://some.redirect/url",
         restorePreviousSession: true,
+      });
+      // We know that handleincomingRedirect is never going to return, so just
+      // wait some time for the async calls to complete.
+      await new Promise((resolve) => {
+        setTimeout(resolve, 500);
       });
       expect(window.localStorage.getItem(KEY_CURRENT_URL)).toBeNull();
     });
@@ -668,11 +689,16 @@ describe("Session", () => {
       clientAuthentication.login = jest.fn();
 
       const mySession = new Session({ clientAuthentication });
-      await mySession.handleIncomingRedirect({
+      // eslint-disable-next-line no-void
+      void mySession.handleIncomingRedirect({
         url: "https://some.redirect/url",
         restorePreviousSession: true,
       });
-
+      // We know that handleincomingRedirect is never going to return, so just
+      // wait some time for the async calls to complete.
+      await new Promise((resolve) => {
+        setTimeout(resolve, 500);
+      });
       expect(clientAuthentication.login).toHaveBeenCalledWith("mySession", {
         oidcIssuer: "https://some.issuer",
         prompt: "none",
@@ -683,6 +709,7 @@ describe("Session", () => {
     });
 
     it("does nothing if the developer has not explicitly enabled silent authentication", async () => {
+      jest.useRealTimers();
       const sessionId = "mySession";
       mockLocalStorage({
         [KEY_CURRENT_SESSION]: sessionId,
@@ -713,8 +740,13 @@ describe("Session", () => {
       clientAuthentication.login = jest.fn();
 
       const mySession = new Session({ clientAuthentication });
-      await mySession.handleIncomingRedirect("https://some.redirect/url");
-
+      // eslint-disable-next-line no-void
+      void mySession.handleIncomingRedirect("https://some.redirect/url");
+      // We know that handleincomingRedirect is never going to return, so just
+      // wait some time for the async calls to complete.
+      await new Promise((resolve) => {
+        setTimeout(resolve, 500);
+      });
       expect(window.localStorage.getItem(KEY_CURRENT_URL)).toBeNull();
       expect(clientAuthentication.login).not.toHaveBeenCalled();
     });
@@ -750,11 +782,16 @@ describe("Session", () => {
       clientAuthentication.login = jest.fn();
 
       const mySession = new Session({ clientAuthentication });
-      await mySession.handleIncomingRedirect({
+      // eslint-disable-next-line no-void
+      void mySession.handleIncomingRedirect({
         url: "https://some.redirect/url",
         restorePreviousSession: false,
       });
-
+      // We know that handleincomingRedirect is never going to return, so just
+      // wait some time for the async calls to complete.
+      await new Promise((resolve) => {
+        setTimeout(resolve, 500);
+      });
       expect(window.localStorage.getItem(KEY_CURRENT_URL)).toBeNull();
       expect(clientAuthentication.login).not.toHaveBeenCalled();
     });

--- a/packages/browser/src/Session.ts
+++ b/packages/browser/src/Session.ts
@@ -341,6 +341,16 @@ export class Session extends EventEmitter {
       // if we do have a stored session ID, attempt to re-authenticate now silently.
       if (storedSessionId !== null) {
         await silentlyAuthenticate(storedSessionId, this.clientAuthentication);
+        // At this point, we know that the main window will imminently be redirected.
+        // However, this redirect is asynchronous and there is no way to halt execution
+        // until it happens precisely. That's why we wait an arbitrary length of time,
+        // to make sure this function never returns and the window is properly redirected.
+        await new Promise((resolve) => setTimeout(resolve, 2000));
+        // Just in case the previous sleep wasn't sufficient, undefined is returned
+        // to distinguish from a case when the session is legitimately logged out,
+        // in which case the user may directly call login, which triggers a race
+        // condition on the storage.
+        return undefined;
       }
     }
     this.tokenRequestInProgress = false;

--- a/packages/browser/src/Session.ts
+++ b/packages/browser/src/Session.ts
@@ -307,7 +307,6 @@ export class Session extends EventEmitter {
     const sessionInfo = await this.clientAuthentication.handleIncomingRedirect(
       url
     );
-
     if (sessionInfo?.isLoggedIn) {
       this.info.isLoggedIn = sessionInfo.isLoggedIn;
       this.info.webId = sessionInfo.webId;
@@ -343,14 +342,9 @@ export class Session extends EventEmitter {
         await silentlyAuthenticate(storedSessionId, this.clientAuthentication);
         // At this point, we know that the main window will imminently be redirected.
         // However, this redirect is asynchronous and there is no way to halt execution
-        // until it happens precisely. That's why we wait an arbitrary length of time,
-        // to make sure this function never returns and the window is properly redirected.
-        await new Promise((resolve) => setTimeout(resolve, 2000));
-        // Just in case the previous sleep wasn't sufficient, undefined is returned
-        // to distinguish from a case when the session is legitimately logged out,
-        // in which case the user may directly call login, which triggers a race
-        // condition on the storage.
-        return undefined;
+        // until it happens precisely. That's why the current Promise simply does not
+        // resolve.
+        return new Promise(() => {});
       }
     }
     this.tokenRequestInProgress = false;

--- a/packages/browser/src/login/oidc/oidcHandlers/AuthorizationCodeWithPkceOidcHandler.ts
+++ b/packages/browser/src/login/oidc/oidcHandlers/AuthorizationCodeWithPkceOidcHandler.ts
@@ -120,7 +120,6 @@ export default class AuthorizationCodeWithPkceOidcHandler
       redirector.redirect(signingRequest.url.toString(), {
         handleRedirect: oidcLoginOptions.handleRedirect,
       });
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (err: unknown) {
       // eslint-disable-next-line no-console
       console.error(err);

--- a/packages/browser/src/login/oidc/oidcHandlers/AuthorizationCodeWithPkceOidcHandler.ts
+++ b/packages/browser/src/login/oidc/oidcHandlers/AuthorizationCodeWithPkceOidcHandler.ts
@@ -35,7 +35,7 @@ import {
   LoginResult,
 } from "@inrupt/solid-client-authn-core";
 import { injectable, inject } from "tsyringe";
-import { OidcClient, SigninRequest } from "@inrupt/oidc-client-ext";
+import { OidcClient } from "@inrupt/oidc-client-ext";
 
 /**
  * @hidden
@@ -86,48 +86,45 @@ export default class AuthorizationCodeWithPkceOidcHandler
     const { redirector } = this;
     const storage = this.storageUtility;
 
-    await oidcClientLibrary.createSigninRequest().then((req: SigninRequest) => {
-      return (
-        Promise.all([
-          // We use the OAuth 'state' value (which should be crypto-random) as
-          // the key in our storage to store our actual SessionID. We do this
-          // 'cos we'll need to lookup our session information again when the
-          // browser is redirected back to us (i.e. the OAuth client
-          // application) from the Authorization Server.
-          // We don't want to use our session ID as the OAuth 'state' value, as
-          // that session ID can be any developer-specified value, and therefore
-          // may not be appropriate (since the OAuth 'state' value should really
-          // be an unguessable crypto-random value).
-          // eslint-disable-next-line no-underscore-dangle
-          storage.setForUser(req.state._id, {
-            sessionId: oidcLoginOptions.sessionId,
-          }),
+    try {
+      const signingRequest = await oidcClientLibrary.createSigninRequest();
+      await Promise.all([
+        // We use the OAuth 'state' value (which should be crypto-random) as
+        // the key in our storage to store our actual SessionID. We do this
+        // 'cos we'll need to lookup our session information again when the
+        // browser is redirected back to us (i.e. the OAuth client
+        // application) from the Authorization Server.
+        // We don't want to use our session ID as the OAuth 'state' value, as
+        // that session ID can be any developer-specified value, and therefore
+        // may not be appropriate (since the OAuth 'state' value should really
+        // be an unguessable crypto-random value).
+        // eslint-disable-next-line no-underscore-dangle
+        storage.setForUser(signingRequest.state._id, {
+          sessionId: oidcLoginOptions.sessionId,
+        }),
 
-          // Store our login-process state using the session ID as the key.
-          // Strictly speaking, this indirection from our OAuth state value to
-          // our session ID is unnecessary, but it provides a slightly cleaner
-          // separation of concerns.
-          storage.setForUser(oidcLoginOptions.sessionId, {
-            // eslint-disable-next-line no-underscore-dangle
-            codeVerifier: req.state._code_verifier,
-            issuer: oidcLoginOptions.issuer.toString(),
-            // The redirect URL is read after redirect, so it must be stored now.
-            redirectUrl: oidcLoginOptions.redirectUrl,
-            dpop: oidcLoginOptions.dpop ? "true" : "false",
-          }),
-        ])
-          .then(() => {
-            redirector.redirect(req.url.toString(), {
-              handleRedirect: oidcLoginOptions.handleRedirect,
-            });
-          })
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          .catch((err: unknown) => {
-            // eslint-disable-next-line no-console
-            console.error(err);
-          })
-      );
-    });
+        // Store our login-process state using the session ID as the key.
+        // Strictly speaking, this indirection from our OAuth state value to
+        // our session ID is unnecessary, but it provides a slightly cleaner
+        // separation of concerns.
+        storage.setForUser(oidcLoginOptions.sessionId, {
+          // eslint-disable-next-line no-underscore-dangle
+          codeVerifier: signingRequest.state._code_verifier,
+          issuer: oidcLoginOptions.issuer.toString(),
+          // The redirect URL is read after redirect, so it must be stored now.
+          redirectUrl: oidcLoginOptions.redirectUrl,
+          dpop: oidcLoginOptions.dpop ? "true" : "false",
+        }),
+      ]);
+
+      redirector.redirect(signingRequest.url.toString(), {
+        handleRedirect: oidcLoginOptions.handleRedirect,
+      });
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (err: unknown) {
+      // eslint-disable-next-line no-console
+      console.error(err);
+    }
 
     // The login is only completed AFTER redirect, so nothing to return here.
     return undefined;


### PR DESCRIPTION
There appears to be a race condition when logging in, that does not
manifest consistently. When it does, session information aren't stored
properly in local storage, resulting in a failure after redirection.

I suspect this causes #1242.

- [ ] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
