### PR TITLE
Docs: Fix makefile to use tab

### DIFF
--- a/packages/browser/docs/api/Makefile
+++ b/packages/browser/docs/api/Makefile
@@ -32,7 +32,7 @@ migrate: clean
 	mkdir -p $(SOURCECOPYDIR)
 
    # Using https (not ssh) to clone
-   git clone https://github.com/inrupt/docs-assets.git build/docs-assets
+	git clone https://github.com/inrupt/docs-assets.git build/docs-assets
    
 	# Copying to SOURCECOPYDIR instead of copying source dir to BUILDDIR
    # in case someone forgets to backslash after build/


### PR DESCRIPTION
The docs Makefile in the browser package had a space instead of a tab which caused the line (git clone) not to be run - so that the browser docs weren't building.

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

https://solid-client-authn-js-9m80jzl6n-inrupt.vercel.app/browser/
https://solid-client-authn-js-9m80jzl6n-inrupt.vercel.app/node/
https://solid-client-authn-js-9m80jzl6n-inrupt.vercel.app/core/

