### PR TITLE
Error handling on silent authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ access token. This enables keeping a session alive for longer than the lifetime
 of a single access token.
 - The `Session` class now exposes an `onError` method, which is a hook where
 error-handling callbacks may be registered.
+- The `Session` class now exposes an `onSessionExpiration` method, which is a hook
+where a callback may be registered to handle session expiration in the case when
+silent authentication fails.
 
 ### Bugfixes
 

--- a/packages/browser/src/Session.spec.ts
+++ b/packages/browser/src/Session.spec.ts
@@ -291,7 +291,7 @@ describe("Session", () => {
       );
     });
 
-    it("logs the session out when its tokens expire", async () => {
+    it("listens on the token extension signal to keep the expiration date accurate", async () => {
       jest.useFakeTimers();
       const MOCK_TIMESTAMP = 10000;
       jest.spyOn(Date, "now").mockReturnValueOnce(MOCK_TIMESTAMP);
@@ -307,20 +307,11 @@ describe("Session", () => {
       });
       const mySession = new Session({ clientAuthentication });
       await mySession.handleIncomingRedirect("https://some.url");
-      expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), 1337);
-      expect(mySession.info.isLoggedIn).toBe(true);
-
-      // Usually, we'd be able to use `jest.runAllTimers()` here. However,
-      // logout happens asynchronously. While this is inconsequential in
-      // running apps (the timeout complets asynchronously anyway), here, we can
-      // take advantage that we return the Promise from the callback in
-      // `setTimeout`, so that we can `await` it in this test before checking
-      // whether logout was successful:
-      const expireTimeout = (
-        setTimeout as unknown as jest.Mock<typeof setTimeout>
-      ).mock.calls[0][0];
-      await expireTimeout();
-      expect(mySession.info.isLoggedIn).toBe(false);
+      expect(mySession.info.expirationDate).toBe(MOCK_TIMESTAMP + 1337);
+      mySession.emit(EVENTS.SESSION_EXTENDED, 1337 * 2);
+      expect(mySession.info.expirationDate).toBe(
+        MOCK_TIMESTAMP + 1337 * 2 * 1000
+      );
     });
 
     it("leaves the session's info unchanged if no session is obtained after redirect", async () => {

--- a/packages/browser/src/Session.spec.ts
+++ b/packages/browser/src/Session.spec.ts
@@ -1238,4 +1238,16 @@ describe("Session", () => {
       expect(mySession.info.expirationDate).toBe(961106400);
     });
   });
+
+  describe("onSessionExpiration", () => {
+    it("calls the provided callback when receiving the appropriate event", async () => {
+      const myCallback = jest.fn();
+      const mySession = new Session({
+        clientAuthentication: mockClientAuthentication(),
+      });
+      mySession.onSessionExpiration(myCallback);
+      mySession.emit(EVENTS.SESSION_EXPIRED);
+      expect(myCallback).toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/browser/src/Session.ts
+++ b/packages/browser/src/Session.ts
@@ -493,10 +493,8 @@ export class Session extends EventEmitter {
     this.info.webId = sessionInfo.webId;
     this.info.sessionId = sessionInfo.sessionId;
     this.info.expirationDate = sessionInfo.expirationDate;
-    if (typeof sessionInfo.expirationDate === "number") {
-      setTimeout(async () => {
-        await this.logout();
-      }, sessionInfo.expirationDate - Date.now());
-    }
+    this.on(EVENTS.SESSION_EXTENDED, (expiresIn: number) => {
+      this.info.expirationDate = Date.now() + expiresIn * 1000;
+    });
   }
 }

--- a/packages/browser/src/Session.ts
+++ b/packages/browser/src/Session.ts
@@ -482,6 +482,10 @@ export class Session extends EventEmitter {
     this.on("sessionRestore", callback);
   }
 
+  onSessionExpires(callback: () => unknown): void {
+    this.on(EVENTS.SESSION_EXPIRED, callback);
+  }
+
   private setSessionInfo(
     sessionInfo: ISessionInfo & { isLoggedIn: true }
   ): void {

--- a/packages/browser/src/Session.ts
+++ b/packages/browser/src/Session.ts
@@ -482,7 +482,7 @@ export class Session extends EventEmitter {
     this.on("sessionRestore", callback);
   }
 
-  onSessionExpires(callback: () => unknown): void {
+  onSessionExpiration(callback: () => unknown): void {
     this.on(EVENTS.SESSION_EXPIRED, callback);
   }
 

--- a/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
+++ b/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
@@ -840,8 +840,8 @@ describe("AuthCodeRedirectHandler", () => {
           refreshToken: "some DPoP-bound refresh token",
           sessionId: "mySession",
           tokenRefresher,
-          expiresIn: 1337,
         },
+        expiresIn: 1337,
       })
     );
   });

--- a/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
+++ b/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
@@ -202,14 +202,14 @@ export class AuthCodeRedirectHandler implements IRedirectHandler {
         sessionId: storedSessionId,
         refreshToken: tokens.refreshToken,
         tokenRefresher: this.tokerRefresher,
-        eventEmitter,
-        expiresIn: tokens.expiresIn,
       };
     }
 
     const authFetch = await buildAuthenticatedFetch(fetch, tokens.accessToken, {
       dpopKey: tokens.dpopKey,
       refreshOptions,
+      eventEmitter,
+      expiresIn: tokens.expiresIn,
     });
 
     await this.storageUtility.setForUser(

--- a/packages/browser/src/login/oidc/redirectHandler/ErrorOidcHandler.ts
+++ b/packages/browser/src/login/oidc/redirectHandler/ErrorOidcHandler.ts
@@ -29,7 +29,7 @@ import {
   IRedirectHandler,
   ISessionInfo,
 } from "@inrupt/solid-client-authn-core";
-import { EventEmitter } from "events";
+import type { EventEmitter } from "events";
 
 import { getUnauthenticatedSession } from "../../../sessionInfo/SessionInfoManager";
 

--- a/packages/browser/src/login/oidc/redirectHandler/ErrorOidcHandler.ts
+++ b/packages/browser/src/login/oidc/redirectHandler/ErrorOidcHandler.ts
@@ -29,7 +29,7 @@ import {
   IRedirectHandler,
   ISessionInfo,
 } from "@inrupt/solid-client-authn-core";
-import { EventEmitter } from "stream";
+import { EventEmitter } from "events";
 
 import { getUnauthenticatedSession } from "../../../sessionInfo/SessionInfoManager";
 

--- a/packages/core/src/authenticatedFetch/fetchFactory.spec.ts
+++ b/packages/core/src/authenticatedFetch/fetchFactory.spec.ts
@@ -512,9 +512,7 @@ describe("buildAuthenticatedFetch", () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     mockedFreshener.refresh = jest
       .fn()
-      .mockRejectedValueOnce(
-        new InvalidResponseError("Some error message", ["access_token"])
-      ) as any;
+      .mockRejectedValueOnce(new InvalidResponseError(["access_token"])) as any;
     const mockEmitter = new EventEmitter();
     const spiedEmit = jest.spyOn(mockEmitter, "emit");
 

--- a/packages/core/src/authenticatedFetch/fetchFactory.spec.ts
+++ b/packages/core/src/authenticatedFetch/fetchFactory.spec.ts
@@ -440,6 +440,28 @@ describe("buildAuthenticatedFetch", () => {
     );
   });
 
+  it("calls the provided callback when the access token is refreshed", async () => {
+    const mockedFetch = jest.requireMock("cross-fetch") as jest.Mock;
+    const tokenSet = mockDefaultTokenSet();
+    const mockedFreshener = mockTokenRefresher({
+      ...tokenSet,
+      expiresIn: 1800,
+    });
+    const eventEmitter = new EventEmitter();
+    const spiedEmit = jest.spyOn(eventEmitter, "emit");
+    await buildAuthenticatedFetch(mockedFetch, "myToken", {
+      refreshOptions: {
+        refreshToken: "some refresh token",
+        sessionId: "mySession",
+        tokenRefresher: mockedFreshener,
+      },
+      eventEmitter,
+      expiresIn: 0,
+    });
+    await sleep(200);
+    expect(spiedEmit).toHaveBeenCalledWith(EVENTS.SESSION_EXTENDED, 1800);
+  });
+
   it("calls the provided callback when a new refresh token is issued", async () => {
     const mockedFetch = jest.requireMock("cross-fetch") as jest.Mock;
     const tokenSet = mockDefaultTokenSet();

--- a/packages/core/src/authenticatedFetch/fetchFactory.spec.ts
+++ b/packages/core/src/authenticatedFetch/fetchFactory.spec.ts
@@ -48,6 +48,7 @@ import {
 import { EVENTS } from "../constant";
 import { OidcProviderError } from "../errors/OidcProviderError";
 import { InvalidResponseError } from "../errors/InvalidResponseError";
+import { ITokenRefresher } from "../login/oidc/refresh/ITokenRefresher";
 
 jest.mock("cross-fetch");
 
@@ -303,8 +304,8 @@ describe("buildAuthenticatedFetch", () => {
         refreshToken: "some refresh token",
         sessionId: "mySession",
         tokenRefresher: mockRefresher,
-        expiresIn: 6,
       },
+      expiresIn: 6,
     });
     // It should not refresh the tokens right away...
     expect(mockRefresher.refresh).not.toHaveBeenCalled();
@@ -342,11 +343,21 @@ describe("buildAuthenticatedFetch", () => {
   it("does not rebind the DPoP token on refresh", async () => {
     const mockedFetch = jest.requireMock("cross-fetch") as jest.Mock;
     const keylikePair = await mockJwk();
-    const mockRefresher = mockTokenRefresher({
-      ...mockDefaultTokenSet(),
-      // We get a new expiration date every time we refresh the tokens
-      expiresIn: 0,
-    });
+    // Mocks a refresher which refreshes only once to prevent re-scheduling timeouts.
+    // This would not be necessary with mock timers.
+    const mockedTokenRefresher: ITokenRefresher = {
+      refresh: jest
+        .fn<
+          ReturnType<ITokenRefresher["refresh"]>,
+          Parameters<ITokenRefresher["refresh"]>
+        >()
+        .mockResolvedValueOnce({
+          ...mockDefaultTokenSet(),
+          refreshToken: "some rotated refresh token",
+          expiresIn: 0,
+        })
+        .mockResolvedValue({ ...mockDefaultTokenSet(), expiresIn: 1000 }),
+    };
     await buildAuthenticatedFetch(mockedFetch, "myToken", {
       dpopKey: {
         privateKey: keylikePair.privateKey,
@@ -355,15 +366,15 @@ describe("buildAuthenticatedFetch", () => {
       refreshOptions: {
         refreshToken: "some refresh token",
         sessionId: "mySession",
-        tokenRefresher: mockRefresher,
-        expiresIn: 0,
+        tokenRefresher: mockedTokenRefresher,
       },
+      expiresIn: 0,
     });
 
     await sleep(200);
     // jest.runOnlyPendingTimers();
 
-    expect(mockRefresher.refresh).toHaveBeenCalledWith(
+    expect(mockedTokenRefresher.refresh).toHaveBeenCalledWith(
       expect.anything(),
       "some refresh token",
       {
@@ -386,8 +397,8 @@ describe("buildAuthenticatedFetch", () => {
         refreshToken: "some refresh token",
         sessionId: "mySession",
         tokenRefresher: mockRefresher,
-        expiresIn: 6,
       },
+      expiresIn: 6,
     });
     // Run the timer to pretend the token is about to expire
     // jest.advanceTimersByTime(1800 * 1000);
@@ -415,8 +426,8 @@ describe("buildAuthenticatedFetch", () => {
         refreshToken: "some refresh token",
         sessionId: "mySession",
         tokenRefresher: mockRefresher,
-        expiresIn: 6,
       },
+      expiresIn: 6,
     });
     // Run the timer to pretend the token is about to expire
     // jest.runOnlyPendingTimers();
@@ -441,9 +452,9 @@ describe("buildAuthenticatedFetch", () => {
         refreshToken: "some refresh token",
         sessionId: "mySession",
         tokenRefresher: mockedFreshener,
-        eventEmitter,
-        expiresIn: 0,
       },
+      eventEmitter,
+      expiresIn: 0,
     });
     await sleep(200);
     expect(spiedEmit).toHaveBeenCalledWith(
@@ -454,18 +465,30 @@ describe("buildAuthenticatedFetch", () => {
 
   it("rotates the refresh token if a new one is issued", async () => {
     const mockedFetch = jest.requireMock("cross-fetch") as jest.Mock;
-    const tokenSet = { ...mockDefaultTokenSet(), expiresIn: 0 };
-    tokenSet.refreshToken = "some rotated refresh token";
-    const mockedFreshener = mockTokenRefresher(tokenSet);
-    const refreshCall = jest.spyOn(mockedFreshener, "refresh");
+    // Mocks a refresher which refreshes only once to prevent re-scheduling timeouts.
+    // This would not be necessary with mock timers.
+    const mockedTokenRefresher: ITokenRefresher = {
+      refresh: jest
+        .fn<
+          ReturnType<ITokenRefresher["refresh"]>,
+          Parameters<ITokenRefresher["refresh"]>
+        >()
+        .mockResolvedValueOnce({
+          ...mockDefaultTokenSet(),
+          refreshToken: "some rotated refresh token",
+          expiresIn: 0,
+        })
+        .mockResolvedValue({ ...mockDefaultTokenSet(), expiresIn: 1000 }),
+    };
+    const refreshCall = jest.spyOn(mockedTokenRefresher, "refresh");
 
     await buildAuthenticatedFetch(mockedFetch, "myToken", {
       refreshOptions: {
         refreshToken: "some refresh token",
         sessionId: "mySession",
-        tokenRefresher: mockedFreshener,
-        expiresIn: 0,
+        tokenRefresher: mockedTokenRefresher,
       },
+      expiresIn: 0,
     });
     await sleep(200);
     expect(refreshCall.mock.calls[1][1]).toEqual("some rotated refresh token");
@@ -492,9 +515,9 @@ describe("buildAuthenticatedFetch", () => {
         refreshToken: "some refresh token",
         sessionId: "mySession",
         tokenRefresher: mockedFreshener,
-        expiresIn: 0,
-        eventEmitter: mockEmitter,
       },
+      expiresIn: 0,
+      eventEmitter: mockEmitter,
     });
     await sleep(200);
     expect(spiedEmit).toHaveBeenCalledTimes(2);
@@ -521,12 +544,40 @@ describe("buildAuthenticatedFetch", () => {
         refreshToken: "some refresh token",
         sessionId: "mySession",
         tokenRefresher: mockedFreshener,
-        expiresIn: 0,
-        eventEmitter: mockEmitter,
       },
+      expiresIn: 0,
+      eventEmitter: mockEmitter,
     });
     await sleep(100);
     expect(spiedEmit).toHaveBeenCalledTimes(1);
     expect(spiedEmit).toHaveBeenCalledWith(EVENTS.SESSION_EXPIRED);
+  });
+
+  it("emits the appropriate events when the access token expires and may not be refreshed", async () => {
+    const mockedFetch = jest.requireMock("cross-fetch") as jest.Mock;
+    const mockedFreshener = mockTokenRefresher(mockDefaultTokenSet());
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mockedFreshener.refresh = jest
+      .fn()
+      .mockRejectedValueOnce(new InvalidResponseError(["access_token"])) as any;
+    const mockEmitter = new EventEmitter();
+    const spiedEmit = jest.spyOn(mockEmitter, "emit");
+
+    await buildAuthenticatedFetch(mockedFetch, "myToken", {
+      expiresIn: 0,
+      eventEmitter: mockEmitter,
+    });
+    await sleep(100);
+    expect(spiedEmit).toHaveBeenCalledTimes(1);
+    expect(spiedEmit).toHaveBeenCalledWith(EVENTS.SESSION_EXPIRED);
+  });
+
+  it("does not schedule any callback to be called if no event can be fired", async () => {
+    const mockedFetch = jest.requireMock("cross-fetch") as jest.Mock;
+    const spyTimeout = jest.spyOn(global, "setTimeout");
+    await buildAuthenticatedFetch(mockedFetch, "myToken");
+    await sleep(100);
+    // The only call to setTimeout should come from the `sleep` function
+    expect(spyTimeout).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/core/src/authenticatedFetch/fetchFactory.ts
+++ b/packages/core/src/authenticatedFetch/fetchFactory.ts
@@ -118,6 +118,10 @@ async function refreshAccessToken(
     refreshOptions.refreshToken,
     dpopKey
   );
+  eventEmitter?.emit(
+    EVENTS.SESSION_EXTENDED,
+    tokenSet.expiresIn ?? DEFAULT_EXPIRATION_TIME_SECONDS
+  );
   if (typeof tokenSet.refreshToken === "string") {
     eventEmitter?.emit(EVENTS.NEW_REFRESH_TOKEN, tokenSet.refreshToken);
   }

--- a/packages/core/src/constant.ts
+++ b/packages/core/src/constant.ts
@@ -35,6 +35,7 @@ export const EVENTS = {
   NEW_REFRESH_TOKEN: "newRefreshToken",
   ERROR: "onError",
   SESSION_EXPIRED: "sessionExpired",
+  SESSION_EXTENDED: "sessionExtended",
 };
 /**
  * We want to refresh a token 5 seconds before it expires.

--- a/packages/core/src/errors/InvalidResponseError.ts
+++ b/packages/core/src/errors/InvalidResponseError.ts
@@ -36,7 +36,9 @@
  */
 export class InvalidResponseError extends Error {
   /* istanbul ignore next */
-  constructor(message: string, public readonly missingFields: string[]) {
-    super(message);
+  constructor(public readonly missingFields: string[]) {
+    super(
+      `Invalid response from OIDC provider: missing fields ${missingFields}`
+    );
   }
 }

--- a/packages/core/src/errors/InvalidResponseError.ts
+++ b/packages/core/src/errors/InvalidResponseError.ts
@@ -20,23 +20,23 @@
  */
 
 /**
- * Intended to be used by dependent packages as a common prefix for keys into
- * storage mechanisms (so as to group all keys related to Solid Client Authn
- * within those storage mechanisms, e.g., window.localStorage).
+ * @hidden
+ * @packageDocumentation
  */
-export const SOLID_CLIENT_AUTHN_KEY_PREFIX = "solidClientAuthn:";
 
 /**
- * Ordered list of signature algorithms, from most preferred to least preferred.
+ * Error to be triggered when receiving a response missing mandatory elements
  */
-export const PREFERRED_SIGNING_ALG = ["ES256", "RS256"];
 
-export const EVENTS = {
-  NEW_REFRESH_TOKEN: "newRefreshToken",
-  ERROR: "onError",
-  SESSION_EXPIRED: "sessionExpired",
-};
+// NOTE: There's a bug with istanbul and typescript that prevents full branch coverages
+// https://github.com/gotwarlost/istanbul/issues/690
+// The workaround is to put istanbul ignore on the constructor
 /**
- * We want to refresh a token 5 seconds before it expires.
+ * @hidden
  */
-export const REFRESH_BEFORE_EXPIRATION_SECONDS = 5;
+export class InvalidResponseError extends Error {
+  /* istanbul ignore next */
+  constructor(message: string, public readonly missingFields: string[]) {
+    super(message);
+  }
+}

--- a/packages/core/src/errors/OidcProviderError.ts
+++ b/packages/core/src/errors/OidcProviderError.ts
@@ -20,23 +20,27 @@
  */
 
 /**
- * Intended to be used by dependent packages as a common prefix for keys into
- * storage mechanisms (so as to group all keys related to Solid Client Authn
- * within those storage mechanisms, e.g., window.localStorage).
+ * @hidden
+ * @packageDocumentation
  */
-export const SOLID_CLIENT_AUTHN_KEY_PREFIX = "solidClientAuthn:";
 
 /**
- * Ordered list of signature algorithms, from most preferred to least preferred.
+ * Error to be triggered when receiving a response missing mandatory elements
  */
-export const PREFERRED_SIGNING_ALG = ["ES256", "RS256"];
 
-export const EVENTS = {
-  NEW_REFRESH_TOKEN: "newRefreshToken",
-  ERROR: "onError",
-  SESSION_EXPIRED: "sessionExpired",
-};
+// NOTE: There's a bug with istanbul and typescript that prevents full branch coverages
+// https://github.com/gotwarlost/istanbul/issues/690
+// The workaround is to put istanbul ignore on the constructor
 /**
- * We want to refresh a token 5 seconds before it expires.
+ * @hidden
  */
-export const REFRESH_BEFORE_EXPIRATION_SECONDS = 5;
+export class OidcProviderError extends Error {
+  /* istanbul ignore next */
+  constructor(
+    message: string,
+    public readonly error: string,
+    public readonly errorDescription?: string
+  ) {
+    super(message);
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -81,6 +81,8 @@ export { default as InMemoryStorage } from "./storage/InMemoryStorage";
 
 export { default as ConfigurationError } from "./errors/ConfigurationError";
 export { default as NotImplementedError } from "./errors/NotImplementedError";
+export { InvalidResponseError } from "./errors/InvalidResponseError";
+export { OidcProviderError } from "./errors/OidcProviderError";
 
 export {
   createDpopHeader,

--- a/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.ts
@@ -118,9 +118,9 @@ export default class ClientCredentialsOidcHandler implements IOidcHandler {
               refreshToken: tokens.refresh_token,
               sessionId: oidcLoginOptions.sessionId,
               tokenRefresher: this.tokenRefresher,
-              eventEmitter: oidcLoginOptions.eventEmitter,
             }
           : undefined,
+        eventEmitter: oidcLoginOptions.eventEmitter,
       }
     );
 

--- a/packages/node/src/login/oidc/oidcHandlers/RefreshTokenOidcHandler.spec.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/RefreshTokenOidcHandler.spec.ts
@@ -414,8 +414,7 @@ describe("RefreshTokenOidcHandler", () => {
     expect(mockedTokenRefresher.refresh).toHaveBeenCalledWith(
       expect.anything(),
       expect.anything(),
-      expect.anything(),
-      mockEmitter
+      expect.anything()
     );
   });
 

--- a/packages/node/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
+++ b/packages/node/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
@@ -155,8 +155,6 @@ export class AuthCodeRedirectHandler implements IRedirectHandler {
         refreshToken: tokenSet.refresh_token,
         sessionId,
         tokenRefresher: this.tokenRefresher,
-        eventEmitter,
-        expiresIn: tokenSet.expires_in,
       };
     }
     const authFetch = await buildAuthenticatedFetch(
@@ -165,6 +163,8 @@ export class AuthCodeRedirectHandler implements IRedirectHandler {
       {
         dpopKey,
         refreshOptions,
+        eventEmitter,
+        expiresIn: tokenSet.expires_in,
       }
     );
 

--- a/packages/oidc/src/dpop/tokenExchange.spec.ts
+++ b/packages/oidc/src/dpop/tokenExchange.spec.ts
@@ -257,11 +257,7 @@ describe("getTokens", () => {
       mockEndpointInput(),
       false
     );
-    await expect(request).rejects.toThrow(
-      `Invalid token endpoint response (missing the field 'token_type'): ${JSON.stringify(
-        tokenResponse
-      )}`
-    );
+    await expect(request).rejects.toThrow("token_type");
   });
 
   // See https://tools.ietf.org/html/rfc6749#page-29 for the required parameters
@@ -327,11 +323,7 @@ describe("getTokens", () => {
     mockFetch(JSON.stringify(tokenEndpointResponse), 200);
     await expect(
       getTokens(mockIssuer(), mockClient(), mockEndpointInput(), true)
-    ).rejects.toThrow(
-      `Invalid token endpoint response (missing the field 'access_token'): ${JSON.stringify(
-        tokenEndpointResponse
-      )}`
-    );
+    ).rejects.toThrow("access_token");
   });
 
   it("throws if the ID token is missing", async () => {
@@ -341,11 +333,7 @@ describe("getTokens", () => {
     mockFetch(JSON.stringify(tokenEndpointResponse), 200);
     await expect(
       getTokens(mockIssuer(), mockClient(), mockEndpointInput(), true)
-    ).rejects.toThrow(
-      `Invalid token endpoint response (missing the field 'id_token'): ${JSON.stringify(
-        tokenEndpointResponse
-      )}`
-    );
+    ).rejects.toThrow("id_token");
   });
 
   it("throws if the token endpoint returned an error", async () => {

--- a/packages/oidc/src/dpop/tokenExchange.spec.ts
+++ b/packages/oidc/src/dpop/tokenExchange.spec.ts
@@ -43,7 +43,19 @@ import {
 // Some spec-compliant claims are camel-cased.
 /* eslint-disable camelcase */
 
-jest.mock("@inrupt/solid-client-authn-core");
+jest.mock("@inrupt/solid-client-authn-core", () => {
+  const actualCoreModule = jest.requireActual(
+    "@inrupt/solid-client-authn-core"
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ) as any;
+  return {
+    ...actualCoreModule,
+    // This works around the network lookup to the JWKS in order to validate the ID token.
+    getWebidFromTokenPayload: jest.fn(() =>
+      Promise.resolve("https://my.webid/")
+    ),
+  };
+});
 
 // The following module introduces randomness in the process, which prevents
 // making assumptions on the returned values. Mocking them out makes keys and

--- a/packages/oidc/src/dpop/tokenExchange.ts
+++ b/packages/oidc/src/dpop/tokenExchange.ts
@@ -154,7 +154,7 @@ export function validateTokenEndpointResponse(
       `Invalid token endpoint response (missing the field 'access_token'): ${JSON.stringify(
         tokenResponse
       )}`,
-      "access_token"
+      ["access_token"]
     );
   }
 
@@ -163,7 +163,7 @@ export function validateTokenEndpointResponse(
       `Invalid token endpoint response (missing the field 'id_token'): ${JSON.stringify(
         tokenResponse
       )}.`,
-      "id_token"
+      ["id_token"]
     );
   }
 
@@ -172,7 +172,7 @@ export function validateTokenEndpointResponse(
       `Invalid token endpoint response (missing the field 'token_type'): ${JSON.stringify(
         tokenResponse
       )}`,
-      "token_type"
+      ["token_type"]
     );
   }
 
@@ -181,7 +181,7 @@ export function validateTokenEndpointResponse(
       `Invalid token endpoint response (invalid field 'expires_in'): ${JSON.stringify(
         tokenResponse
       )}`,
-      "expires_in"
+      ["expires_in"]
     );
   }
 

--- a/packages/oidc/src/dpop/tokenExchange.ts
+++ b/packages/oidc/src/dpop/tokenExchange.ts
@@ -29,6 +29,8 @@ import {
   KeyPair,
   generateDpopKeyPair,
   TokenEndpointResponse,
+  OidcProviderError,
+  InvalidResponseError,
 } from "@inrupt/solid-client-authn-core";
 
 // Identifiers in camelcase are mandated by the OAuth spec.
@@ -132,44 +134,54 @@ export function validateTokenEndpointResponse(
   expires_in?: number;
 } {
   if (hasError(tokenResponse)) {
-    throw new Error(
+    throw new OidcProviderError(
       `Token endpoint returned error [${tokenResponse.error}]${
         hasErrorDescription(tokenResponse)
           ? `: ${tokenResponse.error_description}`
           : ""
-      }${hasErrorUri(tokenResponse) ? ` (see ${tokenResponse.error_uri})` : ""}`
+      }${
+        hasErrorUri(tokenResponse) ? ` (see ${tokenResponse.error_uri})` : ""
+      }`,
+      tokenResponse.error,
+      hasErrorDescription(tokenResponse)
+        ? tokenResponse.error_description
+        : undefined
     );
   }
 
   if (!hasAccessToken(tokenResponse)) {
-    throw new Error(
+    throw new InvalidResponseError(
       `Invalid token endpoint response (missing the field 'access_token'): ${JSON.stringify(
         tokenResponse
-      )}`
+      )}`,
+      "access_token"
     );
   }
 
   if (!hasIdToken(tokenResponse)) {
-    throw new Error(
+    throw new InvalidResponseError(
       `Invalid token endpoint response (missing the field 'id_token'): ${JSON.stringify(
         tokenResponse
-      )}.`
+      )}.`,
+      "id_token"
     );
   }
 
   if (!hasTokenType(tokenResponse)) {
-    throw new Error(
+    throw new InvalidResponseError(
       `Invalid token endpoint response (missing the field 'token_type'): ${JSON.stringify(
         tokenResponse
-      )}`
+      )}`,
+      "token_type"
     );
   }
 
   if (!hasExpiresIn(tokenResponse)) {
-    throw new Error(
+    throw new InvalidResponseError(
       `Invalid token endpoint response (invalid field 'expires_in'): ${JSON.stringify(
         tokenResponse
-      )}`
+      )}`,
+      "expires_in"
     );
   }
 

--- a/packages/oidc/src/dpop/tokenExchange.ts
+++ b/packages/oidc/src/dpop/tokenExchange.ts
@@ -150,39 +150,19 @@ export function validateTokenEndpointResponse(
   }
 
   if (!hasAccessToken(tokenResponse)) {
-    throw new InvalidResponseError(
-      `Invalid token endpoint response (missing the field 'access_token'): ${JSON.stringify(
-        tokenResponse
-      )}`,
-      ["access_token"]
-    );
+    throw new InvalidResponseError(["access_token"]);
   }
 
   if (!hasIdToken(tokenResponse)) {
-    throw new InvalidResponseError(
-      `Invalid token endpoint response (missing the field 'id_token'): ${JSON.stringify(
-        tokenResponse
-      )}.`,
-      ["id_token"]
-    );
+    throw new InvalidResponseError(["id_token"]);
   }
 
   if (!hasTokenType(tokenResponse)) {
-    throw new InvalidResponseError(
-      `Invalid token endpoint response (missing the field 'token_type'): ${JSON.stringify(
-        tokenResponse
-      )}`,
-      ["token_type"]
-    );
+    throw new InvalidResponseError(["token_type"]);
   }
 
   if (!hasExpiresIn(tokenResponse)) {
-    throw new InvalidResponseError(
-      `Invalid token endpoint response (invalid field 'expires_in'): ${JSON.stringify(
-        tokenResponse
-      )}`,
-      ["expires_in"]
-    );
+    throw new InvalidResponseError(["expires_in"]);
   }
 
   // TODO: Due to a bug in both the ESS ID broker AND NSS (what were the odds), a DPoP token is returned

--- a/packages/oidc/src/refresh/refreshGrant.spec.ts
+++ b/packages/oidc/src/refresh/refreshGrant.spec.ts
@@ -139,9 +139,7 @@ describe("refreshGrant", () => {
     );
     await expect(
       refresh("some refresh token", mockIssuer(), mockClient())
-    ).rejects.toThrow(
-      "Invalid token endpoint response (missing the field 'access_token')"
-    );
+    ).rejects.toThrow("access_token");
   });
 
   it("throws if the token endpoint does not return an ID token", async () => {
@@ -154,9 +152,7 @@ describe("refreshGrant", () => {
     );
     await expect(
       refresh("some refresh token", mockIssuer(), mockClient())
-    ).rejects.toThrow(
-      "Invalid token endpoint response (missing the field 'id_token')"
-    );
+    ).rejects.toThrow("id_token");
   });
 
   it("throws if the token endpoint returns an error", async () => {


### PR DESCRIPTION
When using refresh tokens to keep the session alive, for some reason the
silent authentication may fail. In this case, we want to notify the app
that it no longer is authenticated, and that it should prompt the user
for re-authentication.

- [X] All acceptance criteria are met.
- [ ] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).