### PR TITLE
Skip node e2e tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,8 @@ jobs:
       - # Dependabot cannot access secrets, so it doesn't have a token to authenticate to ESS.
         # Since all the other jobs of this workflow depend on this one, skipping it should
         # skip the entire workflow.
-        if: ${{ github.actor != 'dependabot[bot]' }}
+        # Temporary: always skip end-to-end tests until authentication is fixed.
+        if: ${{ github.actor != 'dependabot[bot]' && false  }}
         run: npm run e2e-test
         env: 
           E2E_TEST_REFRESH_TOKEN: ${{ secrets.E2E_TEST_REFRESH_TOKEN }}


### PR DESCRIPTION
The current auth workaround, i.e. using an NSS instance as our Solid
Identity Provider, isn't very helpful, because it keeps timing out, and
that's introducing a weird bug where Jest never completes the tests.
It complains that some async code never resolved, but when using the
proposed debug method (`--detectOpenHandles`) the bug doesn't manifest
clearly, and it's a pain to debug.

Given that we're looking at changing this approach anyway, this
disables e2e tests instead of trying to figure out how to work with
NSS, which we know has some performance issues.