### PR TITLE
Set expiration date during refresh grant

### DIFF
--- a/packages/oidc/src/refresh/refreshGrant.spec.ts
+++ b/packages/oidc/src/refresh/refreshGrant.spec.ts
@@ -171,11 +171,12 @@ describe("refreshGrant", () => {
     ).rejects.toThrow("Token endpoint returned error [Some error]");
   });
 
-  it("returns the access, ID and refresh tokens, as well as the WebID and DPoP key if applicable", async () => {
+  it("returns the access, ID and refresh tokens, as well as the WebID, DPoP key anr expiration date if applicable", async () => {
     mockFetch(
       JSON.stringify({
         ...mockDpopTokens(),
         refresh_token: "Some new refresh token",
+        expires_in: 1800,
       }),
       200
     );
@@ -192,5 +193,6 @@ describe("refreshGrant", () => {
     expect(result.refreshToken).toBe("Some new refresh token");
     expect(result.webId).toBe(mockWebId());
     expect(result.dpopKey).toEqual(keyPair);
+    expect(result.expiresIn).toBe(1800);
   });
 });

--- a/packages/oidc/src/refresh/refreshGrant.spec.ts
+++ b/packages/oidc/src/refresh/refreshGrant.spec.ts
@@ -171,7 +171,7 @@ describe("refreshGrant", () => {
     ).rejects.toThrow("Token endpoint returned error [Some error]");
   });
 
-  it("returns the access, ID and refresh tokens, as well as the WebID, DPoP key anr expiration date if applicable", async () => {
+  it("returns the access, ID and refresh tokens, as well as the WebID, DPoP key and expiration date if applicable", async () => {
     mockFetch(
       JSON.stringify({
         ...mockDpopTokens(),

--- a/packages/oidc/src/refresh/refreshGrant.ts
+++ b/packages/oidc/src/refresh/refreshGrant.ts
@@ -101,5 +101,6 @@ export async function refresh(
         : undefined,
     webId,
     dpopKey,
+    expiresIn: validatedResponse.expires_in,
   };
 }


### PR DESCRIPTION
The expiration date returned by the OIDC provider wasn't returned along
with the refreshed access token.

- [X] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable. **Technically the feature is unreleased, so I don't think it's worth adding this to the changelog** 
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).