### PR TITLE
Feat/browser/2156 refresh grant

### DIFF
--- a/packages/browser/__tests__/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
+++ b/packages/browser/__tests__/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
@@ -179,6 +179,7 @@ function mockOidcClient(jwt: typeof defaultJwt = defaultJwt): any {
   mockedOidcClient.getBearerToken = mockTokenEndpointBearerResponse;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   mockedOidcClient.validateIdToken = (jest.fn() as any).mockResolvedValue(true);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   mockedOidcClient.refresh = (jest.fn() as any).mockResolvedValueOnce({
     ...mockTokenEndpointBearerResponse(),
     refreshToken: "some rotated refresh token",

--- a/packages/browser/__tests__/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
+++ b/packages/browser/__tests__/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
@@ -41,6 +41,10 @@ import { RedirectorMock } from "../../../../src/login/oidc/__mocks__/Redirector"
 import { SessionInfoManagerMock } from "../../../../src/sessionInfo/__mocks__/SessionInfoManager";
 import { KEY_CURRENT_SESSION } from "../../../../src/constant";
 import { LocalStorageMock } from "../../../../src/storage/__mocks__/LocalStorage";
+import {
+  mockDefaultTokenRefresher,
+  mockTokenRefresher,
+} from "../../../../src/login/oidc/refresh/__mocks__/TokenRefresher";
 
 const mockJwk = (): JWK => {
   return {
@@ -106,6 +110,7 @@ const mockTokenEndpointBearerResponse = (): CodeExchangeResult => {
     idToken: mockIdToken(),
     webId: mockWebId(),
     expiresIn: MOCK_EXPIRE_TIME,
+    refreshToken: "some refresh token",
   };
 };
 
@@ -121,6 +126,7 @@ const mockTokenEndpointDpopResponse = async (): Promise<CodeExchangeResult> => {
       publicKey: mockJwk(),
     },
     expiresIn: MOCK_EXPIRE_TIME,
+    refreshToken: "some DPoP-bound refresh token",
   };
 };
 
@@ -134,6 +140,20 @@ const mockLocalStorage = (stored: Record<string, string>) => {
     writable: true,
   });
 };
+
+const mockDefaultRedirectStorage = () =>
+  mockStorageUtility({
+    "solidClientAuthenticationUser:someState": {
+      sessionId: "mySession",
+    },
+    "solidClientAuthenticationUser:mySession": {
+      issuer: "https://my.idp/",
+      codeVerifier: "some code verifier",
+      redirectUrl: "https://my.app/redirect",
+      dpop: "true",
+      idTokenSignedResponseAlg: "RS256",
+    },
+  });
 
 jest.mock("@inrupt/oidc-client-ext");
 
@@ -159,6 +179,10 @@ function mockOidcClient(jwt: typeof defaultJwt = defaultJwt): any {
   mockedOidcClient.getBearerToken = mockTokenEndpointBearerResponse;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   mockedOidcClient.validateIdToken = (jest.fn() as any).mockResolvedValue(true);
+  mockedOidcClient.refresh = (jest.fn() as any).mockResolvedValueOnce({
+    ...mockTokenEndpointBearerResponse(),
+    refreshToken: "some rotated refresh token",
+  });
   return mockedOidcClient;
 }
 
@@ -197,6 +221,7 @@ const defaultMocks = {
   sessionInfoManager: SessionInfoManagerMock,
   clientRegistrar: mockClientRegistrar(mockClient()),
   issuerConfigFetcher: mockIssuerConfigFetcher(mockIssuer()),
+  tokenRefresher: mockDefaultTokenRefresher(),
 };
 
 function getAuthCodeRedirectHandler(
@@ -206,7 +231,8 @@ function getAuthCodeRedirectHandler(
     mocks.storageUtility ?? defaultMocks.storageUtility,
     mocks.sessionInfoManager ?? defaultMocks.sessionInfoManager,
     mocks.issuerConfigFetcher ?? defaultMocks.issuerConfigFetcher,
-    mocks.clientRegistrar ?? defaultMocks.clientRegistrar
+    mocks.clientRegistrar ?? defaultMocks.clientRegistrar,
+    mocks.tokenRefresher ?? defaultMocks.tokenRefresher
   );
 }
 
@@ -775,5 +801,37 @@ describe("AuthCodeRedirectHandler", () => {
         (await mockedStorage.get("tmp-resource-server-session-info")) ?? "{}"
       )
     ).toEqual({});
+  });
+
+  it("returns a fetch that supports the refresh flow", async () => {
+    window.localStorage.setItem("tmp-resource-server-session-enabled", "false");
+    mockOidcClient();
+    const mockedStorage = mockDefaultRedirectStorage();
+
+    const tokenRefresher = mockTokenRefresher(
+      await mockTokenEndpointDpopResponse()
+    );
+    // Run the test
+    const authCodeRedirectHandler = getAuthCodeRedirectHandler({
+      storageUtility: mockedStorage,
+      tokenRefresher,
+    });
+
+    // Check that the returned fetch function is authenticated
+    const response = new Response("", {
+      status: 401,
+    });
+
+    jest.spyOn(response, "url", "get").mockReturnValue("https://some.url/");
+
+    mockFetch(response);
+
+    const result = await authCodeRedirectHandler.handle(
+      "https://my.app/redirect?code=someCode&state=someState"
+    );
+
+    await result.fetch("https://some.url/");
+
+    expect(tokenRefresher.refresh).toHaveBeenCalled();
   });
 });

--- a/packages/browser/__tests__/login/oidc/refresh/TokenRefresher.spec.ts
+++ b/packages/browser/__tests__/login/oidc/refresh/TokenRefresher.spec.ts
@@ -1,0 +1,263 @@
+/*
+ * Copyright 2021 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { jest, it, describe, expect } from "@jest/globals";
+import {
+  mockStorageUtility,
+  StorageUtilityMock,
+  TokenEndpointResponse,
+} from "@inrupt/solid-client-authn-core";
+import { JWK, parseJwk } from "@inrupt/jose-legacy-modules";
+import { refresh } from "@inrupt/oidc-client-ext";
+import TokenRefresher from "../../../../src/login/oidc/refresh/TokenRefresher";
+import {
+  mockDefaultIssuerConfigFetcher,
+  IssuerConfigFetcherFetchConfigResponse,
+} from "../../../../src/login/oidc/__mocks__/IssuerConfigFetcher";
+import { mockDefaultClientRegistrar } from "../../../../src/login/oidc/__mocks__/ClientRegistrar";
+
+jest.mock("@inrupt/oidc-client-ext");
+
+const mockDefaultStorageContent = {
+  "solidClientAuthenticationUser:mySession": {
+    issuer: "https://my.idp",
+    codeVerifier: "some code verifier",
+    redirectUrl: "https://my.app/redirect",
+    idTokenSignedResponseAlg: "ES256",
+    dpop: "true",
+  },
+};
+
+const mockRefresherDefaultStorageUtility = () =>
+  mockStorageUtility(mockDefaultStorageContent);
+
+const mockJwk = (): JWK => {
+  return {
+    kty: "EC",
+    kid: "oOArcXxcwvsaG21jAx_D5CHr4BgVCzCEtlfmNFQtU0s",
+    alg: "ES256",
+    crv: "P-256",
+    x: "0dGe_s-urLhD3mpqYqmSXrqUZApVV5ZNxMJXg7Vp-2A",
+    y: "-oMe9gGkpfIrnJ0aiSUHMdjqYVm5ZrGCeQmRKoIIfj8",
+    d: "yR1bCsR7m4hjFCvWo8Jw3OfNR4aiYDAFbBD9nkudJKM",
+  };
+};
+
+const mockKeyPair = async () => {
+  return {
+    privateKey: await parseJwk(mockJwk()),
+    // Use the same JWK for public and private key out of convenience, don't do
+    // this in real life.
+    publicKey: mockJwk(),
+  };
+};
+
+const mockIdToken = (): string =>
+  "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJodHRwczovL215LndlYmlkIiwiaXNzIjoiaHR0cHM6Ly9teS5pZHAvIiwiYXVkIjoiaHR0cHM6Ly9yZXNvdXJjZS5leGFtcGxlLm9yZyIsImV4cCI6MTY2MjI2NjIxNiwiaWF0IjoxNDYyMjY2MjE2fQ.IwumuwJtQw5kUBMMHAaDPJBppfBpRHbiXZw_HlKe6GNVUWUlyQRYV7W7r9OQtHmMsi6GVwOckelA3ErmhrTGVw";
+
+type AccessJwt = {
+  sub: string;
+  iss: string;
+  aud: string;
+  nbf: number;
+  exp: number;
+  cnf: {
+    jkt: string;
+  };
+};
+
+const mockWebId = (): string => "https://my.webid/";
+
+const mockKeyBoundToken = (): AccessJwt => {
+  return {
+    sub: mockWebId(),
+    iss: IssuerConfigFetcherFetchConfigResponse.issuer,
+    aud: "https://resource.example.org",
+    nbf: 1562262611,
+    exp: 1562266216,
+    cnf: {
+      jkt: mockJwk().kid as string,
+    },
+  };
+};
+
+const mockDpopTokens = (): TokenEndpointResponse => {
+  return {
+    accessToken: JSON.stringify(mockKeyBoundToken()),
+    idToken: mockIdToken(),
+    tokenType: "DPoP",
+  };
+};
+
+const mockOidcModule = async (response?: TokenEndpointResponse) => {
+  const oidcModule = jest.requireMock("@inrupt/oidc-client-ext") as {
+    refresh: typeof refresh;
+  };
+  oidcModule.refresh = jest.fn().mockReturnValueOnce(
+    response === undefined
+      ? {
+          ...mockDpopTokens(),
+          dpopKey: await mockKeyPair(),
+          webId: mockWebId(),
+        }
+      : response
+  ) as typeof refresh;
+  return oidcModule;
+};
+
+const defaultMocks = {
+  storageUtility: StorageUtilityMock,
+  issuerConfigFetcher: mockDefaultIssuerConfigFetcher(),
+  clientRegistrar: mockDefaultClientRegistrar(),
+};
+
+function getTokenRefresher(
+  mocks: Partial<typeof defaultMocks> = defaultMocks
+): TokenRefresher {
+  return new TokenRefresher(
+    mocks.storageUtility ?? defaultMocks.storageUtility,
+    mocks.issuerConfigFetcher ?? defaultMocks.issuerConfigFetcher,
+    mocks.clientRegistrar ?? defaultMocks.clientRegistrar
+  );
+}
+
+describe("TokenRefresher", () => {
+  describe("refresh", () => {
+    it("throws if no OIDC issuer can be retrieved from storage", async () => {
+      const mockedStorage = mockStorageUtility({});
+
+      const refresher = getTokenRefresher({
+        storageUtility: mockedStorage,
+      });
+
+      await expect(
+        refresher.refresh("mySession", "some refresh token")
+      ).rejects.toThrow(
+        "Failed to retrieve OIDC context from storage associated with session [mySession]"
+      );
+    });
+
+    it("throws if the token type cannot be retrieved from storage", async () => {
+      const mockedStorage = mockStorageUtility({
+        "solidClientAuthenticationUser:mySession": {
+          issuer: "https://my.idp",
+        },
+      });
+
+      const refresher = getTokenRefresher({
+        storageUtility: mockedStorage,
+      });
+
+      await expect(
+        refresher.refresh("mySession", "some refresh token")
+      ).rejects.toThrow(
+        "Failed to retrieve OIDC context from storage associated with session [mySession]"
+      );
+    });
+
+    it("throws if a refresh token isn't provided", async () => {
+      const mockedStorage = mockRefresherDefaultStorageUtility();
+
+      const refresher = getTokenRefresher({
+        storageUtility: mockedStorage,
+      });
+
+      await expect(refresher.refresh("mySession")).rejects.toThrow(
+        "Session [mySession] has no refresh token to allow it to refresh its access token."
+      );
+    });
+
+    it("throws if a DPoP token is expected, but no DPoP key is provided", async () => {
+      const mockedStorage = mockRefresherDefaultStorageUtility();
+
+      const refresher = getTokenRefresher({
+        storageUtility: mockedStorage,
+      });
+
+      await expect(
+        refresher.refresh("mySession", "some refresh token")
+      ).rejects.toThrow(
+        "For session [mySession], the key bound to the DPoP access token must be provided to refresh said access token."
+      );
+    });
+
+    // This tests for implementation rather than behaviour, but it does so for an internal
+    // piece of code that is therefore tested elsewhere.
+    it("calls oidc-client-ext::refresh", async () => {
+      const mockedStorage = mockRefresherDefaultStorageUtility();
+      const oidcModule = await mockOidcModule();
+      const refresher = getTokenRefresher({
+        storageUtility: mockedStorage,
+      });
+      const result = await refresher.refresh(
+        "mySession",
+        "some refresh token",
+        await mockKeyPair()
+      );
+      expect(oidcModule.refresh).toHaveBeenCalled();
+      expect(result).toEqual({
+        ...mockDpopTokens(),
+        dpopKey: await mockKeyPair(),
+        webId: mockWebId(),
+      });
+    });
+
+    it("calls the refresh token rotation callback if a new refresh token is isued", async () => {
+      const mockedStorage = mockRefresherDefaultStorageUtility();
+      await mockOidcModule({
+        ...mockDpopTokens(),
+        refreshToken: "Some rotated refresh token",
+        dpopKey: await mockKeyPair(),
+        webId: mockWebId(),
+      });
+      const refresher = getTokenRefresher({
+        storageUtility: mockedStorage,
+      });
+      const callback = jest.fn();
+      await refresher.refresh(
+        "mySession",
+        "some refresh token",
+        await mockKeyPair(),
+        callback
+      );
+      expect(callback).toHaveBeenCalled();
+    });
+
+    it("accepts a new refresh token without a callback", async () => {
+      const mockedStorage = mockRefresherDefaultStorageUtility();
+      await mockOidcModule({
+        ...mockDpopTokens(),
+        refreshToken: "Some rotated refresh token",
+        dpopKey: await mockKeyPair(),
+        webId: mockWebId(),
+      });
+      const refresher = getTokenRefresher({
+        storageUtility: mockedStorage,
+      });
+      const result = await refresher.refresh(
+        "mySession",
+        "some refresh token",
+        await mockKeyPair()
+      );
+      expect(result.refreshToken).toBe("Some rotated refresh token");
+    });
+  });
+});

--- a/packages/browser/src/dependencies.ts
+++ b/packages/browser/src/dependencies.ts
@@ -42,6 +42,7 @@ import BrowserStorage from "./storage/BrowserStorage";
 import Redirector from "./login/oidc/Redirector";
 import ClientRegistrar from "./login/oidc/ClientRegistrar";
 import { ErrorOidcHandler } from "./login/oidc/redirectHandler/ErrorOidcHandler";
+import TokenRefresher from "./login/oidc/refresh/TokenRefresher";
 
 /**
  *
@@ -74,13 +75,20 @@ export function getClientAuthenticationWithDependencies(dependencies: {
     clientRegistrar
   );
 
+  const refresher = new TokenRefresher(
+    storageUtility,
+    issuerConfigFetcher,
+    clientRegistrar
+  );
+
   const redirectHandler = new AggregateRedirectHandler([
     new ErrorOidcHandler(),
     new AuthCodeRedirectHandler(
       storageUtility,
       sessionInfoManager,
       issuerConfigFetcher,
-      clientRegistrar
+      clientRegistrar,
+      refresher
     ),
     // This catch-all class will always be able to handle the
     // redirect IRI, so it must be registered last.

--- a/packages/browser/src/login/oidc/refresh/TokenRefresher.ts
+++ b/packages/browser/src/login/oidc/refresh/TokenRefresher.ts
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2021 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * @hidden
+ * @packageDocumentation
+ */
+
+import {
+  IClient,
+  IClientRegistrar,
+  IIssuerConfigFetcher,
+  IStorageUtility,
+  loadOidcContextFromStorage,
+  KeyPair,
+  ITokenRefresher,
+  TokenEndpointResponse,
+} from "@inrupt/solid-client-authn-core";
+import { refresh } from "@inrupt/oidc-client-ext";
+
+// Some identifiers are not in camelcase on purpose, as they are named using the
+// official names from the OIDC/OAuth2 specifications.
+/* eslint-disable camelcase */
+
+/**
+ * @hidden
+ */
+export default class TokenRefresher implements ITokenRefresher {
+  constructor(
+    private storageUtility: IStorageUtility,
+    private issuerConfigFetcher: IIssuerConfigFetcher,
+    private clientRegistrar: IClientRegistrar
+  ) {}
+
+  async refresh(
+    sessionId: string,
+    refreshToken?: string,
+    dpopKey?: KeyPair,
+    onNewRefreshToken?: (newToken: string) => unknown
+  ): Promise<TokenEndpointResponse> {
+    const oidcContext = await loadOidcContextFromStorage(
+      sessionId,
+      this.storageUtility,
+      this.issuerConfigFetcher
+    );
+    // This should also retrieve the client from storage
+    const clientInfo: IClient = await this.clientRegistrar.getClient(
+      { sessionId },
+      oidcContext.issuerConfig
+    );
+
+    if (refreshToken === undefined) {
+      // TODO: in a next PR, look up storage for a refresh token
+      throw new Error(
+        `Session [${sessionId}] has no refresh token to allow it to refresh its access token.`
+      );
+    }
+
+    if (oidcContext.dpop && dpopKey === undefined) {
+      throw new Error(
+        `For session [${sessionId}], the key bound to the DPoP access token must be provided to refresh said access token.`
+      );
+    }
+
+    const tokenSet = await refresh(
+      refreshToken,
+      oidcContext.issuerConfig,
+      clientInfo,
+      dpopKey
+    );
+
+    if (tokenSet.refreshToken !== undefined) {
+      await this.storageUtility.setForUser(sessionId, {
+        refreshToken: tokenSet.refreshToken,
+      });
+      if (typeof onNewRefreshToken === "function") {
+        onNewRefreshToken(tokenSet.refreshToken);
+      }
+    }
+    return tokenSet;
+  }
+}

--- a/packages/browser/src/login/oidc/refresh/__mocks__/TokenRefresher.ts
+++ b/packages/browser/src/login/oidc/refresh/__mocks__/TokenRefresher.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2021 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { jest } from "@jest/globals";
+import {
+  ITokenRefresher,
+  TokenEndpointResponse,
+} from "@inrupt/solid-client-authn-core";
+
+// Some identifiers are in camelcase on purpose.
+/* eslint-disable camelcase */
+
+export const mockTokenRefresher = (
+  tokenSet: TokenEndpointResponse
+): ITokenRefresher => {
+  return {
+    refresh: jest
+      .fn<
+        ReturnType<ITokenRefresher["refresh"]>,
+        Parameters<ITokenRefresher["refresh"]>
+      >()
+      .mockResolvedValue(tokenSet),
+  };
+};
+
+const mockIdTokenPayload = () => {
+  return {
+    sub: "https://my.webid",
+    iss: "https://my.idp/",
+    aud: "https://resource.example.org",
+    exp: 1662266216,
+    iat: 1462266216,
+  };
+};
+
+export const mockDefaultTokenSet = (): TokenEndpointResponse => {
+  return {
+    accessToken: "some refreshed access token",
+    idToken: JSON.stringify(mockIdTokenPayload()),
+  };
+};
+
+export const mockDefaultTokenRefresher = (): ITokenRefresher =>
+  mockTokenRefresher(mockDefaultTokenSet());

--- a/packages/core/src/authenticatedFetch/fetchFactory.ts
+++ b/packages/core/src/authenticatedFetch/fetchFactory.ts
@@ -148,7 +148,6 @@ export async function buildDpopFetch(
   let currentAccessToken = accessToken;
   const currentRefreshOptions: RefreshOptions | undefined = refreshOptions;
   return async (url, options): Promise<Response> => {
-    console.log("coucou");
     let response = await unauthFetch(
       url,
       await buildDpopFetchOptions(

--- a/packages/core/src/authenticatedFetch/fetchFactory.ts
+++ b/packages/core/src/authenticatedFetch/fetchFactory.ts
@@ -148,6 +148,7 @@ export async function buildDpopFetch(
   let currentAccessToken = accessToken;
   const currentRefreshOptions: RefreshOptions | undefined = refreshOptions;
   return async (url, options): Promise<Response> => {
+    console.log("coucou");
     let response = await unauthFetch(
       url,
       await buildDpopFetchOptions(


### PR DESCRIPTION
This adds refresh token management capability to the browser codebase. Currently, the browser does not specift the `offline_scope` which asks for the refresh token, but when it does the refresh token will be stored in the authenticated fetch closure and used to get new access tokens on 401.

Note: there is a lot of mocks duplication in these tests, i'll fix this in a separate PR.

# Checklist

- [X] All acceptance criteria are met.
- [ ] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).