### PR TITLE
Disable ESS-specific session workaround by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased
 
+### Bugfixes
+
+- The workaround to maintain sessions in 1.6.1 has been disabled by default;
+  this means you should see no more (failed) calls to `/session` in your network
+  console. If you want to make sure a session is preserved across page reloads,
+  please see [the documentation on using the `restorePreviousSession`
+  option](https://docs.inrupt.com/developer-tools/javascript/client-libraries/tutorial/restore-session-browser-refresh/).
+
 The following sections document changes that have been released already:
 
 ## 1.8.0 - 2021-04-21

--- a/packages/browser/__tests__/ClientAuthentication.spec.ts
+++ b/packages/browser/__tests__/ClientAuthentication.spec.ts
@@ -228,13 +228,14 @@ describe("ClientAuthentication", () => {
   });
 
   describe("fetch", () => {
-    it("calls fetch using the browser cookies if available", async () => {
+    it("calls fetch", async () => {
       window.fetch = jest.fn();
       const clientAuthn = getClientAuthentication();
       await clientAuthn.fetch("https://html5zombo.com");
-      expect(window.fetch).toHaveBeenCalledWith("https://html5zombo.com", {
-        credentials: "include",
-      });
+      expect(window.fetch).toHaveBeenCalledWith(
+        "https://html5zombo.com",
+        undefined
+      );
     });
   });
 
@@ -260,6 +261,7 @@ describe("ClientAuthentication", () => {
         credentials: "omit",
       });
       // Calling logout should revert back to our un-authenticated fetch.
+      expect(clientAuthn.fetch).toBe(unauthFetch);
       expect(spyFetch).toHaveBeenCalledWith("https://example.com", {
         credentials: "omit",
       });

--- a/packages/browser/examples/single/bundle/package.json
+++ b/packages/browser/examples/single/bundle/package.json
@@ -12,7 +12,6 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC",
   "devDependencies": {
     "@babel/core": "^7.8.6",
     "@babel/preset-env": "^7.8.6",

--- a/packages/browser/examples/single/script/package.json
+++ b/packages/browser/examples/single/script/package.json
@@ -10,7 +10,6 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",
-  "license": "ISC",
   "dependencies": {
     "@types/express": "^4.17.11",
     "express": "^4.17.1"

--- a/packages/browser/src/sessionInfo/SessionInfoManager.ts
+++ b/packages/browser/src/sessionInfo/SessionInfoManager.ts
@@ -34,7 +34,6 @@ import {
 } from "@inrupt/solid-client-authn-core";
 import { v4 } from "uuid";
 import { clearOidcPersistentStorage } from "@inrupt/oidc-client-ext";
-import { fetchWithCookies } from "../ClientAuthentication";
 
 export function getUnauthenticatedSession(): ISessionInfo & {
   fetch: typeof fetch;
@@ -42,7 +41,7 @@ export function getUnauthenticatedSession(): ISessionInfo & {
   return {
     isLoggedIn: false,
     sessionId: v4(),
-    fetch: fetchWithCookies,
+    fetch,
   };
 }
 


### PR DESCRIPTION
The calls to /session that resulted in 404s were confusing to
developers, and a less brittle workaround is now available with
`restorePreviousSession`. ESS has also disabled the option by
default.

- [x] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
