### PR TITLE
Cleanup login options

### DIFF
--- a/packages/browser/__tests__/ClientAuthentication.spec.ts
+++ b/packages/browser/__tests__/ClientAuthentication.spec.ts
@@ -157,7 +157,9 @@ describe("ClientAuthentication", () => {
   describe("login", () => {
     it("calls login, and defaults to a DPoP token", async () => {
       const clientAuthn = getClientAuthentication();
-      await clientAuthn.login("mySession", {
+      await clientAuthn.login({
+        sessionId: "mySession",
+        tokenType: "DPoP",
         clientId: "coolApp",
         redirectUrl: "https://coolapp.com/redirect",
         oidcIssuer: "https://idp.com",
@@ -177,7 +179,8 @@ describe("ClientAuthentication", () => {
 
     it("request a bearer token if specified", async () => {
       const clientAuthn = getClientAuthentication();
-      await clientAuthn.login("mySession", {
+      await clientAuthn.login({
+        sessionId: "mySession",
         clientId: "coolApp",
         redirectUrl: "https://coolapp.com/redirect",
         oidcIssuer: "https://idp.com",
@@ -208,7 +211,9 @@ describe("ClientAuthentication", () => {
       const clientAuthn = getClientAuthentication({
         sessionInfoManager: mockSessionInfoManager(nonEmptyStorage),
       });
-      await clientAuthn.login("someUser", {
+      await clientAuthn.login({
+        sessionId: "someUser",
+        tokenType: "DPoP",
         clientId: "coolApp",
         clientName: "coolApp Name",
         redirectUrl: "https://coolapp.com/redirect",
@@ -296,7 +301,11 @@ describe("ClientAuthentication", () => {
       });
       const session = await clientAuthn.getSessionInfo("mySession");
       // isLoggedIn is stored as a string under the hood, but deserialized as a boolean
-      expect(session).toEqual({ ...sessionInfo, isLoggedIn: true });
+      expect(session).toEqual({
+        ...sessionInfo,
+        isLoggedIn: true,
+        tokenType: "DPoP",
+      });
     });
   });
 

--- a/packages/browser/__tests__/Session.spec.ts
+++ b/packages/browser/__tests__/Session.spec.ts
@@ -122,6 +122,20 @@ describe("Session", () => {
       expect(clientAuthnLogin).toHaveBeenCalled();
     });
 
+    it("Uses the token type provided (if any)", async () => {
+      const clientAuthentication = mockClientAuthentication();
+      const clientAuthnLogin = jest.spyOn(clientAuthentication, "login");
+      const mySession = new Session({ clientAuthentication });
+      await mySession.login({
+        tokenType: "Bearer",
+      });
+      expect(clientAuthnLogin).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tokenType: "Bearer",
+        })
+      );
+    });
+
     it("preserves a binding to its Session instance", async () => {
       const clientAuthentication = mockClientAuthentication();
       const clientAuthnLogin = jest.spyOn(clientAuthentication, "login");
@@ -707,6 +721,7 @@ describe("Session", () => {
         clientAppId: "some client ID",
         clientAppSecret: "some client secret",
         redirectUrl: "https://some.redirect/url",
+        tokenType: "DPoP",
       });
       clientAuthentication.validateCurrentSession = jest
         .fn()
@@ -725,7 +740,9 @@ describe("Session", () => {
       });
       await incomingRedirectPromise;
       await validateCurrentSessionPromise;
-      expect(clientAuthentication.login).toHaveBeenCalledWith("mySession", {
+      expect(clientAuthentication.login).toHaveBeenCalledWith({
+        sessionId: "mySession",
+        tokenType: "DPoP",
         oidcIssuer: "https://some.issuer",
         prompt: "none",
         clientId: "some client ID",

--- a/packages/browser/__tests__/sessionInfo/SessionInfoManager.spec.ts
+++ b/packages/browser/__tests__/sessionInfo/SessionInfoManager.spec.ts
@@ -111,6 +111,7 @@ describe("SessionInfoManager", () => {
             idToken: "some.id.token",
             redirectUrl: "https://some.redirect/url",
             issuer: "https://some.issuer",
+            tokenType: "DPoP",
           },
         })
       );
@@ -129,6 +130,7 @@ describe("SessionInfoManager", () => {
         idToken: "some.id.token",
         refreshToken: "some refresh token",
         redirectUrl: "https://some.redirect/url",
+        tokenType: "DPoP",
       });
     });
 
@@ -157,6 +159,7 @@ describe("SessionInfoManager", () => {
         idToken: undefined,
         refreshToken: undefined,
         redirectUrl: undefined,
+        tokenType: "DPoP",
       });
     });
 
@@ -169,6 +172,34 @@ describe("SessionInfoManager", () => {
     });
 
     it("retrieves internal session information from specified storage", async () => {
+      const sessionId = "commanderCool";
+
+      const webId = "https://zoomies.com/commanderCool#me";
+
+      const storageMock = new StorageUtility(
+        mockStorage({
+          [`solidClientAuthenticationUser:${sessionId}`]: {
+            webId,
+            isLoggedIn: "true",
+          },
+        }),
+        mockStorage({
+          [`solidClientAuthenticationUser:${sessionId}`]: {
+            issuer: "https://my.idp",
+            tokenType: "Some arbitrary token type",
+          },
+        })
+      );
+
+      const sessionManager = getSessionInfoManager({
+        storageUtility: storageMock,
+      });
+      await expect(sessionManager.get(sessionId)).rejects.toThrow(
+        "Tokens of type [Some arbitrary token type] are not supported."
+      );
+    });
+
+    it("throws if the stored token type isn't supported", async () => {
       const sessionId = "commanderCool";
 
       const webId = "https://zoomies.com/commanderCool#me";

--- a/packages/browser/src/Session.ts
+++ b/packages/browser/src/Session.ts
@@ -107,12 +107,14 @@ async function silentlyAuthenticate(
     // on incoming redirect. This way, the user is eventually redirected back
     // to the page they were on and not to the app's redirect page.
     window.localStorage.setItem(KEY_CURRENT_URL, window.location.href);
-    await clientAuthn.login(sessionId, {
+    await clientAuthn.login({
+      sessionId,
       prompt: "none",
       oidcIssuer: storedSessionInfo.issuer,
       redirectUrl: storedSessionInfo.redirectUrl,
       clientId: storedSessionInfo.clientAppId,
       clientSecret: storedSessionInfo.clientAppSecret,
+      tokenType: storedSessionInfo.tokenType ?? "DPoP",
     });
   }
 }
@@ -188,8 +190,11 @@ export class Session extends EventEmitter {
   // Define these functions as properties so that they don't get accidentally re-bound.
   // Isn't Javascript fun?
   login = async (options: ILoginInputOptions): Promise<void> => {
-    await this.clientAuthentication.login(this.info.sessionId, {
+    await this.clientAuthentication.login({
+      sessionId: this.info.sessionId,
       ...options,
+      // Defaults the token type to DPoP
+      tokenType: options.tokenType ?? "DPoP",
     });
   };
 

--- a/packages/browser/src/sessionInfo/SessionInfoManager.ts
+++ b/packages/browser/src/sessionInfo/SessionInfoManager.ts
@@ -31,6 +31,7 @@ import {
   ISessionInternalInfo,
   ISessionInfoManagerOptions,
   IStorageUtility,
+  isSupportedTokenType,
 } from "@inrupt/solid-client-authn-core";
 import { v4 } from "uuid";
 import { clearOidcPersistentStorage } from "@inrupt/oidc-client-ext";
@@ -176,6 +177,15 @@ export class SessionInfoManager implements ISessionInfoManager {
       secure: false,
     });
 
+    const tokenType =
+      (await this.storageUtility.getForUser(sessionId, "tokenType", {
+        secure: false,
+      })) ?? "DPoP";
+
+    if (!isSupportedTokenType(tokenType)) {
+      throw new Error(`Tokens of type [${tokenType}] are not supported.`);
+    }
+
     if (
       clientId === undefined &&
       idToken === undefined &&
@@ -196,6 +206,7 @@ export class SessionInfoManager implements ISessionInfoManager {
       issuer,
       clientAppId: clientId,
       clientAppSecret: clientSecret,
+      tokenType,
     };
   }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -40,7 +40,11 @@ export {
 } from "./login/oidc/redirectHandler/IRedirectHandler";
 export { IRedirector, IRedirectorOptions } from "./login/oidc/IRedirector";
 
-export { ISessionInfo, ISessionInternalInfo } from "./sessionInfo/ISessionInfo";
+export {
+  ISessionInfo,
+  ISessionInternalInfo,
+  isSupportedTokenType,
+} from "./sessionInfo/ISessionInfo";
 export {
   ISessionInfoManager,
   ISessionInfoManagerOptions,

--- a/packages/core/src/sessionInfo/ISessionInfo.spec.ts
+++ b/packages/core/src/sessionInfo/ISessionInfo.spec.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2021 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { isSupportedTokenType } from "./ISessionInfo";
+
+describe("isSupportedTokenType", () => {
+  it("returns true for supported token types", async () => {
+    expect(isSupportedTokenType("DPoP")).toBe(true);
+    expect(isSupportedTokenType("Bearer")).toBe(true);
+  });
+
+  it("returns false for unkonwn token types", async () => {
+    expect(isSupportedTokenType("SomeTokenType")).toBe(false);
+    expect(isSupportedTokenType("")).toBe(false);
+    expect(isSupportedTokenType((undefined as unknown) as string)).toBe(false);
+  });
+});

--- a/packages/core/src/sessionInfo/ISessionInfo.ts
+++ b/packages/core/src/sessionInfo/ISessionInfo.ts
@@ -85,4 +85,15 @@ export interface ISessionInternalInfo {
    * WebIDs, the client secret is still required at the token endpoint.
    */
   clientAppSecret?: string;
+
+  /**
+   * The token type used by the session
+   */
+  tokenType?: "DPoP" | "Bearer";
+}
+
+export function isSupportedTokenType(
+  token: string | "DPoP" | "Bearer"
+): token is "DPoP" | "Bearer" {
+  return typeof token === "string" && ["DPoP", "Bearer"].includes(token);
 }


### PR DESCRIPTION
This internal refactor simply changes some internal interfaces (so it's a non-breaking change) in order to make the configuration of iframe-based behaviour cleaner. This mostly intends at removing duplication between login options objects at the different levels (Session, ClientAuthentication, OIDC handler). Note that this change doesn't contain anything iframe-based yet, this is just a preparatory PR to make review easier.

# Checklist

- [X] All acceptance criteria are met.
- [X] New functions/types have been exported in `index.ts`, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).