### PR TITLE
Prepare release 1.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 The following sections document changes that have been released already:
 
+## 1.9.1 - 2021-06-16
+
+Something went wrong publishing @inrupt/solid-client-authn-core version 1.9.0;
+this is another attempt containing the same changes.
+
 ## 1.9.0 - 2021-06-16
 
 ### Breaking changes

--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
   "packages": ["packages/*"],
-  "version": "1.9.0"
+  "version": "1.9.1"
 }

--- a/packages/browser/package-lock.json
+++ b/packages/browser/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/solid-client-authn-browser",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/solid-client-authn-browser",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "license": "MIT",
   "types": "dist/index",
   "browser": "dist/index.js",
@@ -65,8 +65,8 @@
   },
   "dependencies": {
     "@inrupt/jose-legacy-modules": "0.0.3-3.12.3",
-    "@inrupt/oidc-client-ext": "^1.9.0",
-    "@inrupt/solid-client-authn-core": "^1.9.0",
+    "@inrupt/oidc-client-ext": "^1.9.1",
+    "@inrupt/solid-client-authn-core": "^1.9.1",
     "@types/lodash.clonedeep": "^4.5.6",
     "@types/node": "^15.0.1",
     "@types/uuid": "^8.3.0",

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/solid-client-authn-core",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/solid-client-authn-core",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index",

--- a/packages/node/package-lock.json
+++ b/packages/node/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/solid-client-authn-node",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/solid-client-authn-node",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index",
@@ -30,7 +30,7 @@
     "typescript": "^4.0.5"
   },
   "dependencies": {
-    "@inrupt/solid-client-authn-core": "^1.9.0",
+    "@inrupt/solid-client-authn-core": "^1.9.1",
     "@types/node": "^15.0.1",
     "@types/uuid": "^8.3.0",
     "cross-fetch": "^3.0.6",

--- a/packages/oidc/package-lock.json
+++ b/packages/oidc/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/oidc-client-ext",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/oidc/package.json
+++ b/packages/oidc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/oidc-client-ext",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "A module extending oidc-client-js with new features, such as dynamic client registration and DPoP support.",
   "homepage": "https://github.com/inrupt/solid-client-authn-js/tree/main/packages/oidc/",
   "bugs": "https://github.com/inrupt/solid-client-authn-js/issues",
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@inrupt/jose-legacy-modules": "0.0.3-3.12.3",
-    "@inrupt/solid-client-authn-core": "^1.9.0",
+    "@inrupt/solid-client-authn-core": "^1.9.1",
     "@types/uuid": "^8.3.0",
     "form-urlencoded": "~6.0.3",
     "oidc-client": "^1.11.3",


### PR DESCRIPTION
This PR bumps the version to 1.9.1. For some reason -core wasn't published for 1.9.0, so this is an attempt to release it again.

# Checklist

- [x] I used `npm run lerna-version -- <major|minor|patch> --no-push` to update the version number, first inspecting the CHANGELOG to determine if the release was major, minor or patch.
- [x] The CHANGELOG has been updated to show version and release date - https://keepachangelog.com/en/1.0.0/.
- [x] The **only** commits in this PR are:
  - the CHANGELOG update.
  - the version update.
- [x] I will make sure **not** to squash these commits, but **rebase** instead.
- [x] Once this PR is merged, I will push the tag created by `lerna version ...` (e.g. `git push origin vX.X.X`).
