### PR TITLE
Implement support for client credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased
 
+### New features
+
+#### node
+
+- Client credential grant: for Solid Identity Providers which support it, a client
+may statically register, and use the obtained credentials (client ID and secret)
+to log in to an Identity Provider. This is convenient in some cases, such as CI
+environment. However, it requires offline provider/client interaction, which does
+not scale in the decentralized ecosystem of Solid. As such, it should only be
+used in specific cases.
+
 The following sections document changes that have been released already:
 
 ## 1.8.1 - 2021-04-30

--- a/packages/core/src/login/oidc/IClient.ts
+++ b/packages/core/src/login/oidc/IClient.ts
@@ -32,4 +32,5 @@ export interface IClient {
   clientSecret?: string;
   clientName?: string;
   idTokenSignedResponseAlg?: string;
+  isPublic?: boolean;
 }

--- a/packages/core/src/login/oidc/IClientRegistrar.ts
+++ b/packages/core/src/login/oidc/IClientRegistrar.ts
@@ -115,5 +115,6 @@ export async function handleRegistration(
     clientId: options.clientId,
     clientSecret: options.clientSecret,
     clientName: options.clientName,
+    isPublic: false,
   };
 }

--- a/packages/node/src/authenticatedFetch/fetchFactory.ts
+++ b/packages/node/src/authenticatedFetch/fetchFactory.ts
@@ -262,3 +262,23 @@ export async function buildDpopFetch(
     return response;
   };
 }
+
+/**
+ * @param authToken a DPoP token.
+ * @param dpopKey The private key the token is bound to.
+ * @param
+ * @returns A fetch function that adds an Authorization header with the provided
+ * DPoP token, and adds a dpop header.
+ */
+export async function buildAuthenticatedFetch(
+  accessToken: string,
+  options?: {
+    dpopKey?: JWK.ECKey;
+    refreshOptions?: RefreshOptions;
+  }
+): Promise<typeof fetch> {
+  if (options?.dpopKey) {
+    return buildDpopFetch(accessToken, options.dpopKey, options.refreshOptions);
+  }
+  return buildBearerFetch(accessToken, options?.refreshOptions);
+}

--- a/packages/node/src/dependencies.ts
+++ b/packages/node/src/dependencies.ts
@@ -100,16 +100,16 @@ container.register<IOidcHandler>("node:oidcHandler", {
 container.register<IOidcHandler>("node:oidcHandlers", {
   useClass: RefreshTokenOidcHandler,
 });
-
+// The client credential handler must be called before the auth code one,
+// since it is less generic.
+container.register<IOidcHandler>("node:oidcHandlers", {
+  useClass: ClientCredentialsOidcHandler,
+});
 container.register<IOidcHandler>("node:oidcHandlers", {
   useClass: AuthorizationCodeOidcHandler,
 });
 container.register<IOidcHandler>("node:oidcHandlers", {
   useClass: AuthorizationCodeWithPkceOidcHandler,
-});
-
-container.register<IOidcHandler>("node:oidcHandlers", {
-  useClass: ClientCredentialsOidcHandler,
 });
 container.register<IOidcHandler>("node:oidcHandlers", {
   useClass: PrimaryDeviceOidcHandler,

--- a/packages/node/src/login/oidc/ClientRegistrar.spec.ts
+++ b/packages/node/src/login/oidc/ClientRegistrar.spec.ts
@@ -85,6 +85,7 @@ describe("ClientRegistrar", () => {
               clientSecret: "a secret",
               clientName: "my client name",
               idTokenSignedResponseAlg: "ES256",
+              isPublic: "true",
             },
           },
           false
@@ -99,10 +100,11 @@ describe("ClientRegistrar", () => {
           ...IssuerConfigFetcherFetchConfigResponse,
         }
       );
-      expect(client.clientId).toEqual("an id");
-      expect(client.clientSecret).toEqual("a secret");
-      expect(client.clientName).toEqual("my client name");
-      expect(client.idTokenSignedResponseAlg).toEqual("ES256");
+      expect(client.clientId).toBe("an id");
+      expect(client.clientSecret).toBe("a secret");
+      expect(client.clientName).toBe("my client name");
+      expect(client.idTokenSignedResponseAlg).toBe("ES256");
+      expect(client.isPublic).toBe(true);
     });
 
     it("properly performs dynamic registration and saves client information", async () => {
@@ -134,26 +136,26 @@ describe("ClientRegistrar", () => {
       );
 
       // Check that the returned value is what we expect
-      expect(client.clientId).toEqual(mockDefaultClientConfig().client_id);
-      expect(client.clientSecret).toEqual(
-        mockDefaultClientConfig().client_secret
-      );
-      expect(client.idTokenSignedResponseAlg).toEqual(
+      expect(client.clientId).toBe(mockDefaultClientConfig().client_id);
+      expect(client.clientSecret).toBe(mockDefaultClientConfig().client_secret);
+      expect(client.idTokenSignedResponseAlg).toBe(
         mockDefaultClientConfig().id_token_signed_response_alg
       );
+      expect(client.isPublic).toBe(mockDefaultClientConfig().isPublic);
 
       // Check that the client information have been saved in storage
       await expect(
         mockStorage.getForUser("mySession", "clientId")
-      ).resolves.toEqual(mockDefaultClientConfig().client_id);
+      ).resolves.toBe(mockDefaultClientConfig().client_id);
       await expect(
         mockStorage.getForUser("mySession", "clientSecret")
-      ).resolves.toEqual(mockDefaultClientConfig().client_secret);
+      ).resolves.toBe(mockDefaultClientConfig().client_secret);
       await expect(
         mockStorage.getForUser("mySession", "idTokenSignedResponseAlg")
-      ).resolves.toEqual(
-        mockDefaultClientConfig().id_token_signed_response_alg
-      );
+      ).resolves.toBe(mockDefaultClientConfig().id_token_signed_response_alg);
+      await expect(
+        mockStorage.getForUser("mySession", "isPublic")
+      ).resolves.toBe("true");
     });
 
     it("throws if the issuer doesn't avertise for supported signing algorithms", async () => {

--- a/packages/node/src/login/oidc/ClientRegistrar.ts
+++ b/packages/node/src/login/oidc/ClientRegistrar.ts
@@ -84,11 +84,13 @@ export default class ClientRegistrar implements IClientRegistrar {
       storedClientId,
       storedClientSecret,
       storedClientName,
+      storedIsPublic,
       storedIdTokenSignedResponseAlg,
     ] = await Promise.all([
       this.storageUtility.getForUser(options.sessionId, "clientId"),
       this.storageUtility.getForUser(options.sessionId, "clientSecret"),
       this.storageUtility.getForUser(options.sessionId, "clientName"),
+      this.storageUtility.getForUser(options.sessionId, "isPublic"),
       this.storageUtility.getForUser(
         options.sessionId,
         "idTokenSignedResponseAlg"
@@ -100,6 +102,7 @@ export default class ClientRegistrar implements IClientRegistrar {
         clientSecret: storedClientSecret,
         clientName: storedClientName as string | undefined,
         idTokenSignedResponseAlg: storedIdTokenSignedResponseAlg,
+        isPublic: storedIsPublic === "true",
       };
     }
     const extendedOptions = { ...options };
@@ -148,6 +151,7 @@ export default class ClientRegistrar implements IClientRegistrar {
       clientId: registeredClient.metadata.client_id,
       idTokenSignedResponseAlg:
         registeredClient.metadata.id_token_signed_response_alg ?? signingAlg,
+      isPublic: "true",
     };
     if (registeredClient.metadata.client_secret) {
       infoToSave.clientSecret = registeredClient.metadata.client_secret;
@@ -159,6 +163,7 @@ export default class ClientRegistrar implements IClientRegistrar {
       clientName: registeredClient.metadata.client_name as string | undefined,
       idTokenSignedResponseAlg:
         registeredClient.metadata.id_token_signed_response_alg ?? signingAlg,
+      isPublic: true,
     };
   }
 }

--- a/packages/node/src/login/oidc/__mocks__/ClientRegistrar.ts
+++ b/packages/node/src/login/oidc/__mocks__/ClientRegistrar.ts
@@ -59,6 +59,7 @@ export const mockDefaultClientConfig = (): ClientMetadata => {
     redirect_uris: ["https://my.app/redirect"],
     response_types: ["code"],
     id_token_signed_response_alg: "RS256",
+    isPublic: true,
   };
 };
 

--- a/packages/node/src/login/oidc/__mocks__/IOidcOptions.ts
+++ b/packages/node/src/login/oidc/__mocks__/IOidcOptions.ts
@@ -38,6 +38,7 @@ export const standardOidcOptions: IOidcOptions = {
   },
   client: {
     clientId: "coolApp",
+    isPublic: true,
   },
 };
 

--- a/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.spec.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.spec.ts
@@ -53,7 +53,35 @@ describe("ClientCredentialsOidcHandler", () => {
       ).resolves.toEqual(false);
     });
 
-    it("can handle if both client ID and secret are present", async () => {
+    it("cannot handle if the client is public", async () => {
+      const clientCredentialsOidcHandler = new ClientCredentialsOidcHandler();
+      await expect(
+        clientCredentialsOidcHandler.canHandle({
+          ...standardOidcOptions,
+          client: {
+            clientId: "some client ID",
+            clientSecret: "some secret",
+            isPublic: true,
+          },
+        })
+      ).resolves.toEqual(false);
+    });
+
+    it("cannot handle if the client's nature (public or confidential) is unknown", async () => {
+      const clientCredentialsOidcHandler = new ClientCredentialsOidcHandler();
+      await expect(
+        clientCredentialsOidcHandler.canHandle({
+          ...standardOidcOptions,
+          client: {
+            clientId: "some client ID",
+            clientSecret: "some secret",
+            isPublic: (undefined as unknown) as boolean,
+          },
+        })
+      ).resolves.toEqual(false);
+    });
+
+    it("can handle if both client ID and secret are present for a confidential client", async () => {
       const clientCredentialsOidcHandler = new ClientCredentialsOidcHandler();
       await expect(
         clientCredentialsOidcHandler.canHandle({
@@ -61,6 +89,7 @@ describe("ClientCredentialsOidcHandler", () => {
           client: {
             clientId: "some client ID",
             clientSecret: "some client secret",
+            isPublic: false,
           },
         })
       ).resolves.toEqual(true);

--- a/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.spec.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.spec.ts
@@ -22,14 +22,19 @@
 /**
  * Test for AuthorizationCodeWithPkceOidcHandler
  */
+import { mockStorageUtility } from "@inrupt/solid-client-authn-core";
 import "reflect-metadata";
+import { mockDefaultTokenRefresher } from "../refresh/__mocks__/TokenRefresher";
 import { standardOidcOptions } from "../__mocks__/IOidcOptions";
 import ClientCredentialsOidcHandler from "./ClientCredentialsOidcHandler";
 
 describe("ClientCredentialsOidcHandler", () => {
   describe("canHandle", () => {
     it("cannot handle if the client ID is missing", async () => {
-      const clientCredentialsOidcHandler = new ClientCredentialsOidcHandler();
+      const clientCredentialsOidcHandler = new ClientCredentialsOidcHandler(
+        mockDefaultTokenRefresher(),
+        mockStorageUtility({})
+      );
       await expect(
         clientCredentialsOidcHandler.canHandle({
           ...standardOidcOptions,
@@ -41,7 +46,10 @@ describe("ClientCredentialsOidcHandler", () => {
     });
 
     it("cannot handle if the client secret is missing", async () => {
-      const clientCredentialsOidcHandler = new ClientCredentialsOidcHandler();
+      const clientCredentialsOidcHandler = new ClientCredentialsOidcHandler(
+        mockDefaultTokenRefresher(),
+        mockStorageUtility({})
+      );
       await expect(
         clientCredentialsOidcHandler.canHandle({
           ...standardOidcOptions,
@@ -54,7 +62,10 @@ describe("ClientCredentialsOidcHandler", () => {
     });
 
     it("cannot handle if the client is public", async () => {
-      const clientCredentialsOidcHandler = new ClientCredentialsOidcHandler();
+      const clientCredentialsOidcHandler = new ClientCredentialsOidcHandler(
+        mockDefaultTokenRefresher(),
+        mockStorageUtility({})
+      );
       await expect(
         clientCredentialsOidcHandler.canHandle({
           ...standardOidcOptions,
@@ -68,7 +79,10 @@ describe("ClientCredentialsOidcHandler", () => {
     });
 
     it("cannot handle if the client's nature (public or confidential) is unknown", async () => {
-      const clientCredentialsOidcHandler = new ClientCredentialsOidcHandler();
+      const clientCredentialsOidcHandler = new ClientCredentialsOidcHandler(
+        mockDefaultTokenRefresher(),
+        mockStorageUtility({})
+      );
       await expect(
         clientCredentialsOidcHandler.canHandle({
           ...standardOidcOptions,
@@ -82,7 +96,10 @@ describe("ClientCredentialsOidcHandler", () => {
     });
 
     it("can handle if both client ID and secret are present for a confidential client", async () => {
-      const clientCredentialsOidcHandler = new ClientCredentialsOidcHandler();
+      const clientCredentialsOidcHandler = new ClientCredentialsOidcHandler(
+        mockDefaultTokenRefresher(),
+        mockStorageUtility({})
+      );
       await expect(
         clientCredentialsOidcHandler.canHandle({
           ...standardOidcOptions,
@@ -98,7 +115,10 @@ describe("ClientCredentialsOidcHandler", () => {
 
   describe("handle", () => {
     it("isn't implemented yet", async () => {
-      const clientCredentialsOidcHandler = new ClientCredentialsOidcHandler();
+      const clientCredentialsOidcHandler = new ClientCredentialsOidcHandler(
+        mockDefaultTokenRefresher(),
+        mockStorageUtility({})
+      );
       await expect(() =>
         clientCredentialsOidcHandler.handle(standardOidcOptions)
       ).rejects.toThrow("not implemented");

--- a/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.spec.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.spec.ts
@@ -28,11 +28,42 @@ import ClientCredentialsOidcHandler from "./ClientCredentialsOidcHandler";
 
 describe("ClientCredentialsOidcHandler", () => {
   describe("canHandle", () => {
-    it("doesn't handle anything", async () => {
+    it("cannot handle if the client ID is missing", async () => {
       const clientCredentialsOidcHandler = new ClientCredentialsOidcHandler();
       await expect(
-        clientCredentialsOidcHandler.canHandle(standardOidcOptions)
+        clientCredentialsOidcHandler.canHandle({
+          ...standardOidcOptions,
+          client: {
+            clientId: (undefined as unknown) as string,
+          },
+        })
       ).resolves.toEqual(false);
+    });
+
+    it("cannot handle if the client secret is missing", async () => {
+      const clientCredentialsOidcHandler = new ClientCredentialsOidcHandler();
+      await expect(
+        clientCredentialsOidcHandler.canHandle({
+          ...standardOidcOptions,
+          client: {
+            clientId: "some client ID",
+            clientSecret: undefined,
+          },
+        })
+      ).resolves.toEqual(false);
+    });
+
+    it("can handle if both client ID and secret are present", async () => {
+      const clientCredentialsOidcHandler = new ClientCredentialsOidcHandler();
+      await expect(
+        clientCredentialsOidcHandler.canHandle({
+          ...standardOidcOptions,
+          client: {
+            clientId: "some client ID",
+            clientSecret: "some client secret",
+          },
+        })
+      ).resolves.toEqual(true);
     });
   });
 

--- a/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.spec.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.spec.ts
@@ -24,9 +24,102 @@
  */
 import { mockStorageUtility } from "@inrupt/solid-client-authn-core";
 import "reflect-metadata";
+import { it, describe } from "@jest/globals";
+import { IdTokenClaims, TokenSet } from "openid-client";
+import { JWK } from "jose";
 import { mockDefaultTokenRefresher } from "../refresh/__mocks__/TokenRefresher";
 import { standardOidcOptions } from "../__mocks__/IOidcOptions";
 import ClientCredentialsOidcHandler from "./ClientCredentialsOidcHandler";
+
+import { mockDefaultIssuerConfig } from "../__mocks__/IssuerConfigFetcher";
+
+jest.mock("openid-client");
+jest.mock("cross-fetch");
+
+const mockJwk = (): JWK.ECKey =>
+  JWK.asKey({
+    kty: "EC",
+    kid: "oOArcXxcwvsaG21jAx_D5CHr4BgVCzCEtlfmNFQtU0s",
+    alg: "ES256",
+    crv: "P-256",
+    x: "0dGe_s-urLhD3mpqYqmSXrqUZApVV5ZNxMJXg7Vp-2A",
+    y: "-oMe9gGkpfIrnJ0aiSUHMdjqYVm5ZrGCeQmRKoIIfj8",
+    d: "yR1bCsR7m4hjFCvWo8Jw3OfNR4aiYDAFbBD9nkudJKM",
+  });
+
+const mockIdToken = (): string =>
+  "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJodHRwczovL215LndlYmlkIiwiaXNzIjoiaHR0cHM6Ly9teS5pZHAvIiwiYXVkIjoiaHR0cHM6Ly9yZXNvdXJjZS5leGFtcGxlLm9yZyIsImV4cCI6MTY2MjI2NjIxNiwiaWF0IjoxNDYyMjY2MjE2fQ.IwumuwJtQw5kUBMMHAaDPJBppfBpRHbiXZw_HlKe6GNVUWUlyQRYV7W7r9OQtHmMsi6GVwOckelA3ErmhrTGVw";
+
+type AccessJwt = {
+  sub: string;
+  iss: string;
+  aud: string;
+  nbf: number;
+  exp: number;
+  cnf: {
+    jkt: string;
+  };
+};
+
+const mockWebId = (): string => "https://my.webid/";
+
+const mockKeyBoundToken = (): AccessJwt => {
+  return {
+    sub: mockWebId(),
+    iss: mockDefaultIssuerConfig().issuer.toString(),
+    aud: "https://resource.example.org",
+    nbf: 1562262611,
+    exp: 1562266216,
+    cnf: {
+      jkt: mockJwk().kid as string,
+    },
+  };
+};
+
+const mockIdTokenPayload = (): IdTokenClaims => {
+  return {
+    sub: "https://my.webid/",
+    iss: "https://my.idp/",
+    aud: "https://resource.example.org",
+    exp: 1662266216,
+    iat: 1462266216,
+  };
+};
+
+const mockDpopTokens = (): TokenSet => {
+  return {
+    access_token: JSON.stringify(mockKeyBoundToken()),
+    id_token: mockIdToken(),
+    token_type: "DPoP",
+    expired: () => false,
+    claims: mockIdTokenPayload,
+  };
+};
+
+const mockBearerTokens = (): TokenSet => {
+  return {
+    access_token: "some token",
+    id_token: mockIdToken(),
+    token_type: "Bearer",
+    expired: () => false,
+    claims: mockIdTokenPayload,
+  };
+};
+
+const setupOidcClientMock = (tokenSet: TokenSet) => {
+  const { Issuer } = jest.requireMock("openid-client");
+  function clientConstructor() {
+    // this is untyped, which makes TS complain
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    this.grant = jest.fn().mockResolvedValueOnce(tokenSet);
+  }
+  const mockedIssuer = {
+    metadata: mockDefaultIssuerConfig(),
+    Client: clientConstructor,
+  };
+  Issuer.mockReturnValueOnce(mockedIssuer);
+};
 
 describe("ClientCredentialsOidcHandler", () => {
   describe("canHandle", () => {
@@ -112,16 +205,157 @@ describe("ClientCredentialsOidcHandler", () => {
       ).resolves.toEqual(true);
     });
   });
+});
 
-  describe("handle", () => {
-    it("isn't implemented yet", async () => {
-      const clientCredentialsOidcHandler = new ClientCredentialsOidcHandler(
-        mockDefaultTokenRefresher(),
-        mockStorageUtility({})
-      );
-      await expect(() =>
-        clientCredentialsOidcHandler.handle(standardOidcOptions)
-      ).rejects.toThrow("not implemented");
+describe("handle", () => {
+  it("throws if the issuer does not return an access token", async () => {
+    const tokens = mockDpopTokens();
+    tokens.access_token = undefined;
+    setupOidcClientMock(tokens);
+    const clientCredentialsOidcHandler = new ClientCredentialsOidcHandler(
+      mockDefaultTokenRefresher(),
+      mockStorageUtility({})
+    );
+    await expect(
+      clientCredentialsOidcHandler.handle({
+        ...standardOidcOptions,
+        client: {
+          clientId: "some client ID",
+          clientSecret: "some client secret",
+          isPublic: false,
+        },
+      })
+    ).rejects.toThrow(
+      /Invalid response from Solid Identity Provider \[.+\]: \{.+\} is missing 'access_token'/
+    );
+  });
+
+  it("throws if the issuer does not return an ID token", async () => {
+    const tokens = mockDpopTokens();
+    tokens.id_token = undefined;
+    setupOidcClientMock(tokens);
+    const clientCredentialsOidcHandler = new ClientCredentialsOidcHandler(
+      mockDefaultTokenRefresher(),
+      mockStorageUtility({})
+    );
+    await expect(
+      clientCredentialsOidcHandler.handle({
+        ...standardOidcOptions,
+        client: {
+          clientId: "some client ID",
+          clientSecret: "some client secret",
+          isPublic: false,
+        },
+      })
+    ).rejects.toThrow(
+      /Invalid response from Solid Identity Provider \[.+\]: \{.+\} is missing 'id_token'/
+    );
+  });
+
+  it("builds a fetch authenticated with a DPoP token if appropriate", async () => {
+    const tokens = mockDpopTokens();
+    setupOidcClientMock(tokens);
+    const clientCredentialsOidcHandler = new ClientCredentialsOidcHandler(
+      mockDefaultTokenRefresher(),
+      mockStorageUtility({})
+    );
+    const result = await clientCredentialsOidcHandler.handle({
+      ...standardOidcOptions,
+      dpop: true,
+      client: {
+        clientId: "some client ID",
+        clientSecret: "some client secret",
+        isPublic: false,
+      },
     });
+
+    const mockedFetch = jest.requireMock("cross-fetch");
+    mockedFetch.mockResolvedValue({
+      status: 200,
+      url: "https://some.pod/resource",
+    });
+    await result?.fetch("https://some.pod/resource");
+    expect(mockedFetch.mock.calls[0][1].headers.Authorization).toContain(
+      `DPoP ${tokens.access_token}`
+    );
+  });
+
+  it("builds a fetch authenticated with a Bearer token if appropriate", async () => {
+    const tokens = mockBearerTokens();
+    setupOidcClientMock(tokens);
+    const clientCredentialsOidcHandler = new ClientCredentialsOidcHandler(
+      mockDefaultTokenRefresher(),
+      mockStorageUtility({})
+    );
+    const result = await clientCredentialsOidcHandler.handle({
+      ...standardOidcOptions,
+      dpop: false,
+      client: {
+        clientId: "some client ID",
+        clientSecret: "some client secret",
+        isPublic: false,
+      },
+    });
+
+    const mockedFetch = jest.requireMock("cross-fetch");
+    mockedFetch.mockResolvedValue({
+      status: 200,
+      url: "https://some.pod/resource",
+    });
+    await result?.fetch("https://some.pod/resource");
+    expect(mockedFetch.mock.calls[0][1].headers.Authorization).toContain(
+      `Bearer ${tokens.access_token}`
+    );
+  });
+
+  it("builds a fetch authenticated handling the refresh flow if appropriate", async () => {
+    const tokens = mockDpopTokens();
+    tokens.refresh_token = "some refresh token";
+    setupOidcClientMock(tokens);
+    const refresher = mockDefaultTokenRefresher();
+    const clientCredentialsOidcHandler = new ClientCredentialsOidcHandler(
+      refresher,
+      mockStorageUtility({})
+    );
+    const result = await clientCredentialsOidcHandler.handle({
+      ...standardOidcOptions,
+      dpop: true,
+      client: {
+        clientId: "some client ID",
+        clientSecret: "some client secret",
+        isPublic: false,
+      },
+    });
+
+    const mockedFetch = jest.requireMock("cross-fetch");
+    // A 401 error triggers the refresh flow.
+    mockedFetch.mockResolvedValue({
+      status: 401,
+      url: "https://some.pod/resource",
+    });
+    await result?.fetch("https://some.pod/resource");
+    expect(refresher.refresh).toHaveBeenCalled();
+  });
+
+  it("returns session info with the built fetch", async () => {
+    const tokens = mockDpopTokens();
+    setupOidcClientMock(tokens);
+    const clientCredentialsOidcHandler = new ClientCredentialsOidcHandler(
+      mockDefaultTokenRefresher(),
+      mockStorageUtility({})
+    );
+    const result = await clientCredentialsOidcHandler.handle({
+      ...standardOidcOptions,
+      dpop: true,
+      client: {
+        clientId: "some client ID",
+        clientSecret: "some client secret",
+        isPublic: false,
+      },
+    });
+
+    expect(result?.isLoggedIn).toBe(true);
+    expect(result?.sessionId).toBe(standardOidcOptions.sessionId);
+    expect(result?.webId).toBe(mockIdTokenPayload().sub);
   });
 });

--- a/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.ts
@@ -30,14 +30,28 @@
 import {
   IOidcHandler,
   IOidcOptions,
-  NotImplementedError,
   LoginResult,
+  IStorageUtility,
+  ISessionInfo,
 } from "@inrupt/solid-client-authn-core";
+import { JWK } from "jose";
+import { Issuer } from "openid-client";
+import { inject, injectable } from "tsyringe";
+import { buildDpopFetch } from "../../../authenticatedFetch/fetchFactory";
+import { configToIssuerMetadata } from "../IssuerConfigFetcher";
+import { getWebidFromTokenPayload } from "../redirectHandler/AuthCodeRedirectHandler";
+import { ITokenRefresher } from "../refresh/TokenRefresher";
 
 /**
  * @hidden
  */
+@injectable()
 export default class ClientCredentialsOidcHandler implements IOidcHandler {
+  constructor(
+    @inject("node:tokenRefresher") private tokenRefresher: ITokenRefresher,
+    @inject("node:storageUtility") private storageUtility: IStorageUtility
+  ) {}
+
   async canHandle(oidcLoginOptions: IOidcOptions): Promise<boolean> {
     return (
       typeof oidcLoginOptions.client.clientId === "string" &&
@@ -47,7 +61,74 @@ export default class ClientCredentialsOidcHandler implements IOidcHandler {
     );
   }
 
-  async handle(_oidcLoginOptions: IOidcOptions): Promise<LoginResult> {
-    throw new NotImplementedError("ClientCredentialsOidcHandler handle");
+  async handle(oidcLoginOptions: IOidcOptions): Promise<LoginResult> {
+    const issuer = new Issuer(
+      configToIssuerMetadata(oidcLoginOptions.issuerConfiguration)
+    );
+    const client = new issuer.Client({
+      client_id: oidcLoginOptions.client.clientId,
+      client_secret: oidcLoginOptions.client.clientSecret,
+    });
+
+    // This information must be in storage for the refresh flow to succeed.
+    await this.storageUtility.setForUser(oidcLoginOptions.sessionId, {
+      issuer: oidcLoginOptions.issuer,
+      dpop: oidcLoginOptions.dpop ? "true" : "false",
+      clientId: oidcLoginOptions.client.clientId,
+      // Note: We assume here that a client secret is present, which is checked for when validating the options.
+      clientSecret: oidcLoginOptions.client.clientSecret as string,
+    });
+
+    const dpopKey = await JWK.generate("EC", "P-256");
+
+    const tokens = await client.grant(
+      {
+        grant_type: "client_credentials",
+        client_id: oidcLoginOptions.client.clientId,
+        client_secret: oidcLoginOptions.client.clientSecret,
+        token_endpoint_auth_method: "client_secret_post",
+      },
+      {
+        DPoP: dpopKey?.toJWK(true),
+      }
+    );
+
+    if (tokens.access_token === undefined) {
+      throw new Error(
+        `Invalid response from Solid Identity Provider: ${JSON.stringify(
+          tokens
+        )} is missing 'access_token'.`
+      );
+    }
+
+    const authFetch = await buildDpopFetch(
+      tokens.access_token,
+      dpopKey,
+      tokens.refresh_token
+        ? {
+            // The type assertion is okay, because it is tested for in canHandle.
+            refreshToken: tokens.refresh_token,
+            sessionId: oidcLoginOptions.sessionId,
+            tokenRefresher: this.tokenRefresher,
+            onNewRefreshToken: oidcLoginOptions.onNewRefreshToken,
+          }
+        : undefined
+    );
+
+    const sessionInfo: ISessionInfo = {
+      isLoggedIn: true,
+      sessionId: oidcLoginOptions.sessionId,
+    };
+
+    if (tokens.id_token === undefined) {
+      throw new Error(
+        `The Identity Provider [${oidcLoginOptions.issuer}] did not return an ID token on refresh, which prevents us from getting the user's WebID.`
+      );
+    }
+    sessionInfo.webId = await getWebidFromTokenPayload(tokens.claims());
+
+    return Object.assign(sessionInfo, {
+      fetch: authFetch,
+    });
   }
 }

--- a/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.ts
@@ -41,7 +41,9 @@ export default class ClientCredentialsOidcHandler implements IOidcHandler {
   async canHandle(oidcLoginOptions: IOidcOptions): Promise<boolean> {
     return (
       typeof oidcLoginOptions.client.clientId === "string" &&
-      typeof oidcLoginOptions.client.clientSecret === "string"
+      typeof oidcLoginOptions.client.clientSecret === "string" &&
+      typeof oidcLoginOptions.client.isPublic === "boolean" &&
+      !oidcLoginOptions.client.isPublic
     );
   }
 

--- a/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.ts
@@ -40,8 +40,8 @@ import {
 export default class ClientCredentialsOidcHandler implements IOidcHandler {
   async canHandle(oidcLoginOptions: IOidcOptions): Promise<boolean> {
     return (
-      oidcLoginOptions.client.clientId !== undefined &&
-      oidcLoginOptions.client.clientSecret !== undefined
+      typeof oidcLoginOptions.client.clientId === "string" &&
+      typeof oidcLoginOptions.client.clientSecret === "string"
     );
   }
 

--- a/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.ts
@@ -38,8 +38,11 @@ import {
  * @hidden
  */
 export default class ClientCredentialsOidcHandler implements IOidcHandler {
-  async canHandle(_oidcLoginOptions: IOidcOptions): Promise<boolean> {
-    return false;
+  async canHandle(oidcLoginOptions: IOidcOptions): Promise<boolean> {
+    return (
+      oidcLoginOptions.client.clientId !== undefined &&
+      oidcLoginOptions.client.clientSecret !== undefined
+    );
   }
 
   async handle(_oidcLoginOptions: IOidcOptions): Promise<LoginResult> {


### PR DESCRIPTION
The client credential handle only considers requests where both the
client ID and secret are defined. Only confidential clients are considered
for client credentials, public client (registered through DCR) cannot go 
through this grant. 

if `session.login` is called with the appropriate parameters (that is, a client 
ID an secret), the client credential flow is triggered and directly returns a valid
session, i.e. no redirection is needed.

in order to make it easier to test, and to implement something that is long
overdue, this also adds a new fetch factory that applies to both bearer and
DPoP tokens. 

# Checklist

- [X] All acceptance criteria are met.
- [ ] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).