### PR TITLE
Support DPoP-bound refresh tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased
 
+### New features
+
+#### node
+
+- DPoP-bound refresh tokens are now supported, which allows for an increased protection
+against refresh token extraction.
+
 ### Bugs fixed
 
 #### browser

--- a/packages/core/src/authenticatedFetch/dpopUtils.ts
+++ b/packages/core/src/authenticatedFetch/dpopUtils.ts
@@ -27,6 +27,7 @@ import {
   fromKeyLike,
 } from "@inrupt/jose-legacy-modules";
 import { v4 } from "uuid";
+import { PREFERRED_SIGNING_ALG } from "../constant";
 
 /**
  * Normalizes a URL in order to generate the DPoP token based on a consistent scheme.
@@ -68,7 +69,7 @@ export async function createDpopHeader(
     jti: v4(),
   })
     .setProtectedHeader({
-      alg: "ES256",
+      alg: PREFERRED_SIGNING_ALG[0],
       jwk: dpopKey.publicKey,
       typ: "dpop+jwt",
     })
@@ -77,12 +78,14 @@ export async function createDpopHeader(
 }
 
 export async function generateDpopKeyPair(): Promise<KeyPair> {
-  const { privateKey, publicKey } = await generateKeyPair("ES256");
+  const { privateKey, publicKey } = await generateKeyPair(
+    PREFERRED_SIGNING_ALG[0]
+  );
   const dpopKeyPair = {
     privateKey,
     publicKey: await fromKeyLike(publicKey),
   };
   // The alg property isn't set by fromKeyLike, so set it manually.
-  dpopKeyPair.publicKey.alg = "ES256";
+  dpopKeyPair.publicKey.alg = PREFERRED_SIGNING_ALG[0];
   return dpopKeyPair;
 }

--- a/packages/core/src/authenticatedFetch/dpopUtils.ts
+++ b/packages/core/src/authenticatedFetch/dpopUtils.ts
@@ -86,6 +86,6 @@ export async function generateDpopKeyPair(): Promise<KeyPair> {
     publicKey: await fromKeyLike(publicKey),
   };
   // The alg property isn't set by fromKeyLike, so set it manually.
-  dpopKeyPair.publicKey.alg = PREFERRED_SIGNING_ALG[0];
+  [dpopKeyPair.publicKey.alg] = PREFERRED_SIGNING_ALG;
   return dpopKeyPair;
 }

--- a/packages/core/src/storage/StorageUtility.spec.ts
+++ b/packages/core/src/storage/StorageUtility.spec.ts
@@ -718,6 +718,7 @@ describe("saveSessionInfoToStorage", () => {
 
     expect(
       JSON.parse(
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         (await mockedStorage.getForUser("some session", "publicKey", {
           secure: true,
         }))!
@@ -728,6 +729,7 @@ describe("saveSessionInfoToStorage", () => {
       "privateKey",
       { secure: true }
     );
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     expect(JSON.parse(privateJwk!)).toEqual(
       await fromKeyLike(dpopKey.privateKey)
     );

--- a/packages/node/src/authenticatedFetch/fetchFactory.spec.ts
+++ b/packages/node/src/authenticatedFetch/fetchFactory.spec.ts
@@ -46,6 +46,35 @@ const mockNotRedirectedResponse = (): MockedRedirectResponse => {
   };
 };
 
+let publicKey: KeyLike | undefined;
+let privateKey: KeyLike | undefined;
+
+const mockJwk = async (): Promise<{
+  publicKey: KeyLike;
+  privateKey: KeyLike;
+}> => {
+  if (typeof publicKey === "undefined" || typeof privateKey === "undefined") {
+    const generatedPair = await generateKeyPair("ES256");
+    publicKey = generatedPair.publicKey;
+    privateKey = generatedPair.privateKey;
+  }
+  return {
+    publicKey,
+    privateKey,
+  };
+};
+
+const mockKeyPair = async () => {
+  const { privateKey: prvt, publicKey: pblc } = await mockJwk();
+  const dpopKeyPair = {
+    privateKey: prvt,
+    publicKey: await fromKeyLike(pblc),
+  };
+  // The alg property isn't set by fromKeyLike, so set it manually.
+  dpopKeyPair.publicKey.alg = "ES256";
+  return dpopKeyPair;
+};
+
 describe("buildBearerFetch", () => {
   it("returns a fetch holding the provided token", async () => {
     // eslint-disable-next-line no-shadow
@@ -220,35 +249,6 @@ describe("buildBearerFetch", () => {
     expect(response.status).toEqual(401);
   });
 });
-
-let publicKey: KeyLike | undefined;
-let privateKey: KeyLike | undefined;
-
-const mockJwk = async (): Promise<{
-  publicKey: KeyLike;
-  privateKey: KeyLike;
-}> => {
-  if (typeof publicKey === "undefined" || typeof privateKey === "undefined") {
-    const generatedPair = await generateKeyPair("ES256");
-    publicKey = generatedPair.publicKey;
-    privateKey = generatedPair.privateKey;
-  }
-  return {
-    publicKey,
-    privateKey,
-  };
-};
-
-const mockKeyPair = async () => {
-  const { privateKey: prvt, publicKey: pblc } = await mockJwk();
-  const dpopKeyPair = {
-    privateKey: prvt,
-    publicKey: await fromKeyLike(pblc),
-  };
-  // The alg property isn't set by fromKeyLike, so set it manually.
-  dpopKeyPair.publicKey.alg = "ES256";
-  return dpopKeyPair;
-};
 
 describe("buildDpopFetch", () => {
   it("returns a fetch holding the provided token and key", async () => {

--- a/packages/node/src/login/oidc/ClientRegistrar.spec.ts
+++ b/packages/node/src/login/oidc/ClientRegistrar.spec.ts
@@ -436,6 +436,7 @@ describe("ClientRegistrar", () => {
 
       // Check that the returned algorithm value is what we expect
       expect(client.idTokenSignedResponseAlg).toBe(
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         IssuerConfigFetcherFetchConfigResponse.idTokenSigningAlgValuesSupported![0]
       );
 
@@ -443,6 +444,7 @@ describe("ClientRegistrar", () => {
       await expect(
         mockStorage.getForUser("mySession", "idTokenSignedResponseAlg")
       ).resolves.toBe(
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         IssuerConfigFetcherFetchConfigResponse.idTokenSigningAlgValuesSupported![0]
       );
     });

--- a/packages/node/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
+++ b/packages/node/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
@@ -196,7 +196,9 @@ export class AuthCodeRedirectHandler implements IRedirectHandler {
       tokenSet.id_token,
       webid,
       "true",
-      tokenSet.refresh_token
+      tokenSet.refresh_token,
+      undefined,
+      dpopKeys
     );
 
     const sessionInfo = await this.sessionInfoManager.get(sessionId);


### PR DESCRIPTION
This adds support for DPoP-bound refresh tokens. Effectively, the biggest change is that instead of re-generating a DPoP key when going through the refresh flow, we now have to store the DPoP key when it is issued and reuse it as we go. This does not introduce additional vulnerabilities, as a DPoP-bound refresh token leaking with its DPoP key is just as bad as an unbound refresh token leaking.

Note that the DPoP key was only regenerated as part of the refresh token login flow, but the previous key kept being reused in the refresh flow initiated from within the fetch closure. This is why 07c2fdd only introduces a test: the expected behaviour happened to be already implemented, we just had to prevent regression.

Note that storing the DPoP key is only appropriate in Node, and will not be done in the browser codebase.
  
# Checklist

- [X] All acceptance criteria are met.
- [x] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).