### PR TITLE
Feat/node/2165 client credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 - DPoP-bound refresh tokens are now supported, which allows for an increased protection
 against refresh token extraction.
+- Client credential grant: for Solid Identity Providers which support it, a client
+may statically register, and use the obtained credentials (client ID and secret)
+to log in to an Identity Provider. This is convenient in some cases, such as CI
+environment. However, it requires offline provider/client interaction, which does
+not scale well in the decentralized ecosystem of Solid. As such, it should only be
+used in specific cases, where the user is able to statically register their app 
+to their identity provider (which requires some technical background).
 
 ### Bugs fixed
 

--- a/packages/browser/__tests__/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
+++ b/packages/browser/__tests__/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
@@ -172,6 +172,7 @@ function mockIssuerConfigFetcher(config: IIssuerConfig): IIssuerConfigFetcher {
 const mockClient = (): IClient => {
   return {
     clientId: "some client",
+    clientType: "dynamic",
   };
 };
 

--- a/packages/browser/src/login/oidc/ClientRegistrar.ts
+++ b/packages/browser/src/login/oidc/ClientRegistrar.ts
@@ -64,6 +64,7 @@ export default class ClientRegistrar implements IClientRegistrar {
       return {
         clientId: storedClientId,
         clientSecret: storedClientSecret,
+        clientType: "dynamic",
       };
     }
     const extendedOptions = { ...options };

--- a/packages/browser/src/login/oidc/__mocks__/ClientRegistrar.ts
+++ b/packages/browser/src/login/oidc/__mocks__/ClientRegistrar.ts
@@ -30,10 +30,12 @@ import { jest } from "@jest/globals";
 export const ClientRegistrarResponse: IClient = {
   clientId: "abcde",
   clientSecret: "12345",
+  clientType: "dynamic",
 };
 
 export const PublicClientRegistrarResponse: IClient = {
   clientId: "abcde",
+  clientType: "dynamic",
 };
 
 export const ClientRegistrarMock: jest.Mocked<IClientRegistrar> = {

--- a/packages/browser/src/login/oidc/__mocks__/IOidcOptions.ts
+++ b/packages/browser/src/login/oidc/__mocks__/IOidcOptions.ts
@@ -39,5 +39,6 @@ export const standardOidcOptions: IOidcOptions = {
   },
   client: {
     clientId: "coolApp",
+    clientType: "dynamic",
   },
 };

--- a/packages/core/src/login/oidc/IClient.ts
+++ b/packages/core/src/login/oidc/IClient.ts
@@ -24,6 +24,8 @@
  * @packageDocumentation
  */
 
+export type ClientType = "static" | "dynamic" | "solid-oidc";
+
 /**
  * @hidden
  */
@@ -32,4 +34,5 @@ export interface IClient {
   clientSecret?: string;
   clientName?: string;
   idTokenSignedResponseAlg?: string;
+  clientType: ClientType;
 }

--- a/packages/core/src/login/oidc/IClientRegistrar.test.ts
+++ b/packages/core/src/login/oidc/IClientRegistrar.test.ts
@@ -37,13 +37,14 @@ describe("handleRegistration", () => {
     const clientRegistrar = {
       getClient: jest.fn(),
     };
-    await handleRegistration(
+    const client = await handleRegistration(
       options,
       { solidOidcSupported: undefined } as IIssuerConfig,
       jest.fn() as unknown as IStorageUtility,
       clientRegistrar as IClientRegistrar
     );
     expect(clientRegistrar.getClient).toHaveBeenCalled();
+    expect(client.clientType).toBe("dynamic");
   });
 
   it("should perform DCR if no client ID is provided", async () => {
@@ -54,13 +55,14 @@ describe("handleRegistration", () => {
     const clientRegistrar = {
       getClient: jest.fn(),
     };
-    await handleRegistration(
+    const client = await handleRegistration(
       options,
       { solidOidcSupported: undefined } as IIssuerConfig,
       jest.fn() as unknown as IStorageUtility,
       clientRegistrar as IClientRegistrar
     );
     expect(clientRegistrar.getClient).toHaveBeenCalled();
+    expect(client.clientType).toBe("dynamic");
   });
 
   it("should store provided client WebID if one provided and the Identity Provider supports Solid-OIDC", async () => {
@@ -75,7 +77,7 @@ describe("handleRegistration", () => {
     const storageUtility: IStorageUtility = {
       setForUser: jest.fn(),
     } as unknown as IStorageUtility;
-    await handleRegistration(
+    const client = await handleRegistration(
       options,
       {
         solidOidcSupported: "https://solidproject.org/TR/solid-oidc",
@@ -85,6 +87,7 @@ describe("handleRegistration", () => {
     );
     expect(clientRegistrar.getClient).not.toHaveBeenCalled();
     expect(storageUtility.setForUser).toHaveBeenCalled();
+    expect(client.clientType).toBe("solid-oidc");
   });
 
   it("should store provided client registration information when the client ID is not a WebID", async () => {
@@ -101,7 +104,7 @@ describe("handleRegistration", () => {
     const storageUtility: IStorageUtility = {
       setForUser: jest.fn(),
     } as unknown as IStorageUtility;
-    await handleRegistration(
+    const client = await handleRegistration(
       options,
       {
         solidOidcSupported: undefined,
@@ -111,6 +114,7 @@ describe("handleRegistration", () => {
     );
     expect(clientRegistrar.getClient).not.toHaveBeenCalled();
     expect(storageUtility.setForUser).toHaveBeenCalled();
+    expect(client.clientType).toBe("static");
   });
 });
 

--- a/packages/core/src/login/oidc/IClientRegistrar.test.ts
+++ b/packages/core/src/login/oidc/IClientRegistrar.test.ts
@@ -37,14 +37,13 @@ describe("handleRegistration", () => {
     const clientRegistrar = {
       getClient: jest.fn(),
     };
-    const client = await handleRegistration(
+    await handleRegistration(
       options,
       { solidOidcSupported: undefined } as IIssuerConfig,
       jest.fn() as unknown as IStorageUtility,
       clientRegistrar as IClientRegistrar
     );
     expect(clientRegistrar.getClient).toHaveBeenCalled();
-    expect(client.clientType).toBe("dynamic");
   });
 
   it("should perform DCR if no client ID is provided", async () => {
@@ -55,14 +54,13 @@ describe("handleRegistration", () => {
     const clientRegistrar = {
       getClient: jest.fn(),
     };
-    const client = await handleRegistration(
+    await handleRegistration(
       options,
       { solidOidcSupported: undefined } as IIssuerConfig,
       jest.fn() as unknown as IStorageUtility,
       clientRegistrar as IClientRegistrar
     );
     expect(clientRegistrar.getClient).toHaveBeenCalled();
-    expect(client.clientType).toBe("dynamic");
   });
 
   it("should store provided client WebID if one provided and the Identity Provider supports Solid-OIDC", async () => {

--- a/packages/core/src/login/oidc/IClientRegistrar.ts
+++ b/packages/core/src/login/oidc/IClientRegistrar.ts
@@ -26,7 +26,7 @@
 
 import IStorageUtility from "../../storage/IStorageUtility";
 import ILoginOptions from "../ILoginOptions";
-import { IClient } from "./IClient";
+import { ClientType, IClient } from "./IClient";
 import { IIssuerConfig } from "./IIssuerConfig";
 
 export interface IClientRegistrarOptions {
@@ -69,37 +69,55 @@ export function determineSigningAlg(
   );
 }
 
+function determineClientType(
+  options: ILoginOptions,
+  issuerConfig: IIssuerConfig
+): ClientType {
+  if (options.clientId !== undefined && !isValidUrl(options.clientId)) {
+    return "static";
+  }
+  if (
+    issuerConfig.solidOidcSupported ===
+      "https://solidproject.org/TR/solid-oidc" &&
+    options.clientId !== undefined &&
+    isValidUrl(options.clientId)
+  ) {
+    return "solid-oidc";
+  }
+  // If no client_id is provided, the client must go through DCR.
+  // If a client_id is provided and it looks like a URI, yet the Identity Provider
+  // does *not* support Solid-OIDC, then we also perform DCR (and discard the
+  // provided client_id).
+  return "dynamic";
+}
+
 export async function handleRegistration(
   options: ILoginOptions,
   issuerConfig: IIssuerConfig,
   storageUtility: IStorageUtility,
   clientRegistrar: IClientRegistrar
 ): Promise<IClient> {
-  if (
-    options.clientId === undefined ||
-    (issuerConfig.solidOidcSupported !==
-      "https://solidproject.org/TR/solid-oidc" &&
-      isValidUrl(options.clientId))
-  ) {
-    // If no client_id is provided, the client must go through DCR.
-    // If a client_id is provided and it looks like a URI, yet the Identity Provider
-    // does *not* support Solid-OIDC, then we also perform DCR (and discard the
-    // provided client_id).
-    return clientRegistrar.getClient(
-      {
-        sessionId: options.sessionId,
-        clientName: options.clientName,
-        redirectUrl: options.redirectUrl,
-      },
-      issuerConfig
-    );
+  const clientType = determineClientType(options, issuerConfig);
+  if (clientType === "dynamic") {
+    return {
+      ...clientRegistrar.getClient(
+        {
+          sessionId: options.sessionId,
+          clientName: options.clientName,
+          redirectUrl: options.redirectUrl,
+        },
+        issuerConfig
+      ),
+      clientType,
+    };
   }
   // If a client_id was provided, and the Identity Provider is Solid-OIDC compliant,
   // or it is not compliant but the client_id isn't an IRI (we assume it has already
   // been registered with the IdP), then the client registration information needs
   // to be stored so that it can be retrieved later after redirect.
   await storageUtility.setForUser(options.sessionId, {
-    clientId: options.clientId,
+    // If the client is either static or solid-oidc compliant, its client ID cannot be undefined.
+    clientId: options.clientId!,
   });
   if (options.clientSecret) {
     await storageUtility.setForUser(options.sessionId, {
@@ -112,8 +130,9 @@ export async function handleRegistration(
     });
   }
   return {
-    clientId: options.clientId,
+    clientId: options.clientId!,
     clientSecret: options.clientSecret,
     clientName: options.clientName,
+    clientType,
   };
 }

--- a/packages/core/src/login/oidc/IClientRegistrar.ts
+++ b/packages/core/src/login/oidc/IClientRegistrar.ts
@@ -84,7 +84,7 @@ function determineClientType(
   ) {
     return "solid-oidc";
   }
-  // If no client_id is provided, the client must go through DCR.
+  // If no client_id is provided, the client must go through Dynamic Client Registration.
   // If a client_id is provided and it looks like a URI, yet the Identity Provider
   // does *not* support Solid-OIDC, then we also perform DCR (and discard the
   // provided client_id).

--- a/packages/core/src/login/oidc/IClientRegistrar.ts
+++ b/packages/core/src/login/oidc/IClientRegistrar.ts
@@ -114,6 +114,7 @@ export async function handleRegistration(
   // to be stored so that it can be retrieved later after redirect.
   await storageUtility.setForUser(options.sessionId, {
     // If the client is either static or solid-oidc compliant, its client ID cannot be undefined.
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     clientId: options.clientId!,
   });
   if (options.clientSecret) {
@@ -127,6 +128,7 @@ export async function handleRegistration(
     });
   }
   return {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     clientId: options.clientId!,
     clientSecret: options.clientSecret,
     clientName: options.clientName,

--- a/packages/core/src/login/oidc/IClientRegistrar.ts
+++ b/packages/core/src/login/oidc/IClientRegistrar.ts
@@ -99,17 +99,14 @@ export async function handleRegistration(
 ): Promise<IClient> {
   const clientType = determineClientType(options, issuerConfig);
   if (clientType === "dynamic") {
-    return {
-      ...clientRegistrar.getClient(
-        {
-          sessionId: options.sessionId,
-          clientName: options.clientName,
-          redirectUrl: options.redirectUrl,
-        },
-        issuerConfig
-      ),
-      clientType,
-    };
+    return clientRegistrar.getClient(
+      {
+        sessionId: options.sessionId,
+        clientName: options.clientName,
+        redirectUrl: options.redirectUrl,
+      },
+      issuerConfig
+    );
   }
   // If a client_id was provided, and the Identity Provider is Solid-OIDC compliant,
   // or it is not compliant but the client_id isn't an IRI (we assume it has already

--- a/packages/node/src/authenticatedFetch/fetchFactory.ts
+++ b/packages/node/src/authenticatedFetch/fetchFactory.ts
@@ -220,3 +220,23 @@ export async function buildDpopFetch(
     return response;
   };
 }
+
+/**
+ * @param authToken a DPoP token.
+ * @param dpopKey The private key the token is bound to.
+ * @param
+ * @returns A fetch function that adds an Authorization header with the provided
+ * DPoP token, and adds a dpop header.
+ */
+export async function buildAuthenticatedFetch(
+  accessToken: string,
+  options?: {
+    dpopKey?: KeyPair;
+    refreshOptions?: RefreshOptions;
+  }
+): Promise<typeof fetch> {
+  if (options?.dpopKey) {
+    return buildDpopFetch(accessToken, options.dpopKey, options.refreshOptions);
+  }
+  return buildBearerFetch(accessToken, options?.refreshOptions);
+}

--- a/packages/node/src/dependencies.ts
+++ b/packages/node/src/dependencies.ts
@@ -43,6 +43,7 @@ import AggregateRedirectHandler from "./login/oidc/redirectHandler/AggregateRedi
 import Redirector from "./login/oidc/Redirector";
 import ClientRegistrar from "./login/oidc/ClientRegistrar";
 import TokenRefresher from "./login/oidc/refresh/TokenRefresher";
+import ClientCredentialsOidcHandler from "./login/oidc/oidcHandlers/ClientCredentialsOidcHandler";
 
 /**
  *
@@ -77,6 +78,7 @@ export function getClientAuthenticationWithDependencies(dependencies: {
     new OidcLoginHandler(
       storageUtility,
       new AggregateOidcHandler([
+        new ClientCredentialsOidcHandler(tokenRefresher, storageUtility),
         new RefreshTokenOidcHandler(tokenRefresher, storageUtility),
         new AuthorizationCodeWithPkceOidcHandler(
           storageUtility,

--- a/packages/node/src/login/oidc/ClientRegistrar.ts
+++ b/packages/node/src/login/oidc/ClientRegistrar.ts
@@ -96,6 +96,7 @@ export default class ClientRegistrar implements IClientRegistrar {
         clientSecret: storedClientSecret,
         clientName: storedClientName as string | undefined,
         idTokenSignedResponseAlg: storedIdTokenSignedResponseAlg,
+        clientType: "dynamic",
       };
     }
     const extendedOptions = { ...options };
@@ -155,6 +156,7 @@ export default class ClientRegistrar implements IClientRegistrar {
       clientName: registeredClient.metadata.client_name as string | undefined,
       idTokenSignedResponseAlg:
         registeredClient.metadata.id_token_signed_response_alg ?? signingAlg,
+      clientType: "dynamic",
     };
   }
 }

--- a/packages/node/src/login/oidc/__mocks__/ClientRegistrar.ts
+++ b/packages/node/src/login/oidc/__mocks__/ClientRegistrar.ts
@@ -78,6 +78,7 @@ export const mockDefaultClient = (): IClient => {
   return {
     clientId: "a client id",
     clientSecret: "a client secret",
+    clientType: "dynamic",
   };
 };
 

--- a/packages/node/src/login/oidc/__mocks__/ClientRegistrar.ts
+++ b/packages/node/src/login/oidc/__mocks__/ClientRegistrar.ts
@@ -31,10 +31,12 @@ import { ClientMetadata } from "openid-client";
 export const ClientRegistrarResponse: IClient = {
   clientId: "abcde",
   clientSecret: "12345",
+  clientType: "dynamic",
 };
 
 export const PublicClientRegistrarResponse: IClient = {
   clientId: "abcde",
+  clientType: "dynamic",
 };
 
 export const ClientRegistrarMock: jest.Mocked<IClientRegistrar> = {

--- a/packages/node/src/login/oidc/__mocks__/IOidcOptions.ts
+++ b/packages/node/src/login/oidc/__mocks__/IOidcOptions.ts
@@ -39,6 +39,7 @@ export const standardOidcOptions: IOidcOptions = {
   },
   client: {
     clientId: "coolApp",
+    clientType: "dynamic",
   },
 };
 

--- a/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.spec.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.spec.ts
@@ -120,6 +120,7 @@ const mockBearerTokens = (): TokenSet => {
 };
 
 const setupOidcClientMock = (tokenSet: TokenSet) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const { Issuer } = jest.requireMock("openid-client") as any;
   function clientConstructor() {
     // this is untyped, which makes TS complain

--- a/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.spec.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.spec.ts
@@ -1,0 +1,359 @@
+/*
+ * Copyright 2021 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * Test for AuthorizationCodeWithPkceOidcHandler
+ */
+import { mockStorageUtility } from "@inrupt/solid-client-authn-core";
+import { jest, it, describe } from "@jest/globals";
+import { IdTokenClaims, TokenSet } from "openid-client";
+import { JWK } from "jose/types";
+import { mockDefaultTokenRefresher } from "../refresh/__mocks__/TokenRefresher";
+import { standardOidcOptions } from "../__mocks__/IOidcOptions";
+import ClientCredentialsOidcHandler from "./ClientCredentialsOidcHandler";
+
+import { mockDefaultIssuerConfig } from "../__mocks__/IssuerConfigFetcher";
+
+jest.mock("openid-client");
+jest.mock("cross-fetch");
+jest.mock("@inrupt/solid-client-authn-core", () => {
+  const actualCoreModule = jest.requireActual(
+    "@inrupt/solid-client-authn-core"
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ) as any;
+  return {
+    ...actualCoreModule,
+    // This works around the network lookup to the JWKS in order to validate the ID token.
+    getWebidFromTokenPayload: jest.fn(() =>
+      Promise.resolve("https://my.webid/")
+    ),
+  };
+});
+
+const mockJwk = (): JWK => {
+  return {
+    kty: "EC",
+    kid: "oOArcXxcwvsaG21jAx_D5CHr4BgVCzCEtlfmNFQtU0s",
+    alg: "ES256",
+    crv: "P-256",
+    x: "0dGe_s-urLhD3mpqYqmSXrqUZApVV5ZNxMJXg7Vp-2A",
+    y: "-oMe9gGkpfIrnJ0aiSUHMdjqYVm5ZrGCeQmRKoIIfj8",
+    d: "yR1bCsR7m4hjFCvWo8Jw3OfNR4aiYDAFbBD9nkudJKM",
+  };
+};
+
+const mockIdToken = (): string =>
+  "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJodHRwczovL215LndlYmlkIiwiaXNzIjoiaHR0cHM6Ly9teS5pZHAvIiwiYXVkIjoiaHR0cHM6Ly9yZXNvdXJjZS5leGFtcGxlLm9yZyIsImV4cCI6MTY2MjI2NjIxNiwiaWF0IjoxNDYyMjY2MjE2fQ.IwumuwJtQw5kUBMMHAaDPJBppfBpRHbiXZw_HlKe6GNVUWUlyQRYV7W7r9OQtHmMsi6GVwOckelA3ErmhrTGVw";
+
+type AccessJwt = {
+  sub: string;
+  iss: string;
+  aud: string;
+  nbf: number;
+  exp: number;
+  cnf: {
+    jkt: string;
+  };
+};
+
+const mockWebId = (): string => "https://my.webid/";
+
+const mockKeyBoundToken = (): AccessJwt => {
+  return {
+    sub: mockWebId(),
+    iss: mockDefaultIssuerConfig().issuer.toString(),
+    aud: "https://resource.example.org",
+    nbf: 1562262611,
+    exp: 1562266216,
+    cnf: {
+      jkt: mockJwk().kid as string,
+    },
+  };
+};
+
+const mockIdTokenPayload = (): IdTokenClaims => {
+  return {
+    sub: "https://my.webid/",
+    iss: "https://my.idp/",
+    aud: "https://resource.example.org",
+    exp: 1662266216,
+    iat: 1462266216,
+  };
+};
+
+const mockDpopTokens = (): TokenSet => {
+  return {
+    access_token: JSON.stringify(mockKeyBoundToken()),
+    id_token: mockIdToken(),
+    token_type: "DPoP",
+    expired: () => false,
+    claims: mockIdTokenPayload,
+  };
+};
+
+const mockBearerTokens = (): TokenSet => {
+  return {
+    access_token: "some token",
+    id_token: mockIdToken(),
+    token_type: "Bearer",
+    expired: () => false,
+    claims: mockIdTokenPayload,
+  };
+};
+
+const setupOidcClientMock = (tokenSet: TokenSet) => {
+  const { Issuer } = jest.requireMock("openid-client") as any;
+  function clientConstructor() {
+    // this is untyped, which makes TS complain
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    this.grant = jest.fn().mockResolvedValueOnce(tokenSet);
+  }
+  const mockedIssuer = {
+    metadata: mockDefaultIssuerConfig(),
+    Client: clientConstructor,
+  };
+  Issuer.mockReturnValueOnce(mockedIssuer);
+};
+
+describe("ClientCredentialsOidcHandler", () => {
+  describe("canHandle", () => {
+    it("cannot handle if the client ID is missing", async () => {
+      const clientCredentialsOidcHandler = new ClientCredentialsOidcHandler(
+        mockDefaultTokenRefresher(),
+        mockStorageUtility({})
+      );
+      await expect(
+        clientCredentialsOidcHandler.canHandle({
+          ...standardOidcOptions,
+          client: {
+            clientId: undefined as unknown as string,
+            clientType: "static",
+          },
+        })
+      ).resolves.toEqual(false);
+    });
+
+    it("cannot handle if the client secret is missing", async () => {
+      const clientCredentialsOidcHandler = new ClientCredentialsOidcHandler(
+        mockDefaultTokenRefresher(),
+        mockStorageUtility({})
+      );
+      await expect(
+        clientCredentialsOidcHandler.canHandle({
+          ...standardOidcOptions,
+          client: {
+            clientId: "some client ID",
+            clientSecret: undefined,
+            clientType: "static",
+          },
+        })
+      ).resolves.toEqual(false);
+    });
+
+    it("cannot handle if the client is not statically registered", async () => {
+      const clientCredentialsOidcHandler = new ClientCredentialsOidcHandler(
+        mockDefaultTokenRefresher(),
+        mockStorageUtility({})
+      );
+      await expect(
+        clientCredentialsOidcHandler.canHandle({
+          ...standardOidcOptions,
+          client: {
+            clientId: "some client ID",
+            clientSecret: "some secret",
+            clientType: "dynamic",
+          },
+        })
+      ).resolves.toEqual(false);
+    });
+
+    it("can handle if both client ID and secret are present for a confidential client", async () => {
+      const clientCredentialsOidcHandler = new ClientCredentialsOidcHandler(
+        mockDefaultTokenRefresher(),
+        mockStorageUtility({})
+      );
+      await expect(
+        clientCredentialsOidcHandler.canHandle({
+          ...standardOidcOptions,
+          client: {
+            clientId: "some client ID",
+            clientSecret: "some client secret",
+            clientType: "static",
+          },
+        })
+      ).resolves.toEqual(true);
+    });
+  });
+});
+
+describe("handle", () => {
+  it("throws if the issuer does not return an access token", async () => {
+    const tokens = mockDpopTokens();
+    tokens.access_token = undefined;
+    setupOidcClientMock(tokens);
+    const clientCredentialsOidcHandler = new ClientCredentialsOidcHandler(
+      mockDefaultTokenRefresher(),
+      mockStorageUtility({})
+    );
+    await expect(
+      clientCredentialsOidcHandler.handle({
+        ...standardOidcOptions,
+        client: {
+          clientId: "some client ID",
+          clientSecret: "some client secret",
+          clientType: "static",
+        },
+      })
+    ).rejects.toThrow(
+      /Invalid response from Solid Identity Provider \[.+\]: \{.+\} is missing 'access_token'/
+    );
+  });
+
+  it("throws if the issuer does not return an ID token", async () => {
+    const tokens = mockDpopTokens();
+    tokens.id_token = undefined;
+    setupOidcClientMock(tokens);
+    const clientCredentialsOidcHandler = new ClientCredentialsOidcHandler(
+      mockDefaultTokenRefresher(),
+      mockStorageUtility({})
+    );
+    await expect(
+      clientCredentialsOidcHandler.handle({
+        ...standardOidcOptions,
+        client: {
+          clientId: "some client ID",
+          clientSecret: "some client secret",
+          clientType: "static",
+        },
+      })
+    ).rejects.toThrow(
+      /Invalid response from Solid Identity Provider \[.+\]: \{.+\} is missing 'id_token'/
+    );
+  });
+
+  it("builds a fetch authenticated with a DPoP token if appropriate", async () => {
+    const tokens = mockDpopTokens();
+    setupOidcClientMock(tokens);
+    const clientCredentialsOidcHandler = new ClientCredentialsOidcHandler(
+      mockDefaultTokenRefresher(),
+      mockStorageUtility({})
+    );
+    const result = await clientCredentialsOidcHandler.handle({
+      ...standardOidcOptions,
+      dpop: true,
+      client: {
+        clientId: "some client ID",
+        clientSecret: "some client secret",
+        clientType: "static",
+      },
+    });
+
+    const mockedFetch = jest.requireMock("cross-fetch") as jest.Mock;
+    mockedFetch.mockResolvedValue({
+      status: 200,
+      url: "https://some.pod/resource",
+    });
+    await result?.fetch("https://some.pod/resource");
+    expect(mockedFetch.mock.calls[0][1].headers.Authorization).toContain(
+      `DPoP ${tokens.access_token}`
+    );
+  });
+
+  it("builds a fetch authenticated with a Bearer token if appropriate", async () => {
+    const tokens = mockBearerTokens();
+    setupOidcClientMock(tokens);
+    const clientCredentialsOidcHandler = new ClientCredentialsOidcHandler(
+      mockDefaultTokenRefresher(),
+      mockStorageUtility({})
+    );
+    const result = await clientCredentialsOidcHandler.handle({
+      ...standardOidcOptions,
+      dpop: false,
+      client: {
+        clientId: "some client ID",
+        clientSecret: "some client secret",
+        clientType: "static",
+      },
+    });
+
+    const mockedFetch = jest.requireMock("cross-fetch") as jest.Mock;
+    mockedFetch.mockResolvedValue({
+      status: 200,
+      url: "https://some.pod/resource",
+    });
+    await result?.fetch("https://some.pod/resource");
+    expect(mockedFetch.mock.calls[0][1].headers.Authorization).toContain(
+      `Bearer ${tokens.access_token}`
+    );
+  });
+
+  it("builds a fetch authenticated handling the refresh flow if appropriate", async () => {
+    const tokens = mockDpopTokens();
+    tokens.refresh_token = "some refresh token";
+    setupOidcClientMock(tokens);
+    const refresher = mockDefaultTokenRefresher();
+    const clientCredentialsOidcHandler = new ClientCredentialsOidcHandler(
+      refresher,
+      mockStorageUtility({})
+    );
+    const result = await clientCredentialsOidcHandler.handle({
+      ...standardOidcOptions,
+      dpop: true,
+      client: {
+        clientId: "some client ID",
+        clientSecret: "some client secret",
+        clientType: "static",
+      },
+    });
+
+    const mockedFetch = jest.requireMock("cross-fetch") as jest.Mock;
+    // A 401 error triggers the refresh flow.
+    mockedFetch.mockResolvedValue({
+      status: 401,
+      url: "https://some.pod/resource",
+    });
+    await result?.fetch("https://some.pod/resource");
+    expect(refresher.refresh).toHaveBeenCalled();
+  });
+
+  it("returns session info with the built fetch", async () => {
+    const tokens = mockDpopTokens();
+    setupOidcClientMock(tokens);
+    const clientCredentialsOidcHandler = new ClientCredentialsOidcHandler(
+      mockDefaultTokenRefresher(),
+      mockStorageUtility({})
+    );
+    const result = await clientCredentialsOidcHandler.handle({
+      ...standardOidcOptions,
+      dpop: true,
+      client: {
+        clientId: "some client ID",
+        clientSecret: "some client secret",
+        clientType: "static",
+      },
+    });
+
+    expect(result?.isLoggedIn).toBe(true);
+    expect(result?.sessionId).toBe(standardOidcOptions.sessionId);
+    expect(result?.webId).toBe(mockIdTokenPayload().sub);
+  });
+});

--- a/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.spec.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.spec.ts
@@ -149,7 +149,7 @@ describe("ClientCredentialsOidcHandler", () => {
             clientType: "static",
           },
         })
-      ).resolves.toEqual(false);
+      ).resolves.toBe(false);
     });
 
     it("cannot handle if the client secret is missing", async () => {

--- a/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.ts
@@ -81,9 +81,7 @@ export default class ClientCredentialsOidcHandler implements IOidcHandler {
     const tokens = await client.grant(
       {
         grant_type: "client_credentials",
-        client_id: oidcLoginOptions.client.clientId,
-        client_secret: oidcLoginOptions.client.clientSecret,
-        token_endpoint_auth_method: "client_secret_post",
+        token_endpoint_auth_method: "client_secret_basic",
       },
       {
         DPoP:

--- a/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.ts
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2021 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * @hidden
+ * @packageDocumentation
+ */
+
+/**
+ * Handler for the Client Credentials Flow
+ */
+import {
+  IOidcHandler,
+  IOidcOptions,
+  LoginResult,
+  IStorageUtility,
+  ISessionInfo,
+  KeyPair,
+  generateDpopKeyPair,
+  PREFERRED_SIGNING_ALG,
+  getWebidFromTokenPayload,
+} from "@inrupt/solid-client-authn-core";
+import { KeyObject } from "crypto";
+import { Issuer } from "openid-client";
+import { buildAuthenticatedFetch } from "../../../authenticatedFetch/fetchFactory";
+import { configToIssuerMetadata } from "../IssuerConfigFetcher";
+import { ITokenRefresher } from "../refresh/TokenRefresher";
+
+/**
+ * @hidden
+ */
+export default class ClientCredentialsOidcHandler implements IOidcHandler {
+  constructor(
+    private tokenRefresher: ITokenRefresher,
+    private _storageUtility: IStorageUtility
+  ) {}
+
+  async canHandle(oidcLoginOptions: IOidcOptions): Promise<boolean> {
+    return (
+      typeof oidcLoginOptions.client.clientId === "string" &&
+      typeof oidcLoginOptions.client.clientSecret === "string" &&
+      oidcLoginOptions.client.clientType === "static"
+    );
+  }
+
+  async handle(oidcLoginOptions: IOidcOptions): Promise<LoginResult> {
+    const issuer = new Issuer(
+      configToIssuerMetadata(oidcLoginOptions.issuerConfiguration)
+    );
+    const client = new issuer.Client({
+      client_id: oidcLoginOptions.client.clientId,
+      client_secret: oidcLoginOptions.client.clientSecret,
+    });
+
+    let dpopKey: KeyPair | undefined;
+
+    if (oidcLoginOptions.dpop) {
+      dpopKey = await generateDpopKeyPair();
+      // The alg property isn't set by fromKeyLike, so set it manually.
+      [dpopKey.publicKey.alg] = PREFERRED_SIGNING_ALG;
+    }
+
+    const tokens = await client.grant(
+      {
+        grant_type: "client_credentials",
+        client_id: oidcLoginOptions.client.clientId,
+        client_secret: oidcLoginOptions.client.clientSecret,
+        token_endpoint_auth_method: "client_secret_post",
+      },
+      {
+        DPoP:
+          oidcLoginOptions.dpop && dpopKey !== undefined
+            ? (dpopKey.privateKey as KeyObject)
+            : undefined,
+      }
+    );
+
+    if (tokens.access_token === undefined) {
+      throw new Error(
+        `Invalid response from Solid Identity Provider [${
+          oidcLoginOptions.issuer
+        }]: ${JSON.stringify(tokens)} is missing 'access_token'.`
+      );
+    }
+
+    if (tokens.id_token === undefined) {
+      throw new Error(
+        `Invalid response from Solid Identity Provider [${
+          oidcLoginOptions.issuer
+        }]: ${JSON.stringify(tokens)} is missing 'id_token'`
+      );
+    }
+
+    const authFetch = await buildAuthenticatedFetch(tokens.access_token, {
+      dpopKey,
+      refreshOptions: tokens.refresh_token
+        ? {
+            refreshToken: tokens.refresh_token,
+            sessionId: oidcLoginOptions.sessionId,
+            tokenRefresher: this.tokenRefresher,
+            onNewRefreshToken: oidcLoginOptions.onNewRefreshToken,
+          }
+        : undefined,
+    });
+
+    const sessionInfo: ISessionInfo = {
+      isLoggedIn: true,
+      sessionId: oidcLoginOptions.sessionId,
+      webId: await getWebidFromTokenPayload(
+        tokens.id_token,
+        oidcLoginOptions.issuerConfiguration.jwksUri,
+        oidcLoginOptions.issuer,
+        oidcLoginOptions.client.clientId
+      ),
+    };
+
+    return Object.assign(sessionInfo, {
+      fetch: authFetch,
+    });
+  }
+}

--- a/packages/node/src/login/oidc/oidcHandlers/RefreshTokenOidcHandler.spec.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/RefreshTokenOidcHandler.spec.ts
@@ -211,6 +211,7 @@ describe("RefreshTokenOidcHandler", () => {
           client: {
             clientId: "some client id",
             clientSecret: "some client secret",
+            clientType: "dynamic",
           },
         })
       );

--- a/packages/node/src/login/oidc/oidcHandlers/RefreshTokenOidcHandler.spec.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/RefreshTokenOidcHandler.spec.ts
@@ -74,6 +74,7 @@ describe("RefreshTokenOidcHandler", () => {
             client: {
               clientId: "some client id",
               clientSecret: "some client secret",
+              clientType: "dynamic",
             },
           })
         )
@@ -95,6 +96,7 @@ describe("RefreshTokenOidcHandler", () => {
               // @ts-ignore
               clientId: undefined,
               clientSecret: "some client secret",
+              clientType: "dynamic",
             },
           })
         )
@@ -115,6 +117,7 @@ describe("RefreshTokenOidcHandler", () => {
             client: {
               clientId: "some client id",
               clientSecret: "some client secret",
+              clientType: "dynamic",
             },
           })
         )
@@ -136,6 +139,7 @@ describe("RefreshTokenOidcHandler", () => {
           client: {
             clientId: "some client id",
             clientSecret: "some client secret",
+            clientType: "dynamic",
           },
         })
       );
@@ -165,6 +169,7 @@ describe("RefreshTokenOidcHandler", () => {
           client: {
             clientId: "some client id",
             clientSecret: "some client secret",
+            clientType: "dynamic",
           },
         })
       );
@@ -238,6 +243,7 @@ describe("RefreshTokenOidcHandler", () => {
           client: {
             clientId: "some client id",
             clientSecret: "some client secret",
+            clientType: "dynamic",
           },
           dpop: false,
         })
@@ -271,6 +277,7 @@ describe("RefreshTokenOidcHandler", () => {
             clientId: "some client id",
             clientSecret: "some client secret",
             clientName: "some client name",
+            clientType: "dynamic",
           },
         })
       );
@@ -308,6 +315,7 @@ describe("RefreshTokenOidcHandler", () => {
           clientId: "some client id",
           clientSecret: undefined,
           clientName: "some client name",
+          clientType: "dynamic",
         },
       })
     );
@@ -330,6 +338,7 @@ describe("RefreshTokenOidcHandler", () => {
         client: {
           clientId: "some client id",
           clientSecret: "some client secret",
+          clientType: "dynamic",
         },
       })
     );
@@ -355,6 +364,7 @@ describe("RefreshTokenOidcHandler", () => {
         client: {
           clientId: "some client id",
           clientSecret: "some client secret",
+          clientType: "dynamic",
         },
       })
     );
@@ -391,6 +401,7 @@ describe("RefreshTokenOidcHandler", () => {
         client: {
           clientId: "some client id",
           clientSecret: "some client secret",
+          clientType: "dynamic",
         },
         onNewRefreshToken: refreshTokenRotationHandler,
       })
@@ -421,6 +432,7 @@ describe("RefreshTokenOidcHandler", () => {
         client: {
           clientId: "some client id",
           clientSecret: "some client secret",
+          clientType: "dynamic",
         },
         dpop: false,
       })
@@ -461,6 +473,7 @@ describe("RefreshTokenOidcHandler", () => {
         client: {
           clientId: "some client id",
           clientSecret: "some client secret",
+          clientType: "dynamic",
         },
       })
     );

--- a/packages/node/src/login/oidc/refresh/TokenRefresher.spec.ts
+++ b/packages/node/src/login/oidc/refresh/TokenRefresher.spec.ts
@@ -235,6 +235,7 @@ describe("TokenRefresher", () => {
         clientId: "some client ID",
         clientSecret: "some client secret",
         idTokenSignedResponseAlg: "ES256",
+        clientType: "static",
       }),
     });
 

--- a/packages/oidc/src/dcr/clientRegistrar.ts
+++ b/packages/oidc/src/dcr/clientRegistrar.ts
@@ -143,6 +143,7 @@ export async function registerClient(
       clientId: responseBody.client_id,
       clientSecret: responseBody.client_secret,
       idTokenSignedResponseAlg: responseBody.id_token_signed_response_alg,
+      clientType: "dynamic",
     };
   }
   if (registerResponse.status === 400) {

--- a/packages/oidc/src/dpop/tokenExchange.spec.ts
+++ b/packages/oidc/src/dpop/tokenExchange.spec.ts
@@ -159,6 +159,7 @@ const mockDpopTokens = (): TokenEndpointRawResponse => {
 const mockClient = (): IClient => {
   return {
     clientId: "some client",
+    clientType: "dynamic",
   };
 };
 


### PR DESCRIPTION
This replaces #1329 (additional context there). The reason why this is relevant now is that https://oauth2.inrupt.com/ aims at exposing self-service static registration, which means that developers would be able to register their scripts to our Identity Provider.

Note: Manual e2e tests are currently failing, which is why this is a draft. 

# New feature description

# Checklist

- [x] All acceptance criteria are met.
- [ ] Relevant documentation, if any, has been written/updated. *A dedicated ticket targets documentation*
- [X] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).