### PR TITLE
Add the `events` polyfill as a direct dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased
 
+### Bugs fixed
+
+#### browser
+
+- When not using a bundler that automatically provided a polyfill for Node.js
+  built-in modules, the `events` package had to be installed manually.
+
 The following sections document changes that have been released already:
 
 ## 1.9.1 - 2021-06-24

--- a/packages/browser/package-lock.json
+++ b/packages/browser/package-lock.json
@@ -2392,8 +2392,7 @@
     "events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "dev": true
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
     },
     "exec-sh": {
       "version": "0.3.6",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -70,6 +70,7 @@
     "@types/lodash.clonedeep": "^4.5.6",
     "@types/node": "^15.0.1",
     "@types/uuid": "^8.3.0",
+    "events": "^3.3.0",
     "lodash.clonedeep": "^4.5.0",
     "uuid": "^8.3.1"
   },


### PR DESCRIPTION
We used to make the assumption that native Node modules would
automatically get polyfilled by whatever bundlers developers were
using to get code to run in the browser. However, at least Webpack
5 no longer does that.

Since our upgrade to jose@3 (aka @inrupt/jose-legacy-modules), the
only native module we were still referencing is `events`. Since
it's only the Session class referencing/extending it, we could
probably also consider updating that to no longer do so and just
handle callbacks for the various session events itself, but until
then, this should ensure developers no longer manually have to add
those polyfills.

This PR fixes bug #1099 (or at least the last remnant of it).

- [ ] I've added a unit test to test for potential regressions of this bug. N/A
- [x] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
