### PR TITLE
Prevent di conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Bugfixes
 
+#### oidc
+
+- When the token endpoint returns an error message, it is now bubbled up properly.
+
 #### browser
 
 - Building the browser package is now possible on Windows, thanks to more portable scripts.
@@ -16,9 +20,11 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
   blocking, to prevent the error associated to the message `Field [sessionId] for user [...] is not stored`
   that gets thrown when the user is redirected back from the identity provider.
 
-#### oidc
+#### browser and node
 
-- When the token endpoint returns an error message, it is now bubbled up properly.
+- When loaded in the same environment (e.g. a full-stack NextJS app), it is no longer
+possible that the browser and node code get mixed together, resulting in code being
+executed in the wrong environment.
 
 The following sections document changes that have been released already:
 

--- a/packages/browser/src/ClientAuthentication.ts
+++ b/packages/browser/src/ClientAuthentication.ts
@@ -59,12 +59,13 @@ export const fetchWithCookies = (
 @injectable()
 export default class ClientAuthentication {
   constructor(
-    @inject("loginHandler") private loginHandler: ILoginHandler,
-    @inject("redirectHandler") private redirectHandler: IRedirectHandler,
-    @inject("logoutHandler") private logoutHandler: ILogoutHandler,
-    @inject("sessionInfoManager")
+    @inject("browser:loginHandler") private loginHandler: ILoginHandler,
+    @inject("browser:redirectHandler")
+    private redirectHandler: IRedirectHandler,
+    @inject("browser:logoutHandler") private logoutHandler: ILogoutHandler,
+    @inject("browser:sessionInfoManager")
     private sessionInfoManager: ISessionInfoManager,
-    @inject("issuerConfigFetcher")
+    @inject("browser:issuerConfigFetcher")
     private issuerConfigFetcher: IIssuerConfigFetcher
   ) {}
 

--- a/packages/browser/src/dependencies.ts
+++ b/packages/browser/src/dependencies.ts
@@ -72,96 +72,96 @@ import AggregateLoginHandler from "./login/AggregateLoginHandler";
 
 const container = emptyContainer;
 
-container.register<IStorageUtility>("storageUtility", {
+container.register<IStorageUtility>("browser:storageUtility", {
   useClass: StorageUtilityBrowser,
 });
 
 // Session
-container.register<ISessionInfoManager>("sessionInfoManager", {
+container.register<ISessionInfoManager>("browser:sessionInfoManager", {
   useClass: SessionInfoManager,
 });
-container.register<ISessionManager>("sessionManager", {
+container.register<ISessionManager>("browser:sessionManager", {
   useClass: SessionManager,
 });
 
 // Login
-container.register<ILoginHandler>("loginHandler", {
+container.register<ILoginHandler>("browser:loginHandler", {
   useClass: AggregateLoginHandler,
 });
-container.register<ILoginHandler>("loginHandlers", {
+container.register<ILoginHandler>("browser:loginHandlers", {
   useClass: PopUpLoginHandler,
 });
-container.register<ILoginHandler>("loginHandlers", {
+container.register<ILoginHandler>("browser:loginHandlers", {
   useClass: OidcLoginHandler,
 });
 
-container.register<ILoginHandler>("postPopUpLoginHandler", {
+container.register<ILoginHandler>("browser:postPopUpLoginHandler", {
   useClass: AggregatePostPopUpLoginHandler,
 });
-container.register<ILoginHandler>("postPopUpLoginHandlers", {
+container.register<ILoginHandler>("browser:postPopUpLoginHandlers", {
   useClass: OidcLoginHandler,
 });
 
 // Login/OIDC
-container.register<IOidcHandler>("oidcHandler", {
+container.register<IOidcHandler>("browser:oidcHandler", {
   useClass: AggregateOidcHandler,
 });
-container.register<IOidcHandler>("oidcHandlers", {
+container.register<IOidcHandler>("browser:oidcHandlers", {
   useClass: RefreshTokenOidcHandler,
 });
 
-container.register<IOidcHandler>("oidcHandlers", {
+container.register<IOidcHandler>("browser:oidcHandlers", {
   useClass: AuthorizationCodeOidcHandler,
 });
-container.register<IOidcHandler>("oidcHandlers", {
+container.register<IOidcHandler>("browser:oidcHandlers", {
   useClass: AuthorizationCodeWithPkceOidcHandler,
 });
 
-container.register<IOidcHandler>("oidcHandlers", {
+container.register<IOidcHandler>("browser:oidcHandlers", {
   useClass: ClientCredentialsOidcHandler,
 });
-container.register<IOidcHandler>("oidcHandlers", {
+container.register<IOidcHandler>("browser:oidcHandlers", {
   useClass: PrimaryDeviceOidcHandler,
 });
-container.register<IOidcHandler>("oidcHandlers", {
+container.register<IOidcHandler>("browser:oidcHandlers", {
   useClass: SecondaryDeviceOidcHandler,
 });
 
-container.register<IRedirector>("redirector", {
+container.register<IRedirector>("browser:redirector", {
   useClass: Redirector,
 });
-container.register<IClientRegistrar>("clientRegistrar", {
+container.register<IClientRegistrar>("browser:clientRegistrar", {
   useClass: ClientRegistrar,
 });
-container.register<ITokenRequester>("tokenRequester", {
+container.register<ITokenRequester>("browser:tokenRequester", {
   useClass: TokenRequester,
 });
 
 // Login/OIDC/redirectHandler
-container.register<IRedirectHandler>("redirectHandler", {
+container.register<IRedirectHandler>("browser:redirectHandler", {
   useClass: AggregateRedirectHandler,
 });
-container.register<IRedirectHandler>("redirectHandlers", {
+container.register<IRedirectHandler>("browser:redirectHandlers", {
   useClass: AuthCodeRedirectHandler,
 });
 // This catch-all class will always be able to handle the
 // redirect IRI, so it must be registered last in the container
-container.register<IRedirectHandler>("redirectHandlers", {
+container.register<IRedirectHandler>("browser:redirectHandlers", {
   useClass: FallbackRedirectHandler,
 });
 
 // Login/OIDC/Issuer
-container.register<IIssuerConfigFetcher>("issuerConfigFetcher", {
+container.register<IIssuerConfigFetcher>("browser:issuerConfigFetcher", {
   useClass: IssuerConfigFetcher,
 });
 
 // Login/OIDC/Refresh
-container.register<ITokenRefresher>("tokenRefresher", {
+container.register<ITokenRefresher>("browser:tokenRefresher", {
   useClass: TokenRefresher,
 });
 
 // Logout
-container.register<ILogoutHandler>("logoutHandler", {
+container.register<ILogoutHandler>("browser:logoutHandler", {
   useClass: GeneralLogoutHandler,
 });
 
@@ -178,10 +178,10 @@ export function getClientAuthenticationWithDependencies(dependencies: {
   const insecureStorage = dependencies.insecureStorage || new BrowserStorage();
 
   const authenticatorContainer = container.createChildContainer();
-  authenticatorContainer.register<IStorage>("secureStorage", {
+  authenticatorContainer.register<IStorage>("browser:secureStorage", {
     useValue: secureStorage,
   });
-  authenticatorContainer.register<IStorage>("insecureStorage", {
+  authenticatorContainer.register<IStorage>("browser:insecureStorage", {
     useValue: insecureStorage,
   });
   return authenticatorContainer.resolve(ClientAuthentication);

--- a/packages/browser/src/login/AggregateLoginHandler.ts
+++ b/packages/browser/src/login/AggregateLoginHandler.ts
@@ -42,7 +42,9 @@ import {
 export default class AggregateLoginHandler
   extends AggregateHandler<[ILoginOptions], LoginResult>
   implements ILoginHandler {
-  constructor(@injectAll("loginHandlers") loginHandlers: ILoginHandler[]) {
+  constructor(
+    @injectAll("browser:loginHandlers") loginHandlers: ILoginHandler[]
+  ) {
     super(loginHandlers);
   }
 }

--- a/packages/browser/src/login/oidc/AggregateOidcHandler.ts
+++ b/packages/browser/src/login/oidc/AggregateOidcHandler.ts
@@ -42,7 +42,9 @@ import {
 export default class AggregateOidcHandler
   extends AggregateHandler<[IOidcOptions], LoginResult>
   implements IOidcHandler {
-  constructor(@injectAll("oidcHandlers") oidcLoginHandlers: IOidcHandler[]) {
+  constructor(
+    @injectAll("browser:oidcHandlers") oidcLoginHandlers: IOidcHandler[]
+  ) {
     super(oidcLoginHandlers);
   }
 }

--- a/packages/browser/src/login/oidc/ClientRegistrar.ts
+++ b/packages/browser/src/login/oidc/ClientRegistrar.ts
@@ -40,7 +40,7 @@ import { registerClient } from "@inrupt/oidc-client-ext";
 @injectable()
 export default class ClientRegistrar implements IClientRegistrar {
   constructor(
-    @inject("storageUtility") private storageUtility: IStorageUtility
+    @inject("browser:storageUtility") private storageUtility: IStorageUtility
   ) {}
 
   async getClient(

--- a/packages/browser/src/login/oidc/IssuerConfigFetcher.ts
+++ b/packages/browser/src/login/oidc/IssuerConfigFetcher.ts
@@ -159,7 +159,7 @@ function processConfig(
 @injectable()
 export default class IssuerConfigFetcher implements IIssuerConfigFetcher {
   constructor(
-    @inject("storageUtility") private storageUtility: IStorageUtility
+    @inject("browser:storageUtility") private storageUtility: IStorageUtility
   ) {}
 
   // This method needs no state (so can be static), and can be exposed to allow

--- a/packages/browser/src/login/oidc/OidcLoginHandler.ts
+++ b/packages/browser/src/login/oidc/OidcLoginHandler.ts
@@ -61,11 +61,11 @@ function hasRedirectUrl(
 @injectable()
 export default class OidcLoginHandler implements ILoginHandler {
   constructor(
-    @inject("storageUtility") private storageUtility: IStorageUtility,
-    @inject("oidcHandler") private oidcHandler: IOidcHandler,
-    @inject("issuerConfigFetcher")
+    @inject("browser:storageUtility") private storageUtility: IStorageUtility,
+    @inject("browser:oidcHandler") private oidcHandler: IOidcHandler,
+    @inject("browser:issuerConfigFetcher")
     private issuerConfigFetcher: IIssuerConfigFetcher,
-    @inject("clientRegistrar") private clientRegistrar: IClientRegistrar
+    @inject("browser:clientRegistrar") private clientRegistrar: IClientRegistrar
   ) {}
 
   async canHandle(options: ILoginOptions): Promise<boolean> {

--- a/packages/browser/src/login/oidc/TokenRequester.ts
+++ b/packages/browser/src/login/oidc/TokenRequester.ts
@@ -56,10 +56,10 @@ function btoa(str: string): string {
 @injectable()
 export default class TokenRequester {
   constructor(
-    @inject("storageUtility") private storageUtility: IStorageUtility,
-    @inject("issuerConfigFetcher")
+    @inject("browser:storageUtility") private storageUtility: IStorageUtility,
+    @inject("browser:issuerConfigFetcher")
     private issuerConfigFetcher: IIssuerConfigFetcher,
-    @inject("clientRegistrar") private clientRegistrar: IClientRegistrar
+    @inject("browser:clientRegistrar") private clientRegistrar: IClientRegistrar
   ) {}
 
   async request(

--- a/packages/browser/src/login/oidc/oidcHandlers/AuthorizationCodeWithPkceOidcHandler.ts
+++ b/packages/browser/src/login/oidc/oidcHandlers/AuthorizationCodeWithPkceOidcHandler.ts
@@ -44,8 +44,8 @@ import { OidcClient } from "@inrupt/oidc-client-ext";
 export default class AuthorizationCodeWithPkceOidcHandler
   implements IOidcHandler {
   constructor(
-    @inject("storageUtility") private storageUtility: IStorageUtility,
-    @inject("redirector") private redirector: IRedirector
+    @inject("browser:storageUtility") private storageUtility: IStorageUtility,
+    @inject("browser:redirector") private redirector: IRedirector
   ) {}
 
   async canHandle(oidcLoginOptions: IOidcOptions): Promise<boolean> {

--- a/packages/browser/src/login/oidc/redirectHandler/AggregateRedirectHandler.ts
+++ b/packages/browser/src/login/oidc/redirectHandler/AggregateRedirectHandler.ts
@@ -42,7 +42,7 @@ export default class AggregateRedirectHandler
   extends AggregateHandler<[string], ISessionInfo & { fetch: typeof fetch }>
   implements IRedirectHandler {
   constructor(
-    @injectAll("redirectHandlers") redirectHandlers: IRedirectHandler[]
+    @injectAll("browser:redirectHandlers") redirectHandlers: IRedirectHandler[]
   ) {
     super(redirectHandlers);
   }

--- a/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
+++ b/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
@@ -122,12 +122,12 @@ async function setupResourceServerSession(
 @injectable()
 export class AuthCodeRedirectHandler implements IRedirectHandler {
   constructor(
-    @inject("storageUtility") private storageUtility: IStorageUtility,
-    @inject("sessionInfoManager")
+    @inject("browser:storageUtility") private storageUtility: IStorageUtility,
+    @inject("browser:sessionInfoManager")
     private sessionInfoManager: ISessionInfoManager,
-    @inject("issuerConfigFetcher")
+    @inject("browser:issuerConfigFetcher")
     private issuerConfigFetcher: IIssuerConfigFetcher,
-    @inject("clientRegistrar") private clientRegistrar: IClientRegistrar
+    @inject("browser:clientRegistrar") private clientRegistrar: IClientRegistrar
   ) {}
 
   async canHandle(redirectUrl: string): Promise<boolean> {

--- a/packages/browser/src/login/oidc/refresh/TokenRefresher.ts
+++ b/packages/browser/src/login/oidc/refresh/TokenRefresher.ts
@@ -41,8 +41,8 @@ export interface ITokenRefresher {
 @injectable()
 export default class TokenRefresher implements ITokenRefresher {
   constructor(
-    @inject("storageUtility") private storageUtility: IStorageUtility,
-    @inject("tokenRequester") private tokenRequester: ITokenRequester
+    @inject("browser:storageUtility") private storageUtility: IStorageUtility,
+    @inject("browser:tokenRequester") private tokenRequester: ITokenRequester
   ) {}
 
   async refresh(localUserId: string): Promise<void> {

--- a/packages/browser/src/login/popUp/AggregatePostPopUpLoginHandler.ts
+++ b/packages/browser/src/login/popUp/AggregatePostPopUpLoginHandler.ts
@@ -43,7 +43,7 @@ export default class AggregatePostPopUpLoginHandler
   extends AggregateHandler<[ILoginOptions], LoginResult>
   implements ILoginHandler {
   constructor(
-    @injectAll("postPopUpLoginHandlers") loginHandlers: ILoginHandler[]
+    @injectAll("browser:postPopUpLoginHandlers") loginHandlers: ILoginHandler[]
   ) {
     super(loginHandlers);
   }

--- a/packages/browser/src/login/popUp/PopUpLoginHandler.ts
+++ b/packages/browser/src/login/popUp/PopUpLoginHandler.ts
@@ -46,8 +46,10 @@ import { injectable, inject } from "tsyringe";
 @injectable()
 export default class PopUpLoginHandler implements ILoginHandler {
   constructor(
-    @inject("postPopUpLoginHandler") private loginHandler: ILoginHandler,
-    @inject("sessionInfoManager") private sessionCreator: ISessionInfoManager
+    @inject("browser:postPopUpLoginHandler")
+    private loginHandler: ILoginHandler,
+    @inject("browser:sessionInfoManager")
+    private sessionCreator: ISessionInfoManager
   ) {}
 
   async canHandle(loginOptions: ILoginOptions): Promise<boolean> {

--- a/packages/browser/src/logout/GeneralLogoutHandler.ts
+++ b/packages/browser/src/logout/GeneralLogoutHandler.ts
@@ -37,7 +37,7 @@ import { inject, injectable } from "tsyringe";
 @injectable()
 export default class GeneralLogoutHandler implements ILogoutHandler {
   constructor(
-    @inject("sessionInfoManager")
+    @inject("browser:sessionInfoManager")
     private sessionInfoManager: ISessionInfoManager
   ) {}
 

--- a/packages/browser/src/sessionInfo/SessionInfoManager.ts
+++ b/packages/browser/src/sessionInfo/SessionInfoManager.ts
@@ -80,7 +80,7 @@ export async function clear(
 @injectable()
 export class SessionInfoManager implements ISessionInfoManager {
   constructor(
-    @inject("storageUtility") private storageUtility: IStorageUtility
+    @inject("browser:storageUtility") private storageUtility: IStorageUtility
   ) {}
 
   // eslint-disable-next-line class-methods-use-this

--- a/packages/browser/src/storage/StorageUtility.ts
+++ b/packages/browser/src/storage/StorageUtility.ts
@@ -40,8 +40,8 @@ import { IStorage, StorageUtility } from "@inrupt/solid-client-authn-core";
 @injectable()
 export default class StorageUtilityBrowser extends StorageUtility {
   constructor(
-    @inject("secureStorage") secureStorage: IStorage,
-    @inject("insecureStorage") insecureStorage: IStorage
+    @inject("browser:secureStorage") secureStorage: IStorage,
+    @inject("browser:insecureStorage") insecureStorage: IStorage
   ) {
     super(secureStorage, insecureStorage);
   }

--- a/packages/node/src/ClientAuthentication.ts
+++ b/packages/node/src/ClientAuthentication.ts
@@ -42,10 +42,10 @@ import { fetch } from "cross-fetch";
 @injectable()
 export default class ClientAuthentication {
   constructor(
-    @inject("loginHandler") private loginHandler: ILoginHandler,
-    @inject("redirectHandler") private redirectHandler: IRedirectHandler,
-    @inject("logoutHandler") private logoutHandler: ILogoutHandler,
-    @inject("sessionInfoManager")
+    @inject("node:loginHandler") private loginHandler: ILoginHandler,
+    @inject("node:redirectHandler") private redirectHandler: IRedirectHandler,
+    @inject("node:logoutHandler") private logoutHandler: ILogoutHandler,
+    @inject("node:sessionInfoManager")
     private sessionInfoManager: ISessionInfoManager
   ) {}
 

--- a/packages/node/src/dependencies.ts
+++ b/packages/node/src/dependencies.ts
@@ -42,7 +42,7 @@ import {
   ISessionInfoManager,
   InMemoryStorage,
 } from "@inrupt/solid-client-authn-core";
-import StorageUtilityBrowser from "./storage/StorageUtility";
+import StorageUtilityNode from "./storage/StorageUtility";
 import ClientAuthentication from "./ClientAuthentication";
 import OidcLoginHandler from "./login/oidc/OidcLoginHandler";
 import AggregateOidcHandler from "./login/oidc/AggregateOidcHandler";
@@ -69,91 +69,91 @@ import AggregateLoginHandler from "./login/AggregateLoginHandler";
 
 const container = emptyContainer;
 
-container.register<IStorageUtility>("storageUtility", {
-  useClass: StorageUtilityBrowser,
+container.register<IStorageUtility>("node:storageUtility", {
+  useClass: StorageUtilityNode,
 });
 
 // Session
-container.register<ISessionInfoManager>("sessionInfoManager", {
+container.register<ISessionInfoManager>("node:sessionInfoManager", {
   useClass: SessionInfoManager,
 });
-container.register<ISessionManager>("sessionManager", {
+container.register<ISessionManager>("node:sessionManager", {
   useClass: SessionManager,
 });
 
 // Login
-container.register<ILoginHandler>("loginHandler", {
+container.register<ILoginHandler>("node:loginHandler", {
   useClass: AggregateLoginHandler,
 });
-container.register<ILoginHandler>("loginHandlers", {
+container.register<ILoginHandler>("node:loginHandlers", {
   useClass: OidcLoginHandler,
 });
 
-container.register<ILoginHandler>("postPopUpLoginHandlers", {
+container.register<ILoginHandler>("node:postPopUpLoginHandlers", {
   useClass: OidcLoginHandler,
 });
 
 // Login/OIDC
-container.register<IOidcHandler>("oidcHandler", {
+container.register<IOidcHandler>("node:oidcHandler", {
   useClass: AggregateOidcHandler,
 });
-container.register<IOidcHandler>("oidcHandlers", {
+container.register<IOidcHandler>("node:oidcHandlers", {
   useClass: RefreshTokenOidcHandler,
 });
 
-container.register<IOidcHandler>("oidcHandlers", {
+container.register<IOidcHandler>("node:oidcHandlers", {
   useClass: AuthorizationCodeOidcHandler,
 });
-container.register<IOidcHandler>("oidcHandlers", {
+container.register<IOidcHandler>("node:oidcHandlers", {
   useClass: AuthorizationCodeWithPkceOidcHandler,
 });
 
-container.register<IOidcHandler>("oidcHandlers", {
+container.register<IOidcHandler>("node:oidcHandlers", {
   useClass: ClientCredentialsOidcHandler,
 });
-container.register<IOidcHandler>("oidcHandlers", {
+container.register<IOidcHandler>("node:oidcHandlers", {
   useClass: PrimaryDeviceOidcHandler,
 });
-container.register<IOidcHandler>("oidcHandlers", {
+container.register<IOidcHandler>("node:oidcHandlers", {
   useClass: SecondaryDeviceOidcHandler,
 });
 
-container.register<IRedirector>("redirector", {
+container.register<IRedirector>("node:redirector", {
   useClass: Redirector,
 });
-container.register<IClientRegistrar>("clientRegistrar", {
+container.register<IClientRegistrar>("node:clientRegistrar", {
   useClass: ClientRegistrar,
 });
-container.register<ITokenRequester>("tokenRequester", {
+container.register<ITokenRequester>("node:tokenRequester", {
   useClass: TokenRequester,
 });
 
 // Login/OIDC/redirectHandler
-container.register<IRedirectHandler>("redirectHandler", {
+container.register<IRedirectHandler>("node:redirectHandler", {
   useClass: AggregateRedirectHandler,
 });
-container.register<IRedirectHandler>("redirectHandlers", {
+container.register<IRedirectHandler>("node:redirectHandlers", {
   useClass: AuthCodeRedirectHandler,
 });
 
 // This catch-all class will always be able to handle the
 // redirect IRI, so it must be registered last in the container
-container.register<IRedirectHandler>("redirectHandlers", {
+container.register<IRedirectHandler>("node:redirectHandlers", {
   useClass: FallbackRedirectHandler,
 });
 
 // Login/OIDC/Issuer
-container.register<IIssuerConfigFetcher>("issuerConfigFetcher", {
+container.register<IIssuerConfigFetcher>("node:issuerConfigFetcher", {
   useClass: IssuerConfigFetcher,
 });
 
 // Login/OIDC/Refresh
-container.register<ITokenRefresher>("tokenRefresher", {
+container.register<ITokenRefresher>("node:tokenRefresher", {
   useClass: TokenRefresher,
 });
 
 // Logout
-container.register<ILogoutHandler>("logoutHandler", {
+container.register<ILogoutHandler>("node:logoutHandler", {
   useClass: GeneralLogoutHandler,
 });
 
@@ -171,10 +171,10 @@ export function getClientAuthenticationWithDependencies(dependencies: {
   const insecureStorage = dependencies.insecureStorage || storage;
 
   const authenticatorContainer = container.createChildContainer();
-  authenticatorContainer.register<IStorage>("secureStorage", {
+  authenticatorContainer.register<IStorage>("node:secureStorage", {
     useValue: secureStorage,
   });
-  authenticatorContainer.register<IStorage>("insecureStorage", {
+  authenticatorContainer.register<IStorage>("node:insecureStorage", {
     useValue: insecureStorage,
   });
   return authenticatorContainer.resolve(ClientAuthentication);

--- a/packages/node/src/login/AggregateLoginHandler.ts
+++ b/packages/node/src/login/AggregateLoginHandler.ts
@@ -42,7 +42,7 @@ import {
 export default class AggregateLoginHandler
   extends AggregateHandler<[ILoginOptions], LoginResult>
   implements ILoginHandler {
-  constructor(@injectAll("loginHandlers") loginHandlers: ILoginHandler[]) {
+  constructor(@injectAll("node:loginHandlers") loginHandlers: ILoginHandler[]) {
     super(loginHandlers);
   }
 }

--- a/packages/node/src/login/oidc/AggregateOidcHandler.ts
+++ b/packages/node/src/login/oidc/AggregateOidcHandler.ts
@@ -42,7 +42,9 @@ import {
 export default class AggregateOidcHandler
   extends AggregateHandler<[IOidcOptions], LoginResult>
   implements IOidcHandler {
-  constructor(@injectAll("oidcHandlers") oidcLoginHandlers: IOidcHandler[]) {
+  constructor(
+    @injectAll("node:oidcHandlers") oidcLoginHandlers: IOidcHandler[]
+  ) {
     super(oidcLoginHandlers);
   }
 }

--- a/packages/node/src/login/oidc/ClientRegistrar.ts
+++ b/packages/node/src/login/oidc/ClientRegistrar.ts
@@ -42,7 +42,7 @@ import { configToIssuerMetadata } from "./IssuerConfigFetcher";
 @injectable()
 export default class ClientRegistrar implements IClientRegistrar {
   constructor(
-    @inject("storageUtility") private storageUtility: IStorageUtility
+    @inject("node:storageUtility") private storageUtility: IStorageUtility
   ) {}
 
   async getClient(

--- a/packages/node/src/login/oidc/IssuerConfigFetcher.ts
+++ b/packages/node/src/login/oidc/IssuerConfigFetcher.ts
@@ -140,7 +140,7 @@ export function configToIssuerMetadata(config: IIssuerConfig): IssuerMetadata {
 @injectable()
 export default class IssuerConfigFetcher implements IIssuerConfigFetcher {
   constructor(
-    @inject("storageUtility") private storageUtility: IStorageUtility
+    @inject("node:storageUtility") private storageUtility: IStorageUtility
   ) {}
 
   // This method needs no state (so can be static), and can be exposed to allow

--- a/packages/node/src/login/oidc/OidcLoginHandler.ts
+++ b/packages/node/src/login/oidc/OidcLoginHandler.ts
@@ -62,11 +62,11 @@ function hasIssuer(
 @injectable()
 export default class OidcLoginHandler implements ILoginHandler {
   constructor(
-    @inject("storageUtility") private storageUtility: IStorageUtility,
-    @inject("oidcHandler") private oidcHandler: IOidcHandler,
-    @inject("issuerConfigFetcher")
+    @inject("node:storageUtility") private storageUtility: IStorageUtility,
+    @inject("node:oidcHandler") private oidcHandler: IOidcHandler,
+    @inject("node:issuerConfigFetcher")
     private issuerConfigFetcher: IIssuerConfigFetcher,
-    @inject("clientRegistrar") private clientRegistrar: IClientRegistrar
+    @inject("node:clientRegistrar") private clientRegistrar: IClientRegistrar
   ) {}
 
   async canHandle(options: ILoginOptions): Promise<boolean> {

--- a/packages/node/src/login/oidc/TokenRequester.ts
+++ b/packages/node/src/login/oidc/TokenRequester.ts
@@ -45,10 +45,10 @@ export interface ITokenRequester {
 @injectable()
 export default class TokenRequester {
   constructor(
-    @inject("storageUtility") private storageUtility: IStorageUtility,
-    @inject("issuerConfigFetcher")
+    @inject("node:storageUtility") private storageUtility: IStorageUtility,
+    @inject("node:issuerConfigFetcher")
     private issuerConfigFetcher: IIssuerConfigFetcher,
-    @inject("clientRegistrar") private clientRegistrar: IClientRegistrar
+    @inject("node:clientRegistrar") private clientRegistrar: IClientRegistrar
   ) {}
 
   async request(

--- a/packages/node/src/login/oidc/oidcHandlers/AuthorizationCodeWithPkceOidcHandler.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/AuthorizationCodeWithPkceOidcHandler.ts
@@ -45,8 +45,8 @@ import { configToIssuerMetadata } from "../IssuerConfigFetcher";
 export default class AuthorizationCodeWithPkceOidcHandler
   implements IOidcHandler {
   constructor(
-    @inject("storageUtility") private storageUtility: IStorageUtility,
-    @inject("redirector") private redirector: IRedirector
+    @inject("node:storageUtility") private storageUtility: IStorageUtility,
+    @inject("node:redirector") private redirector: IRedirector
   ) {}
 
   async canHandle(oidcLoginOptions: IOidcOptions): Promise<boolean> {

--- a/packages/node/src/login/oidc/oidcHandlers/RefreshTokenOidcHandler.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/RefreshTokenOidcHandler.ts
@@ -115,8 +115,8 @@ async function refreshAccess(
 @injectable()
 export default class RefreshTokenOidcHandler implements IOidcHandler {
   constructor(
-    @inject("tokenRefresher") private tokenRefresher: ITokenRefresher,
-    @inject("storageUtility") private storageUtility: IStorageUtility
+    @inject("node:tokenRefresher") private tokenRefresher: ITokenRefresher,
+    @inject("node:storageUtility") private storageUtility: IStorageUtility
   ) {}
 
   async canHandle(oidcLoginOptions: IOidcOptions): Promise<boolean> {

--- a/packages/node/src/login/oidc/redirectHandler/AggregateRedirectHandler.ts
+++ b/packages/node/src/login/oidc/redirectHandler/AggregateRedirectHandler.ts
@@ -42,7 +42,7 @@ export default class AggregateRedirectHandler
   extends AggregateHandler<[string], ISessionInfo & { fetch: typeof fetch }>
   implements IRedirectHandler {
   constructor(
-    @injectAll("redirectHandlers") redirectHandlers: IRedirectHandler[]
+    @injectAll("node:redirectHandlers") redirectHandlers: IRedirectHandler[]
   ) {
     super(redirectHandlers);
   }

--- a/packages/node/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
+++ b/packages/node/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
@@ -78,13 +78,13 @@ export async function getWebidFromTokenPayload(
 @injectable()
 export class AuthCodeRedirectHandler implements IRedirectHandler {
   constructor(
-    @inject("storageUtility") private storageUtility: IStorageUtility,
-    @inject("sessionInfoManager")
+    @inject("node:storageUtility") private storageUtility: IStorageUtility,
+    @inject("node:sessionInfoManager")
     private sessionInfoManager: ISessionInfoManager,
-    @inject("issuerConfigFetcher")
+    @inject("node:issuerConfigFetcher")
     private issuerConfigFetcher: IIssuerConfigFetcher,
-    @inject("clientRegistrar") private clientRegistrar: IClientRegistrar,
-    @inject("tokenRefresher") private tokenRefresher: ITokenRefresher
+    @inject("node:clientRegistrar") private clientRegistrar: IClientRegistrar,
+    @inject("node:tokenRefresher") private tokenRefresher: ITokenRefresher
   ) {}
 
   async canHandle(redirectUrl: string): Promise<boolean> {

--- a/packages/node/src/login/oidc/refresh/TokenRefresher.ts
+++ b/packages/node/src/login/oidc/refresh/TokenRefresher.ts
@@ -57,10 +57,10 @@ export interface ITokenRefresher {
 @injectable()
 export default class TokenRefresher implements ITokenRefresher {
   constructor(
-    @inject("storageUtility") private storageUtility: IStorageUtility,
-    @inject("issuerConfigFetcher")
+    @inject("node:storageUtility") private storageUtility: IStorageUtility,
+    @inject("node:issuerConfigFetcher")
     private issuerConfigFetcher: IIssuerConfigFetcher,
-    @inject("clientRegistrar") private clientRegistrar: IClientRegistrar
+    @inject("node:clientRegistrar") private clientRegistrar: IClientRegistrar
   ) {}
 
   async refresh(

--- a/packages/node/src/logout/GeneralLogoutHandler.ts
+++ b/packages/node/src/logout/GeneralLogoutHandler.ts
@@ -37,7 +37,7 @@ import { inject, injectable } from "tsyringe";
 @injectable()
 export default class GeneralLogoutHandler implements ILogoutHandler {
   constructor(
-    @inject("sessionInfoManager")
+    @inject("node:sessionInfoManager")
     private sessionInfoManager: ISessionInfoManager
   ) {}
 

--- a/packages/node/src/sessionInfo/SessionInfoManager.ts
+++ b/packages/node/src/sessionInfo/SessionInfoManager.ts
@@ -71,7 +71,7 @@ export async function clear(
 @injectable()
 export class SessionInfoManager implements ISessionInfoManager {
   constructor(
-    @inject("storageUtility") private storageUtility: IStorageUtility
+    @inject("node:storageUtility") private storageUtility: IStorageUtility
   ) {}
 
   // eslint-disable-next-line class-methods-use-this

--- a/packages/node/src/storage/StorageUtility.ts
+++ b/packages/node/src/storage/StorageUtility.ts
@@ -38,10 +38,10 @@ import { IStorage, StorageUtility } from "@inrupt/solid-client-authn-core";
  * @hidden
  */
 @injectable()
-export default class StorageUtilityBrowser extends StorageUtility {
+export default class StorageUtilityNode extends StorageUtility {
   constructor(
-    @inject("secureStorage") secureStorage: IStorage,
-    @inject("insecureStorage") insecureStorage: IStorage
+    @inject("node:secureStorage") secureStorage: IStorage,
+    @inject("node:insecureStorage") insecureStorage: IStorage
   ) {
     super(secureStorage, insecureStorage);
   }


### PR DESCRIPTION
This aims at preventing conflicts if both solid-client-authn-browser and
-node are loaded in the same context, e.g. a NextJS application with
both server-side and client-side code. With prefixed names, DI
containers from the node context and the browser context cannot be mixed
up by tsyringe.

- [ ] I've added a unit test to test for potential regressions of this bug. N/A
- [x] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).