### PR TITLE
Add refresh token handling hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased
 
+### New features
+
+#### node
+
+- It is now possible to specify a callback when constructing a function in order
+to invoke custom code when the refresh token is rotated. THis is useful for users
+who wish to run authenticated scripts, without implementing a brand new storage.
+
 The following sections document changes that have been released already:
 
 ## 1.7.4 - 2021-04-15

--- a/packages/core/src/ILoginInputOptions.ts
+++ b/packages/core/src/ILoginInputOptions.ts
@@ -59,9 +59,4 @@ export default interface ILoginInputOptions {
    * secret to authenticate.
    */
   refreshToken?: string;
-  /**
-   * This callback will be called if, during the refresh token flow, the refresh token is rotated by the Solid Identity
-   * Provider. In this case, the provided function is called with the new token as a parameter.
-   */
-  handleRefreshTokenRotation?: (token: string) => unknown;
 }

--- a/packages/core/src/ILoginInputOptions.ts
+++ b/packages/core/src/ILoginInputOptions.ts
@@ -45,7 +45,8 @@ export default interface ILoginInputOptions {
    */
   popUp?: boolean;
   /**
-   * If a function is provided, the browser will not auto-redirect and will instead trigger that function to redirect. Required in non-browser environments.
+   * If a function is provided, the browser will not auto-redirect and will instead trigger that function to redirect.
+   * Required in non-browser environments, ignored in the browser.
    */
   handleRedirect?: (redirectUrl: string) => unknown;
   /**
@@ -58,4 +59,9 @@ export default interface ILoginInputOptions {
    * secret to authenticate.
    */
   refreshToken?: string;
+  /**
+   * This callback will be called if, during the refresh token flow, the refresh token is rotated by the Solid Identity
+   * Provider. In this case, the provided function is called with the new token as a parameter.
+   */
+  handleRefreshTokenRotation?: (token: string) => unknown;
 }

--- a/packages/core/src/login/ILoginOptions.ts
+++ b/packages/core/src/login/ILoginOptions.ts
@@ -51,5 +51,5 @@ export default interface ILoginOptions extends ILoginInputOptions {
    * This callback will be called if, during the refresh token flow, the refresh token is rotated by the Solid Identity
    * Provider. In this case, the provided function is called with the new token as a parameter.
    */
-  handleRefreshTokenRotation?: (token: string) => unknown;
+  onNewRefreshToken?: (newToken: string) => unknown;
 }

--- a/packages/core/src/login/ILoginOptions.ts
+++ b/packages/core/src/login/ILoginOptions.ts
@@ -47,4 +47,9 @@ export default interface ILoginOptions extends ILoginInputOptions {
   prompt?: string;
   // Force the token type to be required (i.e. no longer optional).
   tokenType: "DPoP" | "Bearer";
+  /**
+   * This callback will be called if, during the refresh token flow, the refresh token is rotated by the Solid Identity
+   * Provider. In this case, the provided function is called with the new token as a parameter.
+   */
+  handleRefreshTokenRotation?: (token: string) => unknown;
 }

--- a/packages/core/src/login/oidc/IOidcOptions.ts
+++ b/packages/core/src/login/oidc/IOidcOptions.ts
@@ -62,6 +62,8 @@ export interface IOidcOptions {
    */
   redirectUrl: string;
   handleRedirect?: (url: string) => unknown;
+
+  handleRefreshTokenRotation?: (token: string) => unknown;
 }
 
 export default IOidcOptions;

--- a/packages/core/src/login/oidc/IOidcOptions.ts
+++ b/packages/core/src/login/oidc/IOidcOptions.ts
@@ -63,7 +63,7 @@ export interface IOidcOptions {
   redirectUrl: string;
   handleRedirect?: (url: string) => unknown;
 
-  handleRefreshTokenRotation?: (token: string) => unknown;
+  onNewRefreshToken?: (newToken: string) => unknown;
 }
 
 export default IOidcOptions;

--- a/packages/core/src/login/oidc/redirectHandler/IRedirectHandler.ts
+++ b/packages/core/src/login/oidc/redirectHandler/IRedirectHandler.ts
@@ -34,7 +34,7 @@ export type RedirectResult = ISessionInfo & { fetch: typeof fetch };
  * @hidden
  */
 type IRedirectHandler = IHandleable<
-  [url: string, handleRefreshToken?: (token: string) => unknown],
+  [url: string, onNewRefreshToken?: (newToken: string) => unknown],
   RedirectResult
 >;
 export default IRedirectHandler;

--- a/packages/core/src/login/oidc/redirectHandler/IRedirectHandler.ts
+++ b/packages/core/src/login/oidc/redirectHandler/IRedirectHandler.ts
@@ -33,5 +33,8 @@ export type RedirectResult = ISessionInfo & { fetch: typeof fetch };
 /**
  * @hidden
  */
-type IRedirectHandler = IHandleable<[string], RedirectResult>;
+type IRedirectHandler = IHandleable<
+  [url: string, handleRefreshToken?: (token: string) => unknown],
+  RedirectResult
+>;
 export default IRedirectHandler;

--- a/packages/node/example/bootstrappedApp/src/authenticatedScript.ts
+++ b/packages/node/example/bootstrappedApp/src/authenticatedScript.ts
@@ -25,6 +25,9 @@ async function main(): Promise<void> {
   const session = new Session(
     {
       storage,
+      handleRefreshToken: (token: string) => {
+        console.log(`New refresh token: [${token}]`);
+      },
     },
     "my-session"
   );

--- a/packages/node/example/bootstrappedApp/src/authenticatedScript.ts
+++ b/packages/node/example/bootstrappedApp/src/authenticatedScript.ts
@@ -25,8 +25,8 @@ async function main(): Promise<void> {
   const session = new Session(
     {
       storage,
-      handleRefreshToken: (token: string) => {
-        console.log(`New refresh token: [${token}]`);
+      onNewRefreshToken: (newToken: string) => {
+        console.log(`New refresh token: [${newToken}]`);
       },
     },
     "my-session"

--- a/packages/node/src/ClientAuthentication.spec.ts
+++ b/packages/node/src/ClientAuthentication.spec.ts
@@ -246,7 +246,32 @@ describe("ClientAuthentication", () => {
       expect(redirectInfo).toEqual({
         ...RedirectHandlerResponse,
       });
-      expect(defaultMocks.redirectHandler.handle).toHaveBeenCalledWith(url);
+      expect(defaultMocks.redirectHandler.handle).toHaveBeenCalledWith(
+        url,
+        undefined
+      );
+
+      // Calling the redirect handler should have updated the fetch.
+      expect(clientAuthn.fetch).not.toBe(unauthFetch);
+    });
+
+    it("calls handle redirect with the refresh token handler if one is provided", async () => {
+      const clientAuthn = getClientAuthentication();
+      const unauthFetch = clientAuthn.fetch;
+      const refreshTokenHandler = jest.fn();
+      const url =
+        "https://coolapp.com/redirect?state=userId&id_token=idToken&access_token=accessToken";
+      const redirectInfo = await clientAuthn.handleIncomingRedirect(
+        url,
+        refreshTokenHandler
+      );
+      expect(redirectInfo).toEqual({
+        ...RedirectHandlerResponse,
+      });
+      expect(defaultMocks.redirectHandler.handle).toHaveBeenCalledWith(
+        url,
+        refreshTokenHandler
+      );
 
       // Calling the redirect handler should have updated the fetch.
       expect(clientAuthn.fetch).not.toBe(unauthFetch);

--- a/packages/node/src/ClientAuthentication.ts
+++ b/packages/node/src/ClientAuthentication.ts
@@ -71,6 +71,7 @@ export default class ClientAuthentication {
       handleRedirect: options.handleRedirect,
       // Defaults to DPoP
       tokenType: options.tokenType ?? "DPoP",
+      handleRefreshTokenRotation: options.handleRefreshTokenRotation,
     });
 
     if (loginReturn !== undefined) {
@@ -122,9 +123,13 @@ export default class ClientAuthentication {
   };
 
   handleIncomingRedirect = async (
-    url: string
+    url: string,
+    handleRefreshToken?: (token: string) => unknown
   ): Promise<ISessionInfo | undefined> => {
-    const redirectInfo = await this.redirectHandler.handle(url);
+    const redirectInfo = await this.redirectHandler.handle(
+      url,
+      handleRefreshToken
+    );
 
     this.fetch = redirectInfo.fetch;
 

--- a/packages/node/src/ClientAuthentication.ts
+++ b/packages/node/src/ClientAuthentication.ts
@@ -54,7 +54,7 @@ export default class ClientAuthentication {
   login = async (
     sessionId: string,
     options: ILoginInputOptions,
-    handleRefreshToken?: (token: string) => unknown
+    onNewRefreshToken?: (newToken: string) => unknown
   ): Promise<ISessionInfo | undefined> => {
     // Keep track of the session ID
     await this.sessionInfoManager.register(sessionId);
@@ -72,7 +72,7 @@ export default class ClientAuthentication {
       handleRedirect: options.handleRedirect,
       // Defaults to DPoP
       tokenType: options.tokenType ?? "DPoP",
-      handleRefreshTokenRotation: handleRefreshToken,
+      onNewRefreshToken,
     });
 
     if (loginReturn !== undefined) {
@@ -125,11 +125,11 @@ export default class ClientAuthentication {
 
   handleIncomingRedirect = async (
     url: string,
-    handleRefreshToken?: (token: string) => unknown
+    onNewRefreshToken?: (newToken: string) => unknown
   ): Promise<ISessionInfo | undefined> => {
     const redirectInfo = await this.redirectHandler.handle(
       url,
-      handleRefreshToken
+      onNewRefreshToken
     );
 
     this.fetch = redirectInfo.fetch;

--- a/packages/node/src/ClientAuthentication.ts
+++ b/packages/node/src/ClientAuthentication.ts
@@ -53,7 +53,8 @@ export default class ClientAuthentication {
   // Isn't Javascript fun?
   login = async (
     sessionId: string,
-    options: ILoginInputOptions
+    options: ILoginInputOptions,
+    handleRefreshToken?: (token: string) => unknown
   ): Promise<ISessionInfo | undefined> => {
     // Keep track of the session ID
     await this.sessionInfoManager.register(sessionId);
@@ -71,7 +72,7 @@ export default class ClientAuthentication {
       handleRedirect: options.handleRedirect,
       // Defaults to DPoP
       tokenType: options.tokenType ?? "DPoP",
-      handleRefreshTokenRotation: options.handleRefreshTokenRotation,
+      handleRefreshTokenRotation: handleRefreshToken,
     });
 
     if (loginReturn !== undefined) {

--- a/packages/node/src/Session.ts
+++ b/packages/node/src/Session.ts
@@ -197,7 +197,8 @@ export class Session extends EventEmitter {
    * @param url The URL of the page handling the redirect, including the query parameters — these contain the information to process the login.
    */
   handleIncomingRedirect = async (
-    url: string
+    url: string,
+    handleRefreshToken?: (token: string) => unknown
   ): Promise<ISessionInfo | undefined> => {
     let sessionInfo;
 
@@ -212,7 +213,8 @@ export class Session extends EventEmitter {
       try {
         this.tokenRequestInProgress = true;
         sessionInfo = await this.clientAuthentication.handleIncomingRedirect(
-          url
+          url,
+          handleRefreshToken
         );
 
         if (sessionInfo) {

--- a/packages/node/src/Session.ts
+++ b/packages/node/src/Session.ts
@@ -71,7 +71,7 @@ export interface ISessionOptions {
   /**
    * A callback that gets invoked whenever a new refresh token is obtained.
    */
-  handleRefreshToken?: (token: string) => unknown;
+  onNewRefreshToken?: (newToken: string) => unknown;
 }
 
 /**
@@ -92,7 +92,7 @@ export class Session extends EventEmitter {
 
   private tokenRequestInProgress = false;
 
-  private handleRefreshToken?: (token: string) => unknown;
+  private onNewRefreshToken?: (newToken: string) => unknown;
 
   /**
    * Session object constructor. Typically called as follows:
@@ -148,7 +148,7 @@ export class Session extends EventEmitter {
         isLoggedIn: false,
       };
     }
-    this.handleRefreshToken = sessionOptions.handleRefreshToken;
+    this.onNewRefreshToken = sessionOptions.onNewRefreshToken;
   }
 
   /**
@@ -165,7 +165,7 @@ export class Session extends EventEmitter {
       {
         ...options,
       },
-      this.handleRefreshToken
+      this.onNewRefreshToken
     );
     if (loginInfo !== undefined) {
       this.info.isLoggedIn = loginInfo.isLoggedIn;
@@ -221,7 +221,7 @@ export class Session extends EventEmitter {
         this.tokenRequestInProgress = true;
         sessionInfo = await this.clientAuthentication.handleIncomingRedirect(
           url,
-          this.handleRefreshToken
+          this.onNewRefreshToken
         );
 
         if (sessionInfo) {

--- a/packages/node/src/authenticatedFetch/fetchFactory.spec.ts
+++ b/packages/node/src/authenticatedFetch/fetchFactory.spec.ts
@@ -146,7 +146,7 @@ describe("buildBearerFetch", () => {
       refreshToken: "some refresh token",
       sessionId: "mySession",
       tokenRefresher: mockedFreshener,
-      handleRefreshToken: refreshHandler,
+      onNewRefreshToken: refreshHandler,
     });
     await myFetch("someUrl");
     // The mocked fetch will 401, which triggers the refresh flow.
@@ -407,7 +407,7 @@ describe("buildDpopFetch", () => {
       refreshToken: "some refresh token",
       sessionId: "mySession",
       tokenRefresher: mockedFreshener,
-      handleRefreshToken: refreshHandler,
+      onNewRefreshToken: refreshHandler,
     });
 
     await myFetch("https://my.pod/resource");

--- a/packages/node/src/authenticatedFetch/fetchFactory.spec.ts
+++ b/packages/node/src/authenticatedFetch/fetchFactory.spec.ts
@@ -120,7 +120,7 @@ describe("buildBearerFetch", () => {
     const fetch = jest.requireMock("cross-fetch");
     fetch.mockResolvedValue({ status: 401 });
     const tokenSet = mockDefaultTokenSet();
-    tokenSet.refresh_token = "some refreshed refresh token";
+    tokenSet.refresh_token = "some rotated refresh token";
     const mockedFreshener = mockTokenRefresher(tokenSet);
     const refreshCall = jest.spyOn(mockedFreshener, "refresh");
 
@@ -132,16 +132,14 @@ describe("buildBearerFetch", () => {
     await myFetch("someUrl");
     // We make two requests in a row to see that the second uses a different refresh token
     await myFetch("someUrl");
-    expect(refreshCall.mock.calls[1][1]).toEqual(
-      "some refreshed refresh token"
-    );
+    expect(refreshCall.mock.calls[1][1]).toEqual("some rotated refresh token");
   });
 
   it("returns a fetch that calls the refresh token handler if appropriate", async () => {
     const fetch = jest.requireMock("cross-fetch");
     fetch.mockResolvedValue({ status: 401 });
     const tokenSet = mockDefaultTokenSet();
-    tokenSet.refresh_token = "some refreshed refresh token";
+    tokenSet.refresh_token = "some rotated refresh token";
     const mockedFreshener = mockTokenRefresher(tokenSet);
     const refreshHandler = jest.fn();
     const myFetch = buildBearerFetch("myToken", {
@@ -153,7 +151,7 @@ describe("buildBearerFetch", () => {
     await myFetch("someUrl");
     // The mocked fetch will 401, which triggers the refresh flow.
     // The test checks that the mocked refreshed token is used silently.
-    expect(refreshHandler).toHaveBeenCalledWith("some refreshed refresh token");
+    expect(refreshHandler).toHaveBeenCalledWith("some rotated refresh token");
   });
 
   it("does not try to refresh on a non-auth error", async () => {
@@ -378,7 +376,7 @@ describe("buildDpopFetch", () => {
       url: "https://my.pod/resource",
     });
     const tokenSet = mockDefaultTokenSet();
-    tokenSet.refresh_token = "some refreshed refresh token";
+    tokenSet.refresh_token = "some rotated refresh token";
     const mockedFreshener = mockTokenRefresher(tokenSet);
     const refreshCall = jest.spyOn(mockedFreshener, "refresh");
 
@@ -391,9 +389,7 @@ describe("buildDpopFetch", () => {
     await myFetch("https://my.pod/resource");
     // We make two requests in a row to see that the second uses a different refresh token
     await myFetch("https://my.pod/resource");
-    expect(refreshCall.mock.calls[1][1]).toEqual(
-      "some refreshed refresh token"
-    );
+    expect(refreshCall.mock.calls[1][1]).toEqual("some rotated refresh token");
   });
 
   it("calls the refresh token handler if one is provided", async () => {
@@ -403,7 +399,7 @@ describe("buildDpopFetch", () => {
       url: "https://my.pod/resource",
     });
     const tokenSet = mockDefaultTokenSet();
-    tokenSet.refresh_token = "some refreshed refresh token";
+    tokenSet.refresh_token = "some rotated refresh token";
     const mockedFreshener = mockTokenRefresher(tokenSet);
     const refreshHandler = jest.fn();
 
@@ -415,7 +411,7 @@ describe("buildDpopFetch", () => {
     });
 
     await myFetch("https://my.pod/resource");
-    expect(refreshHandler).toHaveBeenCalledWith("some refreshed refresh token");
+    expect(refreshHandler).toHaveBeenCalledWith("some rotated refresh token");
   });
 
   it("does not try to refresh on a non-auth error", async () => {

--- a/packages/node/src/authenticatedFetch/fetchFactory.ts
+++ b/packages/node/src/authenticatedFetch/fetchFactory.ts
@@ -83,7 +83,7 @@ export function buildBearerFetch(
       if (tokenSet.refresh_token) {
         // If the refresh token is rotated, update it in the closure.
         currentRefreshOptions.refreshToken = tokenSet.refresh_token;
-        if (currentRefreshOptions.onNewRefreshToken !== undefined) {
+        if (typeof currentRefreshOptions.onNewRefreshToken === "function") {
           currentRefreshOptions.onNewRefreshToken(tokenSet.refresh_token);
         }
       }
@@ -234,7 +234,7 @@ export async function buildDpopFetch(
         if (tokenSet.refresh_token) {
           // If the refresh token is rotated, update it in the closure.
           currentRefreshOptions.refreshToken = tokenSet.refresh_token;
-          if (currentRefreshOptions.onNewRefreshToken !== undefined) {
+          if (typeof currentRefreshOptions.onNewRefreshToken === "function") {
             currentRefreshOptions.onNewRefreshToken(tokenSet.refresh_token);
           }
         }

--- a/packages/node/src/authenticatedFetch/fetchFactory.ts
+++ b/packages/node/src/authenticatedFetch/fetchFactory.ts
@@ -28,7 +28,7 @@ export type RefreshOptions = {
   sessionId: string;
   refreshToken: string;
   tokenRefresher: ITokenRefresher;
-  handleRefreshToken?: (token: string) => unknown;
+  onNewRefreshToken?: (token: string) => unknown;
 };
 
 function isExpectedAuthError(statusCode: number): boolean {
@@ -83,8 +83,8 @@ export function buildBearerFetch(
       if (tokenSet.refresh_token) {
         // If the refresh token is rotated, update it in the closure.
         currentRefreshOptions.refreshToken = tokenSet.refresh_token;
-        if (currentRefreshOptions.handleRefreshToken !== undefined) {
-          currentRefreshOptions.handleRefreshToken(tokenSet.refresh_token);
+        if (currentRefreshOptions.onNewRefreshToken !== undefined) {
+          currentRefreshOptions.onNewRefreshToken(tokenSet.refresh_token);
         }
       }
       // Once the token has been refreshed, re-issue the authenticated request.
@@ -234,8 +234,8 @@ export async function buildDpopFetch(
         if (tokenSet.refresh_token) {
           // If the refresh token is rotated, update it in the closure.
           currentRefreshOptions.refreshToken = tokenSet.refresh_token;
-          if (currentRefreshOptions.handleRefreshToken !== undefined) {
-            currentRefreshOptions.handleRefreshToken(tokenSet.refresh_token);
+          if (currentRefreshOptions.onNewRefreshToken !== undefined) {
+            currentRefreshOptions.onNewRefreshToken(tokenSet.refresh_token);
           }
         }
         // Once the token has been refreshed, re-issue the authenticated request.

--- a/packages/node/src/authenticatedFetch/fetchFactory.ts
+++ b/packages/node/src/authenticatedFetch/fetchFactory.ts
@@ -28,6 +28,7 @@ export type RefreshOptions = {
   sessionId: string;
   refreshToken: string;
   tokenRefresher: ITokenRefresher;
+  handleRefreshToken?: (token: string) => unknown;
 };
 
 function isExpectedAuthError(statusCode: number): boolean {
@@ -81,8 +82,10 @@ export function buildBearerFetch(
       currentAccessToken = tokenSet.access_token;
       if (tokenSet.refresh_token) {
         // If the refresh token is rotated, update it in the closure.
-        // TODO: Plug this into external storage, if one is provided.
         currentRefreshOptions.refreshToken = tokenSet.refresh_token;
+        if (currentRefreshOptions.handleRefreshToken !== undefined) {
+          currentRefreshOptions.handleRefreshToken(tokenSet.refresh_token);
+        }
       }
       // Once the token has been refreshed, re-issue the authenticated request.
       // If it has an auth failure again, the user legitimately doesn't have access
@@ -230,8 +233,10 @@ export async function buildDpopFetch(
         currentAccessToken = tokenSet.access_token;
         if (tokenSet.refresh_token) {
           // If the refresh token is rotated, update it in the closure.
-          // TODO: Plug this in an external storage if one is provided.
           currentRefreshOptions.refreshToken = tokenSet.refresh_token;
+          if (currentRefreshOptions.handleRefreshToken !== undefined) {
+            currentRefreshOptions.handleRefreshToken(tokenSet.refresh_token);
+          }
         }
         // Once the token has been refreshed, re-issue the authenticated request.
         // If it has an auth failure again, the user legitimately doesn't have access

--- a/packages/node/src/login/oidc/OidcLoginHandler.ts
+++ b/packages/node/src/login/oidc/OidcLoginHandler.ts
@@ -119,6 +119,7 @@ export default class OidcLoginHandler implements ILoginHandler {
           "refreshToken"
         )),
       handleRedirect: options.handleRedirect,
+      handleRefreshTokenRotation: options.handleRefreshTokenRotation,
     };
     // Call proper OIDC Handler
     return this.oidcHandler.handle(oidcOptions);

--- a/packages/node/src/login/oidc/OidcLoginHandler.ts
+++ b/packages/node/src/login/oidc/OidcLoginHandler.ts
@@ -119,7 +119,7 @@ export default class OidcLoginHandler implements ILoginHandler {
           "refreshToken"
         )),
       handleRedirect: options.handleRedirect,
-      handleRefreshTokenRotation: options.handleRefreshTokenRotation,
+      onNewRefreshToken: options.onNewRefreshToken,
     };
     // Call proper OIDC Handler
     return this.oidcHandler.handle(oidcOptions);

--- a/packages/node/src/login/oidc/oidcHandlers/RefreshTokenOidcHandler.spec.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/RefreshTokenOidcHandler.spec.ts
@@ -331,7 +331,7 @@ describe("RefreshTokenOidcHandler", () => {
           clientId: "some client id",
           clientSecret: "some client secret",
         },
-        handleRefreshTokenRotation: refreshTokenRotationHandler,
+        onNewRefreshToken: refreshTokenRotationHandler,
       })
     );
 

--- a/packages/node/src/login/oidc/oidcHandlers/RefreshTokenOidcHandler.spec.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/RefreshTokenOidcHandler.spec.ts
@@ -313,6 +313,36 @@ describe("RefreshTokenOidcHandler", () => {
     );
   });
 
+  it("calls the refresh token rotation handler if applicable", async () => {
+    const tokenSet = mockDefaultTokenSet();
+    tokenSet.refresh_token = "some rotated refresh token";
+    const mockedTokenRefresher = mockTokenRefresher(tokenSet);
+    const refreshTokenRotationHandler = jest.fn();
+
+    // This builds the fetch function holding the refresh token...
+    const refreshTokenOidcHandler = new RefreshTokenOidcHandler(
+      mockedTokenRefresher,
+      mockStorageUtility({})
+    );
+    await refreshTokenOidcHandler.handle(
+      mockOidcOptions({
+        refreshToken: "some refresh token",
+        client: {
+          clientId: "some client id",
+          clientSecret: "some client secret",
+        },
+        handleRefreshTokenRotation: refreshTokenRotationHandler,
+      })
+    );
+
+    expect(mockedTokenRefresher.refresh).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      refreshTokenRotationHandler
+    );
+  });
+
   it("uses the rotated refresh token to build the Bearer-authenticated fetch if applicable", async () => {
     const tokenSet = mockDefaultTokenSet();
     tokenSet.refresh_token = "some rotated refresh token";

--- a/packages/node/src/login/oidc/oidcHandlers/RefreshTokenOidcHandler.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/RefreshTokenOidcHandler.ts
@@ -79,7 +79,7 @@ async function refreshAccess(
         refreshOptions.sessionId,
         refreshOptions.refreshToken,
         dpopKey,
-        refreshOptions.handleRefreshToken
+        refreshOptions.onNewRefreshToken
       );
       // Rotate the refresh token if applicable
       const rotatedRefreshOptions = {
@@ -96,7 +96,7 @@ async function refreshAccess(
         refreshOptions.sessionId,
         refreshOptions.refreshToken,
         undefined,
-        refreshOptions.handleRefreshToken
+        refreshOptions.onNewRefreshToken
       );
       const rotatedRefreshOptions = {
         ...refreshOptions,
@@ -139,7 +139,7 @@ export default class RefreshTokenOidcHandler implements IOidcHandler {
       refreshToken: oidcLoginOptions.refreshToken as string,
       sessionId: oidcLoginOptions.sessionId,
       tokenRefresher: this.tokenRefresher,
-      handleRefreshToken: oidcLoginOptions.handleRefreshTokenRotation,
+      onNewRefreshToken: oidcLoginOptions.onNewRefreshToken,
     };
 
     // This information must be in storage for the refresh flow to succeed.

--- a/packages/node/src/login/oidc/oidcHandlers/RefreshTokenOidcHandler.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/RefreshTokenOidcHandler.ts
@@ -78,7 +78,8 @@ async function refreshAccess(
       tokens = await refreshOptions.tokenRefresher.refresh(
         refreshOptions.sessionId,
         refreshOptions.refreshToken,
-        dpopKey
+        dpopKey,
+        refreshOptions.handleRefreshToken
       );
       // Rotate the refresh token if applicable
       const rotatedRefreshOptions = {
@@ -93,7 +94,9 @@ async function refreshAccess(
     } else {
       tokens = await refreshOptions.tokenRefresher.refresh(
         refreshOptions.sessionId,
-        refreshOptions.refreshToken
+        refreshOptions.refreshToken,
+        undefined,
+        refreshOptions.handleRefreshToken
       );
       const rotatedRefreshOptions = {
         ...refreshOptions,
@@ -136,6 +139,7 @@ export default class RefreshTokenOidcHandler implements IOidcHandler {
       refreshToken: oidcLoginOptions.refreshToken as string,
       sessionId: oidcLoginOptions.sessionId,
       tokenRefresher: this.tokenRefresher,
+      handleRefreshToken: oidcLoginOptions.handleRefreshTokenRotation,
     };
 
     // This information must be in storage for the refresh flow to succeed.

--- a/packages/node/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
+++ b/packages/node/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
@@ -368,6 +368,27 @@ describe("AuthCodeRedirectHandler", () => {
       ).resolves.toEqual("some refresh token");
     });
 
+    it("calls the refresh token handler if one is provided", async () => {
+      const mockedTokens = mockDpopTokens();
+      mockedTokens.refresh_token = "some refresh token";
+      setupOidcClientMock(mockedTokens);
+      const mockedStorage = mockDefaultRedirectStorage();
+      const refreshTokenHandler = jest.fn();
+
+      // Run the test
+      const authCodeRedirectHandler = getAuthCodeRedirectHandler({
+        storageUtility: mockedStorage,
+        sessionInfoManager: mockSessionInfoManager(mockedStorage),
+      });
+
+      await authCodeRedirectHandler.handle(
+        "https://my.app/redirect?code=someCode&state=someState",
+        refreshTokenHandler
+      );
+
+      expect(refreshTokenHandler).toHaveBeenCalledWith("some refresh token");
+    });
+
     it("throws if the IdP does not return an access token", async () => {
       const mockedTokens = mockDpopTokens();
       mockedTokens.access_token = undefined;

--- a/packages/node/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
+++ b/packages/node/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
@@ -182,7 +182,7 @@ export class AuthCodeRedirectHandler implements IRedirectHandler {
         tokenRefresher: this.tokenRefresher,
         onNewRefreshToken,
       };
-      if (onNewRefreshToken !== undefined) {
+      if (typeof onNewRefreshToken === "function") {
         onNewRefreshToken(tokenSet.refresh_token);
       }
     }

--- a/packages/node/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
+++ b/packages/node/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
@@ -103,7 +103,7 @@ export class AuthCodeRedirectHandler implements IRedirectHandler {
 
   async handle(
     inputRedirectUrl: string,
-    handleRefreshToken?: (token: string) => unknown
+    onNewRefreshToken?: (newToken: string) => unknown
   ): Promise<ISessionInfo & { fetch: typeof fetch }> {
     if (!(await this.canHandle(inputRedirectUrl))) {
       throw new Error(
@@ -180,10 +180,10 @@ export class AuthCodeRedirectHandler implements IRedirectHandler {
         refreshToken: tokenSet.refresh_token,
         sessionId,
         tokenRefresher: this.tokenRefresher,
-        handleRefreshToken,
+        onNewRefreshToken,
       };
-      if (handleRefreshToken !== undefined) {
-        handleRefreshToken(tokenSet.refresh_token);
+      if (onNewRefreshToken !== undefined) {
+        onNewRefreshToken(tokenSet.refresh_token);
       }
     }
     if (oidcContext.dpop) {

--- a/packages/node/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
+++ b/packages/node/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
@@ -102,7 +102,8 @@ export class AuthCodeRedirectHandler implements IRedirectHandler {
   }
 
   async handle(
-    inputRedirectUrl: string
+    inputRedirectUrl: string,
+    handleRefreshToken?: (token: string) => unknown
   ): Promise<ISessionInfo & { fetch: typeof fetch }> {
     if (!(await this.canHandle(inputRedirectUrl))) {
       throw new Error(
@@ -180,6 +181,9 @@ export class AuthCodeRedirectHandler implements IRedirectHandler {
         sessionId,
         tokenRefresher: this.tokenRefresher,
       };
+      if (handleRefreshToken !== undefined) {
+        handleRefreshToken(tokenSet.refresh_token);
+      }
     }
     if (oidcContext.dpop) {
       authFetch = await buildDpopFetch(

--- a/packages/node/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
+++ b/packages/node/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
@@ -180,6 +180,7 @@ export class AuthCodeRedirectHandler implements IRedirectHandler {
         refreshToken: tokenSet.refresh_token,
         sessionId,
         tokenRefresher: this.tokenRefresher,
+        handleRefreshToken,
       };
       if (handleRefreshToken !== undefined) {
         handleRefreshToken(tokenSet.refresh_token);

--- a/packages/node/src/login/oidc/refresh/TokenRefresher.spec.ts
+++ b/packages/node/src/login/oidc/refresh/TokenRefresher.spec.ts
@@ -299,6 +299,30 @@ describe("TokenRefresher", () => {
     ).resolves.toEqual("some new refresh token");
   });
 
+  it("calls the refresh token rotation handler if one is provided", async () => {
+    const mockedTokens = mockDpopTokens();
+    mockedTokens.refresh_token = "some new refresh token";
+    setupOidcClientMock(mockedTokens);
+    const mockedStorage = mockRefresherDefaultStorageUtility();
+    const refreshTokenRotationHandler = jest.fn();
+
+    const refresher = getTokenRefresher({
+      storageUtility: mockedStorage,
+    });
+
+    const refreshedTokens = await refresher.refresh(
+      "mySession",
+      "some old refresh token",
+      mockJwk(),
+      refreshTokenRotationHandler
+    );
+
+    expect(refreshedTokens.refresh_token).toEqual("some new refresh token");
+    expect(refreshTokenRotationHandler).toHaveBeenCalledWith(
+      "some new refresh token"
+    );
+  });
+
   it("throws if the IdP does not return an access token", async () => {
     const mockedTokens = mockDpopTokens();
     mockedTokens.access_token = undefined;

--- a/packages/node/src/login/oidc/refresh/TokenRefresher.ts
+++ b/packages/node/src/login/oidc/refresh/TokenRefresher.ts
@@ -49,7 +49,8 @@ export interface ITokenRefresher {
   refresh(
     localUserId: string,
     refreshToken?: string,
-    dpopKey?: JWK.ECKey
+    dpopKey?: JWK.ECKey,
+    handleRefreshTokenRotation?: (token: string) => unknown
   ): Promise<TokenSet & { access_token: string }>;
 }
 
@@ -68,7 +69,8 @@ export default class TokenRefresher implements ITokenRefresher {
   async refresh(
     sessionId: string,
     refreshToken?: string,
-    dpopKey?: JWK.ECKey
+    dpopKey?: JWK.ECKey,
+    handleRefreshTokenRotation?: (token: string) => unknown
   ): Promise<TokenSet & { access_token: string }> {
     const oidcContext = await loadOidcContextFromStorage(
       sessionId,
@@ -122,6 +124,9 @@ export default class TokenRefresher implements ITokenRefresher {
       await this.storageUtility.setForUser(sessionId, {
         refreshToken: tokenSet.refresh_token,
       });
+      if (handleRefreshTokenRotation !== undefined) {
+        handleRefreshTokenRotation(tokenSet.refresh_token);
+      }
     }
     // The type assertion is fine, since we throw on undefined access_token
     return tokenSet as TokenSet & { access_token: string };

--- a/packages/node/src/login/oidc/refresh/TokenRefresher.ts
+++ b/packages/node/src/login/oidc/refresh/TokenRefresher.ts
@@ -124,7 +124,7 @@ export default class TokenRefresher implements ITokenRefresher {
       await this.storageUtility.setForUser(sessionId, {
         refreshToken: tokenSet.refresh_token,
       });
-      if (onNewRefreshToken !== undefined) {
+      if (typeof onNewRefreshToken === "function") {
         onNewRefreshToken(tokenSet.refresh_token);
       }
     }

--- a/packages/node/src/login/oidc/refresh/TokenRefresher.ts
+++ b/packages/node/src/login/oidc/refresh/TokenRefresher.ts
@@ -50,7 +50,7 @@ export interface ITokenRefresher {
     localUserId: string,
     refreshToken?: string,
     dpopKey?: JWK.ECKey,
-    handleRefreshTokenRotation?: (token: string) => unknown
+    onNewRefreshToken?: (token: string) => unknown
   ): Promise<TokenSet & { access_token: string }>;
 }
 
@@ -70,7 +70,7 @@ export default class TokenRefresher implements ITokenRefresher {
     sessionId: string,
     refreshToken?: string,
     dpopKey?: JWK.ECKey,
-    handleRefreshTokenRotation?: (token: string) => unknown
+    onNewRefreshToken?: (newToken: string) => unknown
   ): Promise<TokenSet & { access_token: string }> {
     const oidcContext = await loadOidcContextFromStorage(
       sessionId,
@@ -124,8 +124,8 @@ export default class TokenRefresher implements ITokenRefresher {
       await this.storageUtility.setForUser(sessionId, {
         refreshToken: tokenSet.refresh_token,
       });
-      if (handleRefreshTokenRotation !== undefined) {
-        handleRefreshTokenRotation(tokenSet.refresh_token);
+      if (onNewRefreshToken !== undefined) {
+        onNewRefreshToken(tokenSet.refresh_token);
       }
     }
     // The type assertion is fine, since we throw on undefined access_token

--- a/packages/node/src/login/oidc/refresh/__mocks__/TokenRefresher.ts
+++ b/packages/node/src/login/oidc/refresh/__mocks__/TokenRefresher.ts
@@ -29,7 +29,7 @@ export const mockTokenRefresher = (
   tokenSet: TokenSet & { access_token: string }
 ): ITokenRefresher => {
   return {
-    refresh: async () => tokenSet,
+    refresh: jest.fn().mockResolvedValue(tokenSet),
   };
 };
 

--- a/packages/node/src/multiSession.ts
+++ b/packages/node/src/multiSession.ts
@@ -44,7 +44,7 @@ import { defaultStorage, Session } from "./Session";
 export async function getSessionFromStorage(
   sessionId: string,
   storage?: IStorage,
-  handleRefreshToken?: (token: string) => unknown
+  onNewRefreshToken?: (newToken: string) => unknown
 ): Promise<Session | undefined> {
   const clientAuth: ClientAuthentication = storage
     ? getClientAuthenticationWithDependencies({
@@ -62,7 +62,7 @@ export async function getSessionFromStorage(
   const session = new Session({
     sessionInfo,
     clientAuthentication: clientAuth,
-    handleRefreshToken,
+    onNewRefreshToken,
   });
   if (sessionInfo.refreshToken) {
     await session.login({

--- a/packages/node/src/multiSession.ts
+++ b/packages/node/src/multiSession.ts
@@ -43,7 +43,8 @@ import { defaultStorage, Session } from "./Session";
  */
 export async function getSessionFromStorage(
   sessionId: string,
-  storage?: IStorage
+  storage?: IStorage,
+  handleRefreshToken?: (token: string) => unknown
 ): Promise<Session | undefined> {
   const clientAuth: ClientAuthentication = storage
     ? getClientAuthenticationWithDependencies({
@@ -61,6 +62,7 @@ export async function getSessionFromStorage(
   const session = new Session({
     sessionInfo,
     clientAuthentication: clientAuth,
+    handleRefreshToken,
   });
   if (sessionInfo.refreshToken) {
     await session.login({


### PR DESCRIPTION
In order to allow for some use cases where using the storage isn't the
most practical solution, this makes it possible to run some custom code
when getting an access token. Two paths are considered:
- when initially logging in, when the refresh token is returned as a
response from the token endpoint. In this case,
`session.handleincomingRedirect` accepts a new parameter,
`handleRefreshToken`, which allows the caller to run custom code at this
point. An example usage for this would be to replace the current
behaviour of `generate-oidc-token`, which looks into the storage to get
the refresh token, and which could instead use this handler.
- when using a refresh token to get a new access token. In this case,
the refresh token may be rotated by the identity provider. The
`session.login` function takes for this use case a new parameter,
`handleRefreshTokenRotation`, which allows the caller to execute custom
code to manage the new refresh token, e.g. in the case the used storage
isn't adapted to handling the token. This would be useful to us in the
case of end-to-end tests, where we could share the new refresh token to
other tests via an environment variable. This could also be useful to NodeJS scripts, in the case they don't implement a persistent storage.

# Checklist

- [X] All acceptance criteria are met.
- [ ] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).