### PR TITLE
Feat/oidc/2156 refresh grant

### DIFF
--- a/packages/core/src/login/oidc/refresh/ITokenRefresher.ts
+++ b/packages/core/src/login/oidc/refresh/ITokenRefresher.ts
@@ -39,6 +39,10 @@ export type TokenEndpointResponse = {
    */
   idToken?: string;
   /**
+   * URL identifying the subject of the ID token.
+   */
+  webId?: string;
+  /**
    * Refresh token (not necessarily a JWT)
    */
   refreshToken?: string;
@@ -52,6 +56,11 @@ export type TokenEndpointResponse = {
    * ExpiresAt should be computed from expiresIn when receiving the token.
    */
   expiresIn?: number;
+
+  /**
+   * DPoP key to which the access token, and potentially the refresh token, are bound.
+   */
+  dpopKey?: KeyPair;
 };
 
 export interface ITokenRefresher {

--- a/packages/oidc/src/__mocks__/issuer.mocks.ts
+++ b/packages/oidc/src/__mocks__/issuer.mocks.ts
@@ -23,8 +23,14 @@ import { jest } from "@jest/globals";
 // eslint-disable-next-line no-shadow
 import { Response } from "cross-fetch";
 import { JWK, parseJwk, SignJWT } from "@inrupt/jose-legacy-modules";
-import { IClient, IIssuerConfig } from "@inrupt/solid-client-authn-core";
+import {
+  IClient,
+  IIssuerConfig,
+  KeyPair,
+} from "@inrupt/solid-client-authn-core";
 import { TokenEndpointInput } from "../dpop/tokenExchange";
+
+/* eslint-disable camelcase */
 
 export const mockJwk = (): JWK => {
   return {
@@ -35,6 +41,15 @@ export const mockJwk = (): JWK => {
     x: "0dGe_s-urLhD3mpqYqmSXrqUZApVV5ZNxMJXg7Vp-2A",
     y: "-oMe9gGkpfIrnJ0aiSUHMdjqYVm5ZrGCeQmRKoIIfj8",
     d: "yR1bCsR7m4hjFCvWo8Jw3OfNR4aiYDAFbBD9nkudJKM",
+  };
+};
+
+export const mockKeyPair = async (): Promise<KeyPair> => {
+  const publicKey = mockJwk();
+  delete publicKey.d;
+  return {
+    privateKey: await parseJwk(mockJwk()),
+    publicKey,
   };
 };
 
@@ -51,7 +66,7 @@ export const mockIssuer = (): IIssuerConfig => {
   };
 };
 
-export const mockWebId = (): string => "https://my.webid";
+export const mockWebId = (): string => "https://my.webid/";
 
 export const mockEndpointInput = (): TokenEndpointInput => {
   return {

--- a/packages/oidc/src/__mocks__/issuer.mocks.ts
+++ b/packages/oidc/src/__mocks__/issuer.mocks.ts
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2021 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { jest } from "@jest/globals";
+// eslint-disable-next-line no-shadow
+import { Response } from "cross-fetch";
+import { JWK, parseJwk, SignJWT } from "@inrupt/jose-legacy-modules";
+import { IClient, IIssuerConfig } from "@inrupt/solid-client-authn-core";
+import { TokenEndpointInput } from "../dpop/tokenExchange";
+
+export const mockJwk = (): JWK => {
+  return {
+    kty: "EC",
+    kid: "oOArcXxcwvsaG21jAx_D5CHr4BgVCzCEtlfmNFQtU0s",
+    alg: "ES256",
+    crv: "P-256",
+    x: "0dGe_s-urLhD3mpqYqmSXrqUZApVV5ZNxMJXg7Vp-2A",
+    y: "-oMe9gGkpfIrnJ0aiSUHMdjqYVm5ZrGCeQmRKoIIfj8",
+    d: "yR1bCsR7m4hjFCvWo8Jw3OfNR4aiYDAFbBD9nkudJKM",
+  };
+};
+
+export const mockIssuer = (): IIssuerConfig => {
+  return {
+    issuer: "https://some.issuer",
+    authorizationEndpoint: "https://some.issuer/autorization",
+    tokenEndpoint: "https://some.issuer/token",
+    jwksUri: "https://some.issuer/keys",
+    claimsSupported: ["code", "openid"],
+    subjectTypesSupported: ["public", "pairwise"],
+    registrationEndpoint: "https://some.issuer/registration",
+    grantTypesSupported: ["authorization_code"],
+  };
+};
+
+export const mockWebId = (): string => "https://my.webid";
+
+export const mockEndpointInput = (): TokenEndpointInput => {
+  return {
+    grantType: "authorization_code",
+    code: "some code",
+    codeVerifier: "some pkce token",
+    redirectUrl: "https://my.app/redirect",
+  };
+};
+
+// The following function is only there to be used manually if
+// the JWT needed to be manually re-generated.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export async function generateMockJwt(): Promise<void> {
+  const payload = {
+    sub: "https://my.webid",
+  };
+  const jwt = await new SignJWT(payload)
+    .setProtectedHeader({ alg: "ES256" })
+    .setIssuedAt()
+    .setIssuer(mockIssuer().issuer.toString())
+    .setAudience("solid")
+    .setExpirationTime("2h")
+    .sign(await parseJwk(mockJwk()));
+  // This is for manual use.
+  // eslint-disable-next-line no-console
+  console.log(jwt.toString());
+}
+
+// result of generateMockJwt()
+export const mockIdToken = (): string =>
+  "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJodHRwczovL215LndlYmlkIiwiaXNzIjoiaHR0cHM6Ly9zb21lLmlzc3VlciIsImlhdCI6MTYwMjQ5MTk5N30.R0hNKpCR3J8fS6JkTGTuFdz43_2zBMAQvCejSEO5S88DEaMQ4ktOYT__VfPmS7DHLt6Mju-J9bEc4twCnPxXjA";
+
+export type AccessJwt = {
+  sub: string;
+  iss: string;
+  aud: string;
+  nbf: number;
+  exp: number;
+  cnf: {
+    jkt: string;
+  };
+};
+
+export const mockKeyBoundToken = (): AccessJwt => {
+  return {
+    sub: mockWebId(),
+    iss: mockIssuer().issuer.toString(),
+    aud: "https://resource.example.org",
+    nbf: 1562262611,
+    exp: 1562266216,
+    cnf: {
+      jkt: mockJwk().kid as string,
+    },
+  };
+};
+
+export const mockBearerAccessToken = (): string => "some token";
+
+export type TokenEndpointRawResponse = {
+  access_token: string;
+  id_token: string;
+  refresh_token?: string;
+  token_type: string;
+};
+
+export const mockBearerTokens = (): TokenEndpointRawResponse => {
+  return {
+    access_token: mockBearerAccessToken(),
+    id_token: mockIdToken(),
+    token_type: "Bearer",
+  };
+};
+
+export const mockDpopTokens = (): TokenEndpointRawResponse => {
+  return {
+    access_token: JSON.stringify(mockKeyBoundToken()),
+    id_token: mockIdToken(),
+    token_type: "DPoP",
+  };
+};
+
+export const mockClient = (): IClient => {
+  return {
+    clientId: "some client",
+    clientType: "dynamic",
+  };
+};
+
+export const mockFetch = (payload: string, statusCode: number) => {
+  const mockedFetch = jest.fn(
+    async (
+      _url: RequestInfo,
+      _init?: RequestInit
+    ): ReturnType<typeof window.fetch> =>
+      new Response(payload, { status: statusCode })
+  );
+  window.fetch = mockedFetch;
+  return mockedFetch;
+};

--- a/packages/oidc/src/__mocks__/issuer.mocks.ts
+++ b/packages/oidc/src/__mocks__/issuer.mocks.ts
@@ -156,6 +156,10 @@ export const mockClient = (): IClient => {
   };
 };
 
+// Since this is only for tests, the ESLint warning may be disabled.
+// I'm not sure why, but the type definitions I would expect conflict either with
+// the object actually returned or with the .mock calls in the tests.
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export const mockFetch = (payload: string, statusCode: number) => {
   const mockedFetch = jest.fn(
     async (

--- a/packages/oidc/src/dpop/tokenExchange.spec.ts
+++ b/packages/oidc/src/dpop/tokenExchange.spec.ts
@@ -20,14 +20,12 @@
  */
 
 import { jest, it, describe, expect } from "@jest/globals";
-import { IClient, IIssuerConfig } from "@inrupt/solid-client-authn-core";
-import { JWK, SignJWT, parseJwk } from "@inrupt/jose-legacy-modules";
+import { IIssuerConfig } from "@inrupt/solid-client-authn-core";
 
 import {
   getBearerToken,
   getDpopToken,
   getTokens,
-  TokenEndpointInput,
   validateTokenEndpointResponse,
 } from "./tokenExchange";
 import {

--- a/packages/oidc/src/dpop/tokenExchange.spec.ts
+++ b/packages/oidc/src/dpop/tokenExchange.spec.ts
@@ -20,9 +20,6 @@
  */
 
 import { jest, it, describe, expect } from "@jest/globals";
-
-// eslint-disable-next-line no-shadow
-import { Response } from "cross-fetch";
 import { IClient, IIssuerConfig } from "@inrupt/solid-client-authn-core";
 import { JWK, SignJWT, parseJwk } from "@inrupt/jose-legacy-modules";
 
@@ -33,23 +30,22 @@ import {
   TokenEndpointInput,
   validateTokenEndpointResponse,
 } from "./tokenExchange";
+import {
+  mockBearerAccessToken,
+  mockBearerTokens,
+  mockClient,
+  mockDpopTokens,
+  mockEndpointInput,
+  mockFetch,
+  mockIdToken,
+  mockIssuer,
+  mockKeyBoundToken,
+} from "../__mocks__/issuer.mocks";
 
 // Some spec-compliant claims are camel-cased.
 /* eslint-disable camelcase */
 
 jest.mock("@inrupt/solid-client-authn-core");
-
-const mockJwk = (): JWK => {
-  return {
-    kty: "EC",
-    kid: "oOArcXxcwvsaG21jAx_D5CHr4BgVCzCEtlfmNFQtU0s",
-    alg: "ES256",
-    crv: "P-256",
-    x: "0dGe_s-urLhD3mpqYqmSXrqUZApVV5ZNxMJXg7Vp-2A",
-    y: "-oMe9gGkpfIrnJ0aiSUHMdjqYVm5ZrGCeQmRKoIIfj8",
-    d: "yR1bCsR7m4hjFCvWo8Jw3OfNR4aiYDAFbBD9nkudJKM",
-  };
-};
 
 // The following module introduces randomness in the process, which prevents
 // making assumptions on the returned values. Mocking them out makes keys and
@@ -59,121 +55,6 @@ jest.mock("uuid", () => {
     v4: (): string => "1234",
   };
 });
-
-const mockIssuer = (): IIssuerConfig => {
-  return {
-    issuer: "https://some.issuer",
-    authorizationEndpoint: "https://some.issuer/autorization",
-    tokenEndpoint: "https://some.issuer/token",
-    jwksUri: "https://some.issuer/keys",
-    claimsSupported: ["code", "openid"],
-    subjectTypesSupported: ["public", "pairwise"],
-    registrationEndpoint: "https://some.issuer/registration",
-    grantTypesSupported: ["authorization_code"],
-  };
-};
-
-const mockWebId = (): string => "https://my.webid";
-
-const mockEndpointInput = (): TokenEndpointInput => {
-  return {
-    grantType: "authorization_code",
-    code: "some code",
-    codeVerifier: "some pkce token",
-    redirectUrl: "https://my.app/redirect",
-  };
-};
-
-// The following function is only there to be used manually if
-// the JWT needed to be manually re-generated.
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-async function generateMockJwt(): Promise<void> {
-  const payload = {
-    sub: "https://my.webid",
-  };
-  const jwt = await new SignJWT(payload)
-    .setProtectedHeader({ alg: "ES256" })
-    .setIssuedAt()
-    .setIssuer(mockIssuer().issuer.toString())
-    .setAudience("solid")
-    .setExpirationTime("2h")
-    .sign(await parseJwk(mockJwk()));
-  // This is for manual use.
-  // eslint-disable-next-line no-console
-  console.log(jwt.toString());
-}
-
-// result of generateMockJwt()
-const mockIdToken = (): string =>
-  "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJodHRwczovL215LndlYmlkIiwiaXNzIjoiaHR0cHM6Ly9zb21lLmlzc3VlciIsImlhdCI6MTYwMjQ5MTk5N30.R0hNKpCR3J8fS6JkTGTuFdz43_2zBMAQvCejSEO5S88DEaMQ4ktOYT__VfPmS7DHLt6Mju-J9bEc4twCnPxXjA";
-
-type AccessJwt = {
-  sub: string;
-  iss: string;
-  aud: string;
-  nbf: number;
-  exp: number;
-  cnf: {
-    jkt: string;
-  };
-};
-
-const mockKeyBoundToken = (): AccessJwt => {
-  return {
-    sub: mockWebId(),
-    iss: mockIssuer().issuer.toString(),
-    aud: "https://resource.example.org",
-    nbf: 1562262611,
-    exp: 1562266216,
-    cnf: {
-      jkt: mockJwk().kid as string,
-    },
-  };
-};
-
-const mockBearerAccessToken = (): string => "some token";
-
-type TokenEndpointRawResponse = {
-  access_token: string;
-  id_token: string;
-  refresh_token?: string;
-  token_type: string;
-};
-
-const mockBearerTokens = (): TokenEndpointRawResponse => {
-  return {
-    access_token: mockBearerAccessToken(),
-    id_token: mockIdToken(),
-    token_type: "Bearer",
-  };
-};
-
-const mockDpopTokens = (): TokenEndpointRawResponse => {
-  return {
-    access_token: JSON.stringify(mockKeyBoundToken()),
-    id_token: mockIdToken(),
-    token_type: "DPoP",
-  };
-};
-
-const mockClient = (): IClient => {
-  return {
-    clientId: "some client",
-    clientType: "dynamic",
-  };
-};
-
-const mockFetch = (payload: string, statusCode: number) => {
-  const mockedFetch = jest.fn(
-    async (
-      _url: RequestInfo,
-      _init?: RequestInit
-    ): ReturnType<typeof window.fetch> =>
-      new Response(payload, { status: statusCode })
-  );
-  window.fetch = mockedFetch;
-  return mockedFetch;
-};
 
 describe("validateTokenEndpointResponse", () => {
   describe("for DPoP tokens", () => {

--- a/packages/oidc/src/index.ts
+++ b/packages/oidc/src/index.ts
@@ -48,6 +48,7 @@ export {
   TokenEndpointInput,
   CodeExchangeResult,
 } from "./dpop/tokenExchange";
+export { refresh } from "./refresh/refreshGrant";
 export {
   removeOidcQueryParam,
   clearOidcPersistentStorage,

--- a/packages/oidc/src/refresh/refreshGrant.spec.ts
+++ b/packages/oidc/src/refresh/refreshGrant.spec.ts
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2021 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { jest, it, describe, expect } from "@jest/globals";
+import { jwtVerify, parseJwk } from "@inrupt/jose-legacy-modules";
+import {
+  mockBearerTokens,
+  mockClient,
+  mockDpopTokens,
+  mockFetch,
+  mockIdToken,
+  mockIssuer,
+  mockKeyBoundToken,
+  mockKeyPair,
+  mockWebId,
+} from "../__mocks__/issuer.mocks";
+import { refresh } from "./refreshGrant";
+
+jest.mock("@inrupt/solid-client-authn-core", () => {
+  const actualCoreModule = jest.requireActual(
+    "@inrupt/solid-client-authn-core"
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ) as any;
+  return {
+    ...actualCoreModule,
+    // This works around the network lookup to the JWKS in order to validate the ID token.
+    getWebidFromTokenPayload: jest.fn(() =>
+      Promise.resolve("https://my.webid/")
+    ),
+  };
+});
+
+describe("refreshGrant", () => {
+  it("uses basic auth if a client secret is available", async () => {
+    const myFetch = mockFetch(JSON.stringify(mockBearerTokens()), 200);
+    const client = mockClient();
+    client.clientSecret = "some secret";
+    await refresh("some refresh token", mockIssuer(), client);
+    expect(myFetch.mock.calls[0][0]).toBe(
+      mockIssuer().tokenEndpoint.toString()
+    );
+    const headers = myFetch.mock.calls[0][1]?.headers as Record<string, string>;
+    // c29tZSBjbGllbnQ6c29tZSBzZWNyZXQ= is 'some client:some secret' encoded in base 64
+    expect(headers.Authorization).toEqual(
+      "Basic c29tZSBjbGllbnQ6c29tZSBzZWNyZXQ="
+    );
+  });
+
+  it("does not use basic auth if no client secret is available", async () => {
+    const myFetch = mockFetch(JSON.stringify(mockBearerTokens()), 200);
+    const client = mockClient();
+
+    await refresh("some refresh token", mockIssuer(), client);
+    expect(myFetch.mock.calls[0][0]).toBe(
+      mockIssuer().tokenEndpoint.toString()
+    );
+    const headers = myFetch.mock.calls[0][1]?.headers as Record<string, string>;
+    expect(headers.Authorization).toBeUndefined();
+  });
+
+  it("includes a DPoP proof if a DPoP key is provided", async () => {
+    const myFetch = mockFetch(JSON.stringify(mockDpopTokens()), 200);
+    const client = mockClient();
+    const keyPair = await mockKeyPair();
+    await refresh("some refresh token", mockIssuer(), client, keyPair);
+    expect(myFetch.mock.calls[0][0]).toBe(
+      mockIssuer().tokenEndpoint.toString()
+    );
+    const headers = myFetch.mock.calls[0][1]?.headers as Record<string, string>;
+    expect(headers.DPoP).not.toBeUndefined();
+    const dpopHeader = headers.DPoP;
+    const dpopProof = await jwtVerify(
+      dpopHeader,
+      await parseJwk(keyPair.publicKey)
+    );
+    expect(dpopProof.payload.htu).toBe(mockIssuer().tokenEndpoint.toString());
+  });
+
+  it("throws if the token endpoint returns an unexpected data format (i.e. not JSON)", async () => {
+    mockFetch("Some non-JSON data", 200);
+    const client = mockClient();
+    await expect(
+      refresh("some refresh token", mockIssuer(), client)
+    ).rejects.toThrow(
+      `The token endpoint of issuer ${
+        mockIssuer().issuer
+      } returned a malformed response.`
+    );
+  });
+
+  it("POSTs an URL-encoded form with the appropriate grant type", async () => {
+    const myFetch = mockFetch(JSON.stringify(mockBearerTokens()), 200);
+    await refresh("some refresh token", mockIssuer(), mockClient());
+    const requestInit = myFetch.mock.calls[0][1];
+    expect(requestInit?.method).toBe("POST");
+    expect(
+      (requestInit?.headers as Record<string, string>)["Content-Type"]
+    ).toBe("application/x-www-form-urlencoded");
+    const body = requestInit?.body;
+    const searchableBody = new URLSearchParams(body?.toString());
+    expect(searchableBody.get("grant_type")).toBe("refresh_token");
+  });
+
+  it("sends the refresh to the token endpoint, and requests a new refresh token and id token", async () => {
+    const myFetch = mockFetch(JSON.stringify(mockBearerTokens()), 200);
+    await refresh("some refresh token", mockIssuer(), mockClient());
+    const body = myFetch.mock.calls[0][1]?.body;
+    const searchableBody = new URLSearchParams(body?.toString());
+    expect(searchableBody.get("refresh_token")).toBe("some refresh token");
+    expect(searchableBody.get("scope")).toContain("offline_access");
+    expect(searchableBody.get("scope")).toContain("openid");
+  });
+
+  it("throws if the token endpoint does not return an access token", async () => {
+    mockFetch(
+      JSON.stringify({
+        ...mockBearerTokens(),
+        access_token: undefined,
+      }),
+      200
+    );
+    await expect(
+      refresh("some refresh token", mockIssuer(), mockClient())
+    ).rejects.toThrow(
+      "Invalid token endpoint response (missing the field 'access_token')"
+    );
+  });
+
+  it("throws if the token endpoint does not return an ID token", async () => {
+    mockFetch(
+      JSON.stringify({
+        ...mockBearerTokens(),
+        id_token: undefined,
+      }),
+      200
+    );
+    await expect(
+      refresh("some refresh token", mockIssuer(), mockClient())
+    ).rejects.toThrow(
+      "Invalid token endpoint response (missing the field 'id_token')"
+    );
+  });
+
+  it("throws if the token endpoint returns an error", async () => {
+    mockFetch(
+      JSON.stringify({
+        error: "Some error",
+      }),
+      400
+    );
+    await expect(
+      refresh("some refresh token", mockIssuer(), mockClient())
+    ).rejects.toThrow("Token endpoint returned error [Some error]");
+  });
+
+  it("returns the access, ID and refresh tokens, as well as the WebID and DPoP key if applicable", async () => {
+    mockFetch(
+      JSON.stringify({
+        ...mockDpopTokens(),
+        refresh_token: "Some new refresh token",
+      }),
+      200
+    );
+    const client = mockClient();
+    const keyPair = await mockKeyPair();
+    const result = await refresh(
+      "some refresh token",
+      mockIssuer(),
+      client,
+      keyPair
+    );
+    expect(result.accessToken).toBe(JSON.stringify(mockKeyBoundToken()));
+    expect(result.idToken).toBe(mockIdToken());
+    expect(result.refreshToken).toBe("Some new refresh token");
+    expect(result.webId).toBe(mockWebId());
+    expect(result.dpopKey).toEqual(keyPair);
+  });
+});

--- a/packages/oidc/src/refresh/refreshGrant.ts
+++ b/packages/oidc/src/refresh/refreshGrant.ts
@@ -25,13 +25,11 @@ import {
   IClient,
   IIssuerConfig,
   KeyPair,
+  TokenEndpointResponse,
 } from "@inrupt/solid-client-authn-core";
 // NB: once this is rebased on #1560, change dependency to core package.
 import formUrlEncoded from "form-urlencoded";
-import {
-  TokenEndpointResponse,
-  validateTokenEndpointResponse,
-} from "../dpop/tokenExchange";
+import { validateTokenEndpointResponse } from "../dpop/tokenExchange";
 
 // Identifiers in camelcase are mandated by the OAuth spec.
 /* eslint-disable camelcase */

--- a/packages/oidc/src/refresh/refreshGrant.ts
+++ b/packages/oidc/src/refresh/refreshGrant.ts
@@ -31,7 +31,7 @@ import {
 import formUrlEncoded from "form-urlencoded";
 import { validateTokenEndpointResponse } from "../dpop/tokenExchange";
 
-// Identifiers in camelcase are mandated by the OAuth spec.
+// Identifiers in snake_case are mandated by the OAuth spec.
 /* eslint-disable camelcase */
 
 export async function refresh(

--- a/packages/oidc/src/refresh/refreshGrant.ts
+++ b/packages/oidc/src/refresh/refreshGrant.ts
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2021 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import {
+  createDpopHeader,
+  getWebidFromTokenPayload,
+  IClient,
+  IIssuerConfig,
+  KeyPair,
+} from "@inrupt/solid-client-authn-core";
+// NB: once this is rebased on #1560, change dependency to core package.
+import formUrlEncoded from "form-urlencoded";
+import {
+  TokenEndpointResponse,
+  validateTokenEndpointResponse,
+} from "../dpop/tokenExchange";
+
+// Identifiers in camelcase are mandated by the OAuth spec.
+/* eslint-disable camelcase */
+
+export async function refresh(
+  refreshToken: string,
+  issuer: IIssuerConfig,
+  client: IClient,
+  dpopKey?: KeyPair
+): Promise<TokenEndpointResponse> {
+  const requestBody = {
+    grant_type: "refresh_token",
+    refresh_token: refreshToken,
+    scope: "openid offline_access",
+  };
+
+  let dpopHeader = {};
+  if (dpopKey !== undefined) {
+    dpopHeader = {
+      DPoP: await createDpopHeader(issuer.tokenEndpoint, "POST", dpopKey),
+    };
+  }
+
+  let authHeader = {};
+  if (client.clientSecret !== undefined) {
+    authHeader = {
+      // We assume that client_secret_basic is the client authentication method.
+      // TODO: Get the authentication method from the IClient configuration object.
+      Authorization: `Basic ${btoa(
+        `${client.clientId}:${client.clientSecret}`
+      )}`,
+    };
+  }
+
+  const rawResponse = await fetch(issuer.tokenEndpoint, {
+    method: "POST",
+    body: formUrlEncoded(requestBody),
+    headers: {
+      ...dpopHeader,
+      ...authHeader,
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+  });
+  let response;
+  try {
+    response = await rawResponse.json();
+  } catch (e) {
+    // The response is left out of the error on purpose not to leak any sensitive information.
+    throw new Error(
+      `The token endpoint of issuer ${issuer.issuer} returned a malformed response.`
+    );
+  }
+  const validatedResponse = validateTokenEndpointResponse(
+    response,
+    dpopKey !== undefined
+  );
+  const webId = await getWebidFromTokenPayload(
+    validatedResponse.id_token,
+    issuer.jwksUri,
+    issuer.issuer,
+    client.clientId
+  );
+  return {
+    accessToken: validatedResponse.access_token,
+    idToken: validatedResponse.id_token,
+    refreshToken:
+      typeof validatedResponse.refresh_token === "string"
+        ? validatedResponse.refresh_token
+        : undefined,
+    webId,
+    dpopKey,
+  };
+}


### PR DESCRIPTION
This implements the refresh token grant in the `oidc-client-ext` module. It enables exchanging a refresh token for a new access token, and rotates the refresh token too. For the time being, only `client-secret-basic` client authentication is supported.

Eventually, this code will run in `solid-client-authn-browser`, and will enable keeping a user's session alive.

# Checklist

- [X] All acceptance criteria are met.
- [ ] The changelog has been updated, if applicable. **N/A I'll add it to the CHANGELOG when it is available in the browser module** 
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).