### PR TITLE
Update browser-based E2E tests for broker changes

### DIFF
--- a/e2e/browser/helpers/authorizeClientApp.ts
+++ b/e2e/browser/helpers/authorizeClientApp.ts
@@ -15,9 +15,9 @@ export async function authorizeNss() {
 }
 
 export async function authorizeEss() {
-  const approveButton = Selector("button").withText("Approve");
+  // Ideally we'd find the button using the `.withText` Selector method,
+  // to simulate how a regular user finds the relevant button,
+  // but for some reason that doesn't work.
+  const approveButton = Selector('button[form="approve"]');
   await t.click(approveButton);
-
-  // Previous ESS Broker IdP (based on MitreID Connect) used this selector:
-  // await t.click("[name=authorize]");
 }


### PR DESCRIPTION
Unfortunately using the `.withText` selector didn't seem to work
for one reason or another. Investigating why didn't seem worth the
effort, hence just matching on the DOM structure for now.

- [ ] I've added a unit test to test for potential regressions of this bug. N/A
- [x] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
