### PR TITLE
apidocs: pin docs theme requirements

### DIFF
--- a/packages/browser/docs/api/requirements.txt
+++ b/packages/browser/docs/api/requirements.txt
@@ -1,5 +1,5 @@
 # pip install -r requirements.txt
 
-pydata-sphinx-theme
+pydata-sphinx-theme==0.5.2
 myst-parser
 Sphinx

--- a/packages/core/docs/api/requirements.txt
+++ b/packages/core/docs/api/requirements.txt
@@ -1,5 +1,5 @@
 # pip install -r requirements.txt
 
-pydata-sphinx-theme
+pydata-sphinx-theme==0.5.2
 myst-parser
 Sphinx

--- a/packages/node/docs/api/requirements.txt
+++ b/packages/node/docs/api/requirements.txt
@@ -1,5 +1,5 @@
 # pip install -r requirements.txt
 
-pydata-sphinx-theme
+pydata-sphinx-theme==0.5.2
 myst-parser
 Sphinx


### PR DESCRIPTION
Pin 3rd party docs theme requirement to a version.  

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
