### PR TITLE
Ask for offline scope in browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased
 
+### New features
+
+#### browser
+
+- Request refresh tokens: The browser client now requests a refresh token, and 
+uses it when its access token has expired to get a new access token. This enables
+keeping a session alive for longer than the lifetime of a single access token.
+
 The following sections document changes that have been released already:
 
 ## 1.10.1 - 2021-09-02

--- a/packages/browser/examples/single/bundle/client-app-profile.ttl
+++ b/packages/browser/examples/single/bundle/client-app-profile.ttl
@@ -4,7 +4,7 @@
     "client_id" : "https://raw.githubusercontent.com/inrupt/solid-client-authn-js/main/packages/browser/examples/single/bundle/client-app-profile.ttl#app",
     "redirect_uris" : ["http://localhost:3113/"],
     "client_name" : "Demo app",
-    "scope" : "openid webid",
+    "scope" : "openid offline_access",
     "grant_types" : ["authorization_code"],
     "response_types" : ["code"]
     }""" .

--- a/packages/browser/src/login/oidc/ClientRegistrar.spec.ts
+++ b/packages/browser/src/login/oidc/ClientRegistrar.spec.ts
@@ -90,6 +90,7 @@ describe("ClientRegistrar", () => {
           subject_type: "pairwise",
           token_endpoint_auth_method: "client_secret_basic",
           id_token_signed_response_alg: "RS256",
+          grant_types: ["authorization_code", "refresh_token"],
           /* eslint-enable camelcase */
         }),
       });

--- a/packages/browser/src/login/oidc/oidcHandlers/AuthorizationCodeWithPkceOidcHandler.spec.ts
+++ b/packages/browser/src/login/oidc/oidcHandlers/AuthorizationCodeWithPkceOidcHandler.spec.ts
@@ -172,7 +172,7 @@ describe("AuthorizationCodeWithPkceOidcHandler", () => {
       ).resolves.not.toBeNull();
     });
 
-    it("passes our the 'prompt' option down to our OIDC client library implementation", async () => {
+    it("passes on the 'prompt' option down to our OIDC client library implementation", async () => {
       const oidcModule = mockOidcModule();
       const authorizationCodeWithPkceOidcHandler =
         getAuthorizationCodeWithPkceOidcHandler();
@@ -188,6 +188,25 @@ describe("AuthorizationCodeWithPkceOidcHandler", () => {
       expect(oidcModule.OidcClient).toHaveBeenCalledWith(
         expect.objectContaining({
           prompt: "none",
+        })
+      );
+    });
+
+    it("defaults the 'prompt' option to consent", async () => {
+      const oidcModule = mockOidcModule();
+      const authorizationCodeWithPkceOidcHandler =
+        getAuthorizationCodeWithPkceOidcHandler();
+      const oidcOptions: IOidcOptions = {
+        ...standardOidcOptions,
+        issuerConfiguration: {
+          ...standardOidcOptions.issuerConfiguration,
+          grantTypesSupported: ["authorization_code"],
+        },
+      };
+      await authorizationCodeWithPkceOidcHandler.handle(oidcOptions);
+      expect(oidcModule.OidcClient).toHaveBeenCalledWith(
+        expect.objectContaining({
+          prompt: "consent",
         })
       );
     });

--- a/packages/browser/src/login/oidc/oidcHandlers/AuthorizationCodeWithPkceOidcHandler.spec.ts
+++ b/packages/browser/src/login/oidc/oidcHandlers/AuthorizationCodeWithPkceOidcHandler.spec.ts
@@ -192,6 +192,25 @@ describe("AuthorizationCodeWithPkceOidcHandler", () => {
       );
     });
 
+    it("requests both openid and offline_access scopes", async () => {
+      const oidcModule = mockOidcModule();
+      const authorizationCodeWithPkceOidcHandler =
+        getAuthorizationCodeWithPkceOidcHandler();
+      const oidcOptions: IOidcOptions = {
+        ...standardOidcOptions,
+        issuerConfiguration: {
+          ...standardOidcOptions.issuerConfiguration,
+          grantTypesSupported: ["authorization_code"],
+        },
+      };
+      await authorizationCodeWithPkceOidcHandler.handle(oidcOptions);
+      expect(oidcModule.OidcClient).toHaveBeenCalledWith(
+        expect.objectContaining({
+          scope: "openid offline_access",
+        })
+      );
+    });
+
     it("handles login when a client secret is present", async () => {
       mockOidcModule();
       const authorizationCodeWithPkceOidcHandler =

--- a/packages/browser/src/login/oidc/oidcHandlers/AuthorizationCodeWithPkceOidcHandler.ts
+++ b/packages/browser/src/login/oidc/oidcHandlers/AuthorizationCodeWithPkceOidcHandler.ts
@@ -67,11 +67,8 @@ export default class AuthorizationCodeWithPkceOidcHandler
       redirect_uri: oidcLoginOptions.redirectUrl.toString(),
       post_logout_redirect_uri: oidcLoginOptions.redirectUrl.toString(),
       response_type: "code",
-      // TODO: The 'webid' scope is still a spec discussion topic
-      //  https://github.com/solid/specification/issues/203, i.e. the 'webid'
-      //  scope does not yet appear in the Solid specification (it's not even
-      //  mentioned in the WebID-OIDC spec).
-      scope: "openid webid",
+      // The offline_access scope requests that a refresh token be returned.
+      scope: "openid offline_access",
       filterProtocolClaims: true,
       // The userinfo endpoint on NSS fails, so disable this for now
       // Note that in Solid, information should be retrieved from the

--- a/packages/browser/src/login/oidc/oidcHandlers/AuthorizationCodeWithPkceOidcHandler.ts
+++ b/packages/browser/src/login/oidc/oidcHandlers/AuthorizationCodeWithPkceOidcHandler.ts
@@ -75,7 +75,7 @@ export default class AuthorizationCodeWithPkceOidcHandler
       // profile referenced by the WebId.
       loadUserInfo: false,
       code_verifier: true,
-      prompt: oidcLoginOptions.prompt,
+      prompt: oidcLoginOptions.prompt ?? "consent",
     };
     /* eslint-enable camelcase */
 

--- a/packages/oidc/src/dcr/clientRegistrar.spec.ts
+++ b/packages/oidc/src/dcr/clientRegistrar.spec.ts
@@ -137,6 +137,7 @@ describe("registerClient", () => {
         subject_type: "pairwise",
         token_endpoint_auth_method: "client_secret_basic",
         id_token_signed_response_alg: "RS256",
+        grant_types: ["authorization_code", "refresh_token"],
       }),
     });
   });

--- a/packages/oidc/src/dcr/clientRegistrar.ts
+++ b/packages/oidc/src/dcr/clientRegistrar.ts
@@ -119,6 +119,7 @@ export async function registerClient(
     subject_type: "pairwise",
     token_endpoint_auth_method: "client_secret_basic",
     id_token_signed_response_alg: signingAlg,
+    grant_types: ["authorization_code", "refresh_token"],
     /* eslint-enable camelcase */
   };
 


### PR DESCRIPTION
This as the browser set the `offine_access`  scope on its token request, which effectively asks a refresh token from the OIDC provider. In order to be able to use this token, dynamically registered clients must also specify that they may use the `refresh_token` grant at registration.

PS: leaving this as a draft until I've run a manual e2e test.

# Checklist

- [X] All acceptance criteria are met.
- [ ] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).