### PR TITLE
Consolidate the fetch factory

### DIFF
--- a/packages/core/src/authenticatedFetch/fetchFactory.spec.ts
+++ b/packages/core/src/authenticatedFetch/fetchFactory.spec.ts
@@ -32,16 +32,11 @@ import { jest, it, describe, expect } from "@jest/globals";
 import {
   KeyLike,
   jwtVerify,
-  parseJwk,
   generateKeyPair,
   fromKeyLike,
 } from "@inrupt/jose-legacy-modules";
 import { EventEmitter } from "events";
-import {
-  buildAuthenticatedFetch,
-  buildBearerFetch,
-  buildDpopFetch,
-} from "./fetchFactory";
+import { buildAuthenticatedFetch } from "./fetchFactory";
 import {
   mockDefaultTokenRefresher,
   mockDefaultTokenSet,
@@ -92,513 +87,6 @@ const mockKeyPair = async () => {
   return dpopKeyPair;
 };
 
-describe("buildBearerFetch", () => {
-  it("returns a fetch holding the provided token", async () => {
-    // eslint-disable-next-line no-shadow
-    const fetch = jest.requireMock("cross-fetch") as jest.Mock;
-    fetch.mockResolvedValueOnce(mockNotRedirectedResponse());
-    const myFetch = buildBearerFetch(fetch, "myToken", undefined);
-    await myFetch("someUrl");
-
-    expect(fetch.mock.calls[0][1].headers.Authorization).toEqual(
-      "Bearer myToken"
-    );
-  });
-
-  it("returns a fetch preserving the optional headers", async () => {
-    // eslint-disable-next-line no-shadow
-    const fetch = jest.requireMock("cross-fetch") as jest.Mock;
-    fetch.mockResolvedValueOnce(mockNotRedirectedResponse());
-    const myFetch = buildBearerFetch(fetch, "myToken", undefined);
-    await myFetch("someUrl", { headers: { someHeader: "SomeValue" } });
-
-    expect(fetch.mock.calls[0][1].headers.Authorization).toEqual(
-      "Bearer myToken"
-    );
-
-    expect(fetch.mock.calls[0][1].headers.someHeader).toEqual("SomeValue");
-  });
-
-  it("returns a fetch overriding any pre-existing authorization headers", async () => {
-    // eslint-disable-next-line no-shadow
-    const fetch = jest.requireMock("cross-fetch") as jest.Mock;
-    fetch.mockResolvedValueOnce(mockNotRedirectedResponse());
-    const myFetch = buildBearerFetch(fetch, "myToken", undefined);
-    await myFetch("someUrl", { headers: { Authorization: "some token" } });
-
-    expect(fetch.mock.calls[0][1].headers.Authorization).toEqual(
-      "Bearer myToken"
-    );
-  });
-
-  it("returns a fetch that refreshes the token on 401", async () => {
-    // eslint-disable-next-line no-shadow
-    const fetch = jest.requireMock("cross-fetch") as jest.Mock;
-    fetch.mockResolvedValueOnce({ status: 401 });
-    const myFetch = buildBearerFetch(fetch, "myToken", {
-      refreshToken: "some refresh token",
-      sessionId: "mySession",
-      tokenRefresher: mockDefaultTokenRefresher(),
-    });
-    await myFetch("someUrl");
-    // The mocked fetch will 401, which triggers the refresh flow.
-    // The test checks that the mocked refreshed token is used silently.
-    expect(fetch.mock.calls[1][1].headers.Authorization).toEqual(
-      "Bearer some refreshed access token"
-    );
-  });
-
-  it("does not rebind the token on refresh", async () => {
-    // eslint-disable-next-line no-shadow
-    const fetch = jest.requireMock("cross-fetch") as jest.Mock;
-    fetch.mockResolvedValueOnce({
-      status: 401,
-      url: "https://somedomain.sometld",
-    });
-    const dpopKey = await mockKeyPair();
-    const myFetch = await buildDpopFetch(fetch, "myToken", dpopKey, {
-      refreshToken: "some refresh token",
-      sessionId: "mySession",
-      tokenRefresher: mockDefaultTokenRefresher(),
-    });
-    await myFetch("https://somedomain.sometld");
-    // The mocked fetch will 401, which triggers the refresh flow.
-    // The test checks that the mocked refreshed token is bound to the same DPoP
-    // key as the previous access token (which is also the key to which the DPoP
-    // token may be bound).
-    const dpopHeader = fetch.mock.calls[1][1].headers.DPoP;
-
-    await expect(
-      jwtVerify(dpopHeader, await parseJwk(dpopKey.publicKey))
-    ).resolves.not.toThrow();
-  });
-
-  it("returns a fetch preserving the optional headers even after refresh", async () => {
-    // eslint-disable-next-line no-shadow
-    const fetch = jest.requireMock("cross-fetch") as jest.Mock;
-    fetch.mockResolvedValueOnce({ status: 401 });
-    const myFetch = buildBearerFetch(fetch, "myToken", {
-      refreshToken: "some refresh token",
-      sessionId: "mySession",
-      tokenRefresher: mockDefaultTokenRefresher(),
-    });
-    await myFetch("someUrl", { headers: { someHeader: "SomeValue" } });
-
-    expect(fetch.mock.calls[0][1].headers.Authorization).toEqual(
-      "Bearer myToken"
-    );
-
-    expect(fetch.mock.calls[0][1].headers.someHeader).toEqual("SomeValue");
-  });
-
-  it("rotates the refresh token if a new one is issued", async () => {
-    // eslint-disable-next-line no-shadow
-    const fetch = jest.requireMock("cross-fetch") as jest.Mock;
-    fetch.mockResolvedValue({ status: 401 });
-    const tokenSet = mockDefaultTokenSet();
-    tokenSet.refreshToken = "some rotated refresh token";
-    const mockedFreshener = mockTokenRefresher(tokenSet);
-    const refreshCall = jest.spyOn(mockedFreshener, "refresh");
-
-    const myFetch = buildBearerFetch(fetch, "myToken", {
-      refreshToken: "some refresh token",
-      sessionId: "mySession",
-      tokenRefresher: mockedFreshener,
-    });
-    await myFetch("someUrl");
-    // We make two requests in a row to see that the second uses a different refresh token
-    await myFetch("someUrl");
-    expect(refreshCall.mock.calls[1][1]).toEqual("some rotated refresh token");
-  });
-
-  it("returns a fetch that calls the refresh token handler if appropriate", async () => {
-    // eslint-disable-next-line no-shadow
-    const fetch = jest.requireMock("cross-fetch") as jest.Mock;
-    fetch.mockResolvedValue({ status: 401 });
-    const tokenSet = mockDefaultTokenSet();
-    const mockEmitter = new EventEmitter();
-    const mockEmit = jest.spyOn(mockEmitter, "emit");
-    tokenSet.refreshToken = "some rotated refresh token";
-    const mockedFreshener = mockTokenRefresher(tokenSet);
-    const myFetch = buildBearerFetch(fetch, "myToken", {
-      refreshToken: "some refresh token",
-      sessionId: "mySession",
-      tokenRefresher: mockedFreshener,
-      eventEmitter: mockEmitter,
-    });
-    await myFetch("someUrl");
-    // The mocked fetch will 401, which triggers the refresh flow.
-    // The test checks that the mocked refreshed token is used silently.
-    expect(mockEmit).toHaveBeenCalledWith(
-      EVENTS.NEW_REFRESH_TOKEN,
-      "some rotated refresh token"
-    );
-  });
-
-  it("does not try to refresh on a non-auth error", async () => {
-    // eslint-disable-next-line no-shadow
-    const fetch = jest.requireMock("cross-fetch") as jest.Mock;
-    fetch.mockResolvedValue({ status: 418 });
-    const mockedRefresher = mockDefaultTokenRefresher();
-    const refreshCall = jest.spyOn(mockedRefresher, "refresh");
-
-    const myFetch = buildBearerFetch(fetch, "myToken", {
-      refreshToken: "some refresh token",
-      sessionId: "mySession",
-      tokenRefresher: mockedRefresher,
-    });
-    await myFetch("someUrl");
-    expect(refreshCall).not.toHaveBeenCalled();
-  });
-
-  it("returns the initial response when the refresh flow fails", async () => {
-    // eslint-disable-next-line no-shadow
-    const fetch = jest.requireMock("cross-fetch") as jest.Mock;
-    fetch.mockResolvedValueOnce({ status: 401 });
-    const myFetch = buildBearerFetch(fetch, "myToken", {
-      refreshToken: "some refresh token",
-      sessionId: "mySession",
-      tokenRefresher: {
-        refresh: () => {
-          throw new Error("Some error");
-        },
-      },
-    });
-    const response = await myFetch("someUrl");
-    // The mocked fetch will 401, which triggers the refresh flow.
-    // The test checks that the mocked refreshed token is used silently.
-    expect(response.status).toEqual(401);
-  });
-});
-
-describe("buildDpopFetch", () => {
-  it("returns a fetch holding the provided token and key", async () => {
-    const mockedFetch = jest.requireMock("cross-fetch") as jest.Mock;
-    mockedFetch.mockResolvedValueOnce(mockNotRedirectedResponse());
-
-    const myFetch = await buildDpopFetch(
-      mockedFetch,
-      "myToken",
-      await mockKeyPair()
-    );
-    await myFetch("http://some.url");
-
-    expect(mockedFetch.mock.calls[0][1].headers.Authorization).toEqual(
-      "DPoP myToken"
-    );
-
-    const dpopHeader = mockedFetch.mock.calls[0][1].headers.DPoP as string;
-    const { payload } = await jwtVerify(
-      dpopHeader,
-      (
-        await mockKeyPair()
-      ).privateKey
-    );
-    expect(payload.htu).toEqual("http://some.url/");
-    expect(payload.htm).toEqual("GET");
-  });
-
-  it("builds the appropriate DPoP header for a given HTTP verb.", async () => {
-    const mockedFetch = jest.requireMock("cross-fetch") as jest.Mock;
-    mockedFetch.mockResolvedValueOnce(mockNotRedirectedResponse());
-
-    const myFetch = await buildDpopFetch(
-      mockedFetch,
-      "myToken",
-      await mockKeyPair()
-    );
-    await myFetch("http://some.url", {
-      method: "POST",
-    });
-
-    const dpopHeader = mockedFetch.mock.calls[0][1].headers.DPoP as string;
-    const { payload } = await jwtVerify(
-      dpopHeader,
-      (
-        await mockKeyPair()
-      ).privateKey
-    );
-    expect(payload.htu).toEqual("http://some.url/");
-    expect(payload.htm).toEqual("POST");
-  });
-
-  it("returns a fetch preserving the provided optional headers", async () => {
-    const mockedFetch = jest.requireMock("cross-fetch") as jest.Mock;
-    mockedFetch.mockResolvedValueOnce(mockNotRedirectedResponse());
-
-    const myFetch = await buildDpopFetch(
-      mockedFetch,
-      "myToken",
-      await mockKeyPair()
-    );
-    await myFetch("http://some.url", { headers: { someHeader: "SomeValue" } });
-
-    expect(mockedFetch.mock.calls[0][1].headers.someHeader).toEqual(
-      "SomeValue"
-    );
-  });
-
-  it("returns a fetch overriding any pre-existing Authorization or DPoP headers", async () => {
-    const mockedFetch = jest.requireMock("cross-fetch") as jest.Mock;
-    mockedFetch.mockResolvedValueOnce(mockNotRedirectedResponse());
-
-    const myFetch = await buildDpopFetch(
-      mockedFetch,
-      "myToken",
-      await mockKeyPair()
-    );
-    await myFetch("http://some.url", {
-      headers: {
-        Authorization: "some token",
-        DPoP: "some header",
-      },
-    });
-
-    expect(mockedFetch.mock.calls[0][1].headers.Authorization).toEqual(
-      "DPoP myToken"
-    );
-  });
-
-  it("returns a fetch that rebuilds the DPoP token if redirected", async () => {
-    const mockedFetch = jest.requireMock("cross-fetch") as jest.Mock;
-
-    // Redirects once
-    mockedFetch
-      .mockResolvedValueOnce({
-        url: "https://my.pod/container/",
-        status: 403,
-        ok: false,
-      } as Response)
-      .mockResolvedValueOnce({
-        url: "https://my.pod/container/",
-        ok: true,
-        status: 200,
-      } as Response);
-
-    const myFetch = await buildDpopFetch(
-      mockedFetch,
-      "myToken",
-      await mockKeyPair()
-    );
-    await myFetch("https://my.pod/container");
-
-    expect(mockedFetch.mock.calls[1][0]).toEqual("https://my.pod/container/");
-    const dpopHeader = mockedFetch.mock.calls[1][1].headers.DPoP as string;
-    const { payload } = await jwtVerify(
-      dpopHeader,
-      (
-        await mockKeyPair()
-      ).privateKey
-    );
-    expect(payload.htu).toEqual("https://my.pod/container/");
-  });
-
-  it("does not retry a redirected fetch if the error is not auth-related", async () => {
-    const mockedFetch = jest.requireMock("cross-fetch") as jest.Mock;
-
-    // Mimics a redirect that lead to a non-auth error.
-    mockedFetch.mockResolvedValueOnce({
-      url: "https://my.pod/container/",
-      status: 400,
-      ok: false,
-    } as Response);
-
-    const myFetch = await buildDpopFetch(
-      mockedFetch,
-      "myToken",
-      await mockKeyPair()
-    );
-    const response = await myFetch("https://my.pod/container");
-
-    expect(mockedFetch.mock.calls).toHaveLength(1);
-    expect(response.status).toEqual(400);
-  });
-
-  it("does not retry a **not** redirected fetch if there was an auth-related issue", async () => {
-    const mockedFetch = jest.requireMock("cross-fetch") as jest.Mock;
-    // Mimics a redirect that lead to a non-auth error.
-    mockedFetch.mockResolvedValueOnce({
-      url: "https://my.pod/resource",
-      status: 403,
-      ok: false,
-    } as Response);
-
-    const myFetch = await buildDpopFetch(
-      mockedFetch,
-      "myToken",
-      await mockKeyPair()
-    );
-    const response = await myFetch("https://my.pod/resource");
-
-    expect(mockedFetch.mock.calls).toHaveLength(1);
-    expect(response.status).toEqual(403);
-  });
-
-  it("returns a fetch that refreshes the access token on 401", async () => {
-    // eslint-disable-next-line no-shadow
-    const fetch = jest.requireMock("cross-fetch") as jest.Mock;
-    fetch.mockResolvedValueOnce({
-      status: 401,
-      url: "https://my.pod/resource",
-    });
-    const myFetch = await buildDpopFetch(
-      fetch,
-      "myToken",
-      await mockKeyPair(),
-      {
-        refreshToken: "some refresh token",
-        sessionId: "mySession",
-        tokenRefresher: mockDefaultTokenRefresher(),
-      }
-    );
-    await myFetch("https://my.pod/resource");
-    // The mocked fetch will 401, which triggers the refresh flow.
-    // The test checks that the mocked refreshed token is used silently.
-    expect(fetch.mock.calls[1][1].headers.Authorization).toEqual(
-      "DPoP some refreshed access token"
-    );
-  });
-
-  it("returns a fetch preserving the optional headers even after refresh", async () => {
-    // eslint-disable-next-line no-shadow
-    const fetch = jest.requireMock("cross-fetch") as jest.Mock;
-    fetch.mockResolvedValueOnce({
-      status: 401,
-      url: "https://my.pod/resource",
-    });
-    const myFetch = await buildDpopFetch(
-      fetch,
-      "myToken",
-      await mockKeyPair(),
-      {
-        refreshToken: "some refresh token",
-        sessionId: "mySession",
-        tokenRefresher: mockDefaultTokenRefresher(),
-      }
-    );
-    await myFetch("https://my.pod/resource", {
-      headers: { someHeader: "SomeValue" },
-    });
-
-    expect(fetch.mock.calls[1][1].headers.Authorization).toEqual(
-      "DPoP some refreshed access token"
-    );
-
-    expect(fetch.mock.calls[1][1].headers.someHeader).toEqual("SomeValue");
-  });
-
-  it("rotates the refresh tokens if a new one is issued", async () => {
-    // eslint-disable-next-line no-shadow
-    const fetch = jest.requireMock("cross-fetch") as jest.Mock;
-    fetch.mockResolvedValue({
-      status: 401,
-      url: "https://my.pod/resource",
-    });
-    const tokenSet = mockDefaultTokenSet();
-    tokenSet.refreshToken = "some rotated refresh token";
-    const mockedFreshener = mockTokenRefresher(tokenSet);
-    const refreshCall = jest.spyOn(mockedFreshener, "refresh");
-
-    const myFetch = await buildDpopFetch(
-      fetch,
-      "myToken",
-      await mockKeyPair(),
-      {
-        refreshToken: "some refresh token",
-        sessionId: "mySession",
-        tokenRefresher: mockedFreshener,
-      }
-    );
-
-    await myFetch("https://my.pod/resource");
-    // We make two requests in a row to see that the second uses a different refresh token
-    await myFetch("https://my.pod/resource");
-    expect(refreshCall.mock.calls[1][1]).toEqual("some rotated refresh token");
-  });
-
-  it("calls the refresh token handler if one is provided", async () => {
-    // eslint-disable-next-line no-shadow
-    const fetch = jest.requireMock("cross-fetch") as jest.Mock;
-    fetch.mockResolvedValue({
-      status: 401,
-      url: "https://my.pod/resource",
-    });
-    const tokenSet = mockDefaultTokenSet();
-    tokenSet.refreshToken = "some rotated refresh token";
-    const mockedFreshener = mockTokenRefresher(tokenSet);
-    const mockEmitter = new EventEmitter();
-    const mockEmit = jest.spyOn(mockEmitter, "emit");
-    const myFetch = await buildDpopFetch(
-      fetch,
-      "myToken",
-      await mockKeyPair(),
-      {
-        refreshToken: "some refresh token",
-        sessionId: "mySession",
-        tokenRefresher: mockedFreshener,
-        eventEmitter: mockEmitter,
-      }
-    );
-
-    await myFetch("https://my.pod/resource");
-    expect(mockEmit).toHaveBeenCalledWith(
-      EVENTS.NEW_REFRESH_TOKEN,
-      "some rotated refresh token"
-    );
-  });
-
-  it("does not try to refresh on a non-auth error", async () => {
-    // eslint-disable-next-line no-shadow
-    const fetch = jest.requireMock("cross-fetch") as jest.Mock;
-    fetch.mockResolvedValue({
-      status: 418,
-      url: "https://my.pod/resource",
-    });
-    const mockedFreshener = mockDefaultTokenRefresher();
-    const refreshCall = jest.spyOn(mockedFreshener, "refresh");
-
-    const myFetch = await buildDpopFetch(
-      fetch,
-      "myToken",
-      await mockKeyPair(),
-      {
-        refreshToken: "some refresh token",
-        sessionId: "mySession",
-        tokenRefresher: mockedFreshener,
-      }
-    );
-    await myFetch("https://my.pod/resource");
-    expect(refreshCall).not.toHaveBeenCalled();
-  });
-
-  it("returns the initial response when the refresh flow fails", async () => {
-    // eslint-disable-next-line no-shadow
-    const fetch = jest.requireMock("cross-fetch") as jest.Mock;
-    fetch.mockResolvedValue({
-      status: 401,
-      url: "https://my.pod/resource",
-    });
-    const myFetch = await buildDpopFetch(
-      fetch,
-      "myToken",
-      await mockKeyPair(),
-      {
-        refreshToken: "some refresh token",
-        sessionId: "mySession",
-        tokenRefresher: {
-          refresh: () => {
-            throw new Error("Some error");
-          },
-        },
-      }
-    );
-    const response = await myFetch("https://my.pod/resource");
-    // The mocked fetch will 401, which triggers the refresh flow.
-    // The test checks that the refresh failure is silent.
-    expect(response.status).toEqual(401);
-  });
-});
-
 describe("buildAuthenticatedFetch", () => {
   it("builds a DPoP fetch if a DPoP key is provided", async () => {
     // eslint-disable-next-line no-shadow
@@ -635,6 +123,28 @@ describe("buildAuthenticatedFetch", () => {
     });
   });
 
+  it("builds the appropriate DPoP header for a given HTTP verb.", async () => {
+    const mockedFetch = jest.requireMock("cross-fetch") as jest.Mock;
+    mockedFetch.mockResolvedValueOnce(mockNotRedirectedResponse());
+
+    const myFetch = await buildAuthenticatedFetch(mockedFetch, "myToken", {
+      dpopKey: await mockKeyPair(),
+    });
+    await myFetch("http://some.url", {
+      method: "POST",
+    });
+
+    const dpopHeader = mockedFetch.mock.calls[0][1].headers.DPoP as string;
+    const { payload } = await jwtVerify(
+      dpopHeader,
+      (
+        await mockKeyPair()
+      ).privateKey
+    );
+    expect(payload.htu).toEqual("http://some.url/");
+    expect(payload.htm).toEqual("POST");
+  });
+
   it("builds a Bearer fetch if no DPoP key is provided", async () => {
     // eslint-disable-next-line no-shadow
     const fetch = jest.requireMock("cross-fetch") as jest.Mock;
@@ -650,26 +160,266 @@ describe("buildAuthenticatedFetch", () => {
     expect(authorizationHeader.startsWith("Bearer")).toBe(true);
   });
 
-  it("passes the appropriate refresh options to the built fetch if applicable", async () => {
+  it("returns a fetch that rebuilds the DPoP token if redirected", async () => {
+    const mockedFetch = jest.requireMock("cross-fetch") as jest.Mock;
+
+    // Redirects once
+    mockedFetch
+      .mockResolvedValueOnce({
+        url: "https://my.pod/container/",
+        status: 403,
+        ok: false,
+      } as Response)
+      .mockResolvedValueOnce({
+        url: "https://my.pod/container/",
+        ok: true,
+        status: 200,
+      } as Response);
+
+    const myFetch = await buildAuthenticatedFetch(mockedFetch, "myToken", {
+      dpopKey: await mockKeyPair(),
+    });
+    await myFetch("https://my.pod/container");
+
+    expect(mockedFetch.mock.calls[1][0]).toEqual("https://my.pod/container/");
+    const dpopHeader = mockedFetch.mock.calls[1][1].headers.DPoP as string;
+    const { payload } = await jwtVerify(
+      dpopHeader,
+      (
+        await mockKeyPair()
+      ).privateKey
+    );
+    expect(payload.htu).toEqual("https://my.pod/container/");
+  });
+
+  it("returns a fetch that does not retry fetching with a Bearer token if redirected", async () => {
+    const mockedFetch = jest.requireMock("cross-fetch") as jest.Mock;
+
+    // Redirects once
+    mockedFetch.mockResolvedValueOnce({
+      url: "https://my.pod/container/",
+      status: 403,
+      ok: false,
+    } as Response);
+
+    const myFetch = await buildAuthenticatedFetch(mockedFetch, "myToken");
+    const response = await myFetch("https://my.pod/container");
+
+    expect(response.status).toBe(403);
+    expect(mockedFetch.mock.calls).toHaveLength(1);
+  });
+
+  it("returns a fetch that refreshes the token on 401", async () => {
     // eslint-disable-next-line no-shadow
     const fetch = jest.requireMock("cross-fetch") as jest.Mock;
     fetch.mockResolvedValue({
       status: 401,
       url: "https://my.pod/resource",
     });
+    const mockRefresher = mockDefaultTokenRefresher();
+    const myFetch = await buildAuthenticatedFetch(fetch, "myToken", {
+      refreshOptions: {
+        refreshToken: "some refresh token",
+        sessionId: "mySession",
+        tokenRefresher: mockRefresher,
+      },
+    });
+    await myFetch("https://my.pod/resource");
+    // The mocked fetch will 401, which triggers the refresh flow.
+    // The test checks that the mocked refreshed token is used silently.
+    expect(fetch.mock.calls[1][1].headers.Authorization).toEqual(
+      "Bearer some refreshed access token"
+    );
+  });
+
+  it("returns a fetch preserving the optional headers", async () => {
+    // eslint-disable-next-line no-shadow
+    const fetch = jest.requireMock("cross-fetch") as jest.Mock;
+    fetch.mockResolvedValueOnce(mockNotRedirectedResponse());
+    const myFetch = await buildAuthenticatedFetch(fetch, "myToken", undefined);
+    await myFetch("someUrl", { headers: { someHeader: "SomeValue" } });
+
+    expect(fetch.mock.calls[0][1].headers.Authorization).toEqual(
+      "Bearer myToken"
+    );
+
+    expect(fetch.mock.calls[0][1].headers.someHeader).toEqual("SomeValue");
+  });
+
+  it("returns a fetch overriding any pre-existing Authorization or DPoP headers", async () => {
+    const mockedFetch = jest.requireMock("cross-fetch") as jest.Mock;
+    mockedFetch.mockResolvedValueOnce(mockNotRedirectedResponse());
+
+    const myFetch = await buildAuthenticatedFetch(mockedFetch, "myToken", {
+      dpopKey: await mockKeyPair(),
+    });
+    await myFetch("http://some.url", {
+      headers: {
+        Authorization: "some token",
+        DPoP: "some header",
+      },
+    });
+
+    expect(mockedFetch.mock.calls[0][1].headers.Authorization).toEqual(
+      "DPoP myToken"
+    );
+  });
+
+  it("does not rebind the DPoP token on refresh", async () => {
+    // eslint-disable-next-line no-shadow
+    const mockedFetch = jest.requireMock("cross-fetch") as jest.Mock;
+    mockedFetch.mockResolvedValueOnce({
+      status: 401,
+      url: "https://somedomain.sometld",
+    });
+    const keylikePair = await mockJwk();
+    const myFetch = await buildAuthenticatedFetch(mockedFetch, "myToken", {
+      dpopKey: {
+        privateKey: keylikePair.privateKey,
+        publicKey: await fromKeyLike(keylikePair.publicKey),
+      },
+      refreshOptions: {
+        refreshToken: "some refresh token",
+        sessionId: "mySession",
+        tokenRefresher: mockDefaultTokenRefresher(),
+      },
+    });
+    await myFetch("https://somedomain.sometld");
+    // The mocked fetch will 401, which triggers the refresh flow.
+    // The test checks that the mocked refreshed token is bound to the same DPoP
+    // key as the previous access token (which is also the key to which the DPoP
+    // token may be bound).
+    const dpopHeader = mockedFetch.mock.calls[1][1].headers.DPoP;
+
+    await expect(
+      jwtVerify(dpopHeader, keylikePair.publicKey)
+    ).resolves.not.toThrow();
+  });
+
+  it("returns a fetch preserving the optional headers even after refresh", async () => {
+    // eslint-disable-next-line no-shadow
+    const fetch = jest.requireMock("cross-fetch") as jest.Mock;
+    fetch.mockResolvedValueOnce({ status: 401 });
+
+    const myFetch = await buildAuthenticatedFetch(fetch, "myToken", {
+      refreshOptions: {
+        refreshToken: "some refresh token",
+        sessionId: "mySession",
+        tokenRefresher: mockDefaultTokenRefresher(),
+      },
+    });
+    await myFetch("someUrl", { headers: { someHeader: "SomeValue" } });
+
+    expect(fetch.mock.calls[0][1].headers.Authorization).toEqual(
+      "Bearer myToken"
+    );
+
+    expect(fetch.mock.calls[0][1].headers.someHeader).toEqual("SomeValue");
+  });
+
+  it("rotates the refresh token if a new one is issued", async () => {
+    // eslint-disable-next-line no-shadow
+    const fetch = jest.requireMock("cross-fetch") as jest.Mock;
+    fetch.mockResolvedValue({ status: 401 });
+    const tokenSet = mockDefaultTokenSet();
+    tokenSet.refreshToken = "some rotated refresh token";
+    const mockedFreshener = mockTokenRefresher(tokenSet);
+    const refreshCall = jest.spyOn(mockedFreshener, "refresh");
+
+    const myFetch = await buildAuthenticatedFetch(fetch, "myToken", {
+      refreshOptions: {
+        refreshToken: "some refresh token",
+        sessionId: "mySession",
+        tokenRefresher: mockedFreshener,
+      },
+    });
+    await myFetch("someUrl");
+    // We make two requests in a row to see that the second uses a different refresh token
+    await myFetch("someUrl");
+    expect(refreshCall.mock.calls[1][1]).toEqual("some rotated refresh token");
+  });
+
+  it("returns a fetch that calls the refresh token handler if appropriate", async () => {
+    // eslint-disable-next-line no-shadow
+    const fetch = jest.requireMock("cross-fetch") as jest.Mock;
+    fetch.mockResolvedValue({ status: 401 });
+    const tokenSet = mockDefaultTokenSet();
+    tokenSet.refreshToken = "some rotated refresh token";
+    const mockedFreshener = mockTokenRefresher(tokenSet);
+    const mockEmitter = new EventEmitter();
+    const mockEmit = jest.spyOn(mockEmitter, "emit");
+    const myFetch = await buildAuthenticatedFetch(fetch, "myToken", {
+      refreshOptions: {
+        refreshToken: "some refresh token",
+        sessionId: "mySession",
+        tokenRefresher: mockedFreshener,
+        eventEmitter: mockEmitter,
+      },
+    });
+    await myFetch("https://my.pod/resource");
+    // The mocked fetch will 401, which triggers the refresh flow.
+    // The test checks that the mocked refreshed token is used silently.
+    expect(mockEmit).toHaveBeenCalledWith(
+      EVENTS.NEW_REFRESH_TOKEN,
+      "some rotated refresh token"
+    );
+  });
+
+  it("does not try to refresh on a non-auth error", async () => {
+    // eslint-disable-next-line no-shadow
+    const fetch = jest.requireMock("cross-fetch") as jest.Mock;
+    fetch.mockResolvedValue({ status: 418 });
+    const mockedRefresher = mockDefaultTokenRefresher();
+    const refreshCall = jest.spyOn(mockedRefresher, "refresh");
+
+    const myFetch = await buildAuthenticatedFetch(fetch, "myToken", {
+      refreshOptions: {
+        refreshToken: "some refresh token",
+        sessionId: "mySession",
+        tokenRefresher: mockedRefresher,
+      },
+    });
+    await myFetch("someUrl");
+    expect(refreshCall).not.toHaveBeenCalled();
+  });
+
+  it("does not retry a **redirected** fetch if the error is not auth-related", async () => {
+    const mockedFetch = jest.requireMock("cross-fetch") as jest.Mock;
+
+    // Mimics a redirect that lead to a non-auth error.
+    mockedFetch.mockResolvedValueOnce({
+      url: "https://my.pod/container/",
+      status: 400,
+      ok: false,
+    } as Response);
+
+    const myFetch = await buildAuthenticatedFetch(mockedFetch, "myToken", {
+      dpopKey: await mockKeyPair(),
+    });
+    const response = await myFetch("https://my.pod/container");
+
+    expect(mockedFetch.mock.calls).toHaveLength(1);
+    expect(response.status).toEqual(400);
+  });
+
+  it("returns the initial response when the refresh flow fails", async () => {
+    // eslint-disable-next-line no-shadow
+    const fetch = jest.requireMock("cross-fetch") as jest.Mock;
+    fetch.mockResolvedValueOnce({ status: 401 });
     const myFetch = await buildAuthenticatedFetch(fetch, "myToken", {
       refreshOptions: {
         refreshToken: "some refresh token",
         sessionId: "mySession",
         tokenRefresher: {
-          refresh: jest.fn(),
+          refresh: () => {
+            throw new Error("Some error");
+          },
         },
       },
     });
-    await myFetch("https://my.pod/resource");
-    expect(fetch.mock.calls[0][0]).toEqual("https://my.pod/resource");
-    const authorizationHeader = fetch.mock.calls[0][1].headers
-      .Authorization as string;
-    expect(authorizationHeader.startsWith("Bearer")).toBe(true);
+    const response = await myFetch("someUrl");
+    // The mocked fetch will 401, which triggers the refresh flow.
+    // The test checks that the mocked refreshed token is used silently.
+    expect(response.status).toEqual(401);
   });
 });

--- a/packages/core/src/authenticatedFetch/fetchFactory.ts
+++ b/packages/core/src/authenticatedFetch/fetchFactory.ts
@@ -126,7 +126,7 @@ async function refreshAccessToken(
  * @param unauthFetch a regular fetch function, compliant with the WHATWG spec.
  * @param authToken an access token, either a Bearer token or a DPoP one.
  * @param options The option object may contain two objects: the DPoP key token
- * is bound to if applicable, and information about refresh.
+ * is bound to if applicable, and options to customise token renewal behaviour.
  *
  * @returns A fetch function that adds an appropriate Authorization header with
  * the provided token, and adds a DPoP header if applicable.

--- a/packages/core/src/authenticatedFetch/fetchFactory.ts
+++ b/packages/core/src/authenticatedFetch/fetchFactory.ts
@@ -161,10 +161,14 @@ export async function buildAuthenticatedFetch(
     const hasBeenRedirected = response.url !== url;
     if (hasBeenRedirected && options?.dpopKey !== undefined) {
       // If the request failed for auth reasons, and has been redirected, we should
-      // replay it with a new DPoP token. It doesn't apply to Bearer tokens.
+      // replay it generating a DPoP header for the rediration target IRI. This
+      // doesn't apply to Bearer tokens, as the Bearer tokens aren't specific
+      // to a given resource and method, while the DPoP header (associated to a
+      // DPoP token) is.
       response = await makeAuthenticatedRequest(
         unauthFetch,
         currentAccessToken,
+        // Replace the original target IRI (`url`) by the redirection target
         response.url,
         requestInit,
         options.dpopKey

--- a/packages/core/src/authenticatedFetch/fetchFactory.ts
+++ b/packages/core/src/authenticatedFetch/fetchFactory.ts
@@ -123,11 +123,13 @@ async function refreshAccessToken(
 }
 
 /**
- * @param authToken a DPoP token.
- * @param dpopKey The private key the token is bound to.
- * @param
- * @returns A fetch function that adds an Authorization header with the provided
- * DPoP token, and adds a dpop header.
+ * @param unauthFetch a regular fetch function, compliant with the WHATWG spec.
+ * @param authToken an access token, either a Bearer token or a DPoP one.
+ * @param options The option object may contain two objects: the DPoP key token
+ * is bound to if applicable, and information about refresh.
+ *
+ * @returns A fetch function that adds an appropriate Authorization header with
+ * the provided token, and adds a DPoP header if applicable.
  */
 export async function buildAuthenticatedFetch(
   unauthFetch: typeof fetch,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -90,8 +90,6 @@ export {
 
 export {
   buildAuthenticatedFetch,
-  buildBearerFetch,
-  buildDpopFetch,
   DpopHeaderPayload,
   RefreshOptions,
 } from "./authenticatedFetch/fetchFactory";

--- a/packages/node/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
+++ b/packages/node/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
@@ -370,7 +370,10 @@ describe("AuthCodeRedirectHandler", () => {
 
       // Check that the returned fetch function is authenticated
       const mockedFetch = jest.requireMock("cross-fetch") as jest.Mock;
-      mockedFetch.mockResolvedValueOnce({ status: 401 } as NodeResponse);
+      mockedFetch.mockResolvedValueOnce({
+        status: 401,
+        url: "https://some.url",
+      } as NodeResponse);
       await result.fetch("https://some.url");
       expect(mockedFetch.mock.calls[1][1].headers.Authorization).toContain(
         "Bearer some refreshed access token"


### PR DESCRIPTION
This reduces a lot code duplication by merging `buildDpopFetch` and
`buildBearerFetch` in a single `buildAuthenticatedFetch` function, which previously existed but delegated to the other two. It will make the implementation of proactive refresh tokens easier, because only one place will need to be updated, as there was a fair amount of duplication between the previous two functions.

The present commit does change any features, it's only a refactoring to
facilitate upcoming feature implementation.

- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).