### PR TITLE
Fix session restore loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased
 
+### Bugs fixed
+
+#### browser
+
+- If `restorePreviousSession` was set to true, yet the user's session at their
+  Pod server had expired, the Promise returned by `handleIncomingRedirect` would
+  never resolve.
+
 ### Changed
 
 #### browser

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - If `restorePreviousSession` was set to true, yet the user's session at their
   Pod server had expired, the Promise returned by `handleIncomingRedirect` would
   never resolve.
+- When initialising a new `Session` in Node, e.g. when doing server-side
+  rendering, an error would be thrown about trying to access `window`.
 
 ### Changed
 


### PR DESCRIPTION
This PR fixes the bug where `handleIncomingRedirect` does not resolve when attempting, but failing (e.g. when the session on the IDP has expired), to silently authenticate. This, in turn, causes solid-ui-react to never set `sessionRequestInProgress` to `false`, which then caused PodBrowser to keep attempting to login.

- [x] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
