### PR TITLE
Runs npm audit as a pre-push hook

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npm audit --audit-level=moderate


### PR DESCRIPTION
This is complementary to
https://github.com/inrupt/solid-client-authn-js/pull/1346, which
disables the audit of dev dependencies in CI. The audit now runs as a
pre-push hook, which may be ignored if need be (e.g. with the current
vulnerability introduced by https://www.npmjs.com/advisories/1677).

It is a pre-push hook rather than a pre-commit one because it could be
disruptive to the development flow to be interrupted on each commit by a
known vulnerability.
