### PR TITLE
Handle token endpoint error appropriately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 - Building the browser package is now possible on Windows, thanks to more portable scripts.
 
+#### oidc
+
+- When the token endpoint returns an error message, it is now bubbled up properly.
+
 The following sections document changes that have been released already:
 
 ## 1.7.2 - 2021-03-10

--- a/packages/oidc/src/dpop/tokenExchange.spec.ts
+++ b/packages/oidc/src/dpop/tokenExchange.spec.ts
@@ -453,6 +453,42 @@ describe("getTokens", () => {
     );
   });
 
+  it("throws if the token endpoint returned an error", async () => {
+    const tokenEndpointResponse = {
+      error: "SomeError",
+    };
+    mockFetch(JSON.stringify(tokenEndpointResponse), 400);
+    await expect(
+      getTokens(mockIssuer(), mockClient(), mockEndpointInput(), true)
+    ).rejects.toThrow(`Token endpoint returned error [SomeError]`);
+  });
+
+  it("throws if the token endpoint returned an error, and shows its description when available", async () => {
+    const tokenEndpointResponse = {
+      error: "SomeError",
+      error_description: "This is an error.",
+    };
+    mockFetch(JSON.stringify(tokenEndpointResponse), 400);
+    await expect(
+      getTokens(mockIssuer(), mockClient(), mockEndpointInput(), true)
+    ).rejects.toThrow(
+      `Token endpoint returned error [SomeError]: This is an error`
+    );
+  });
+
+  it("throws if the token endpoint returned an error, and shows the associated URI when available", async () => {
+    const tokenEndpointResponse = {
+      error: "SomeError",
+      error_uri: "https://some.vocab/error#id",
+    };
+    mockFetch(JSON.stringify(tokenEndpointResponse), 400);
+    await expect(
+      getTokens(mockIssuer(), mockClient(), mockEndpointInput(), true)
+    ).rejects.toThrow(
+      `Token endpoint returned error [SomeError] (see https://some.vocab/error#id)`
+    );
+  });
+
   it("does not return a key with regular bearer tokens", async () => {
     mockFetch(JSON.stringify(mockBearerTokens()), 200);
     const result = await getTokens(

--- a/packages/oidc/src/dpop/tokenExchange.ts
+++ b/packages/oidc/src/dpop/tokenExchange.ts
@@ -29,6 +29,27 @@ import { generateJwkForDpop } from "./keyGeneration";
 // Identifiers in camelcase are mandated by the OAuth spec.
 /* eslint-disable camelcase */
 
+function hasError(
+  value: { error: string } | Record<string, unknown>
+): value is { error: string } {
+  return value.error !== undefined && typeof value.error === "string";
+}
+
+function hasErrorDescription(
+  value: { error_description: string } | Record<string, unknown>
+): value is { error_description: string } {
+  return (
+    value.error_description !== undefined &&
+    typeof value.error_description === "string"
+  );
+}
+
+function hasErrorUri(
+  value: { error_uri: string } | Record<string, unknown>
+): value is { error_uri: string } {
+  return value.error_uri !== undefined && typeof value.error_uri === "string";
+}
+
 function hasAccessToken(
   value: { access_token: string } | Record<string, unknown>
 ): value is { access_token: string } {
@@ -162,6 +183,16 @@ export function validateTokenEndpointResponse(
   id_token: string;
   expires_in?: number;
 } {
+  if (hasError(tokenResponse)) {
+    throw new Error(
+      `Token endpoint returned error [${tokenResponse.error}]${
+        hasErrorDescription(tokenResponse)
+          ? `: ${tokenResponse.error_description}`
+          : ""
+      }${hasErrorUri(tokenResponse) ? ` (see ${tokenResponse.error_uri})` : ""}`
+    );
+  }
+
   if (!hasAccessToken(tokenResponse)) {
     throw new Error(
       `Invalid token endpoint response (missing the field 'access_token'): ${JSON.stringify(


### PR DESCRIPTION
When the token endpoint returns an error, said error is now bubbled back up
to the developer properly, instead of being wrapped in a seemingly
unrelated error message pointing out the absence of an access token.

- [X] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).