### PR TITLE
Do not resolve the login() Promise on success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 - The `popUp` option for the `login` method, although listed in the API docs,
   never had any effect. It has now been removed.
+- The Promise returned by `login` will no longer resolve, because no code is
+  able to reliably run after it is called; it redirects the user away from the
+  app and thereby terminates all running scripts.
 
 The following sections document changes that have been released already:
 

--- a/packages/browser/__tests__/Session.spec.ts
+++ b/packages/browser/__tests__/Session.spec.ts
@@ -116,19 +116,25 @@ describe("Session", () => {
   });
 
   describe("login", () => {
-    it("wraps up ClientAuthentication login", async () => {
+    it("wraps up ClientAuthentication login", () => {
       const clientAuthentication = mockClientAuthentication();
       const clientAuthnLogin = jest.spyOn(clientAuthentication, "login");
       const mySession = new Session({ clientAuthentication });
-      await mySession.login({});
+      // login never resolves if there are no errors,
+      // because a login redirects the user away from the page:
+      // eslint-disable-next-line no-void
+      void mySession.login({});
       expect(clientAuthnLogin).toHaveBeenCalled();
     });
 
-    it("Uses the token type provided (if any)", async () => {
+    it("Uses the token type provided (if any)", () => {
       const clientAuthentication = mockClientAuthentication();
       const clientAuthnLogin = jest.spyOn(clientAuthentication, "login");
       const mySession = new Session({ clientAuthentication });
-      await mySession.login({
+      // login never resolves if there are no errors,
+      // because a login redirects the user away from the page:
+      // eslint-disable-next-line no-void
+      void mySession.login({
         tokenType: "Bearer",
       });
       expect(clientAuthnLogin).toHaveBeenCalledWith(
@@ -138,14 +144,17 @@ describe("Session", () => {
       );
     });
 
-    it("preserves a binding to its Session instance", async () => {
+    it("preserves a binding to its Session instance", () => {
       const clientAuthentication = mockClientAuthentication();
       const clientAuthnLogin = jest.spyOn(clientAuthentication, "login");
       const mySession = new Session({ clientAuthentication });
       const objectWithLogin = {
         login: mySession.login,
       };
-      await objectWithLogin.login({});
+      // login never resolves if there are no errors,
+      // because a login redirects the user away from the page:
+      // eslint-disable-next-line no-void
+      void objectWithLogin.login({});
       expect(clientAuthnLogin).toHaveBeenCalled();
     });
   });
@@ -812,12 +821,11 @@ describe("Session", () => {
         clientAppSecret: "some client secret",
         redirectUrl: "https://some.redirect/url",
       }) as typeof clientAuthentication.validateCurrentSession;
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      clientAuthentication.handleIncomingRedirect = (
-        jest.fn() as any
-      ).mockResolvedValue(
-        undefined
-      ) as typeof clientAuthentication.handleIncomingRedirect;
+      clientAuthentication.handleIncomingRedirect =
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (jest.fn() as any).mockResolvedValue(
+          undefined
+        ) as typeof clientAuthentication.handleIncomingRedirect;
       clientAuthentication.login = jest.fn();
 
       const mySession = new Session({ clientAuthentication });

--- a/packages/browser/__tests__/util/UUIDGenerator.spec.ts
+++ b/packages/browser/__tests__/util/UUIDGenerator.spec.ts
@@ -26,6 +26,7 @@ jest.mock("uuid");
 
 describe("UuidGenerator", () => {
   it("should simply wrap the `uuid` module", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const uuidMock: { v4: jest.Mock } = jest.requireMock("uuid") as any;
     uuidMock.v4.mockReturnValueOnce("some uuid");
 

--- a/packages/browser/src/Session.ts
+++ b/packages/browser/src/Session.ts
@@ -230,6 +230,11 @@ export class Session extends EventEmitter {
       // Defaults the token type to DPoP
       tokenType: options.tokenType ?? "DPoP",
     });
+    // `login` redirects the user away from the app,
+    // so unless it throws an error, there is no code that should run afterwards
+    // (since there is no "after" in the lifetime of the script).
+    // Hence, this Promise never resolves:
+    return new Promise(() => undefined);
   };
 
   /**


### PR DESCRIPTION
If login() doesn't error, it redirects the user away from the page,
so any code following it will not reliably succeed. (The Promise
cannot be suppressed as a whole, since errors can still occur which
should result in a rejected Promise.)

- [ ] I've added a unit test to test for potential regressions of this bug. N/A (Can't test that a program does not terminate I think :) )
- [x] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
