### PR TITLE
Allow 'any' in test files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,6 +16,13 @@ module.exports = {
     {
       files: ["**/__mocks__/**"],
     },
+    {
+      files: ["**/*.spec.ts"],
+      rules: {
+        // Using 'any' in the tests is usually justified.
+        "@typescript-eslint/no-explicit-any": "off",
+      },
+    },
   ],
   env: {
     // eslint will complain about imports from @jest/globals shadowing global

--- a/packages/browser/src/ClientAuthentication.spec.ts
+++ b/packages/browser/src/ClientAuthentication.spec.ts
@@ -48,7 +48,6 @@ import { LocalStorageMock } from "./storage/__mocks__/LocalStorage";
 jest.mock("@inrupt/solid-client-authn-core", () => {
   const actualCoreModule = jest.requireActual(
     "@inrupt/solid-client-authn-core"
-    /* eslint-disable @typescript-eslint/no-explicit-any */
   ) as any;
   return {
     // We only want to fetch specific functions that result in a network fetch,
@@ -419,7 +418,6 @@ describe("ClientAuthentication", () => {
     // In the following describe block, (window as any) is used
     // multiple types to override the window type definition and
     // allow localStorage to be written.
-    /* eslint-disable @typescript-eslint/no-explicit-any */
     it("returns null no current session is in storage", async () => {
       const clientAuthn = getClientAuthentication({});
 

--- a/packages/browser/src/Session.spec.ts
+++ b/packages/browser/src/Session.spec.ts
@@ -608,7 +608,6 @@ describe("Session", () => {
 
       const mySession = new Session({}, "mySession");
       const iframe = jest.requireMock("../src/iframe");
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const postIri = jest.spyOn(iframe as any, "postRedirectUrlToParent");
       await mySession.handleIncomingRedirect({
         url: "https://some.redirect.url?code=someCode&state=someState",
@@ -729,9 +728,7 @@ describe("Session", () => {
         sessionInfoManager: mockSessionInfoManager(mockedStorage),
       });
       clientAuthentication.handleIncomingRedirect = (
-        jest
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          .fn() as any
+        jest.fn() as any
       ).mockResolvedValue(
         undefined
       ) as typeof clientAuthentication.handleIncomingRedirect;
@@ -804,7 +801,6 @@ describe("Session", () => {
       );
       // Check that second parameter is of type session
       expect(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (clientAuthentication.login as any).mock.calls[0][1]
       ).toBeInstanceOf(Session);
     });
@@ -868,20 +864,18 @@ describe("Session", () => {
         sessionInfoManager: mockSessionInfoManager(mockedStorage),
       });
       clientAuthentication.validateCurrentSession = (
-        jest
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          .fn() as any
+        jest.fn() as any
       ).mockResolvedValue({
         issuer: "https://some.issuer",
         clientAppId: "some client ID",
         clientAppSecret: "some client secret",
         redirectUrl: "https://some.redirect/url",
       }) as typeof clientAuthentication.validateCurrentSession;
-      clientAuthentication.handleIncomingRedirect =
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (jest.fn() as any).mockResolvedValue(
-          undefined
-        ) as typeof clientAuthentication.handleIncomingRedirect;
+      clientAuthentication.handleIncomingRedirect = (
+        jest.fn() as any
+      ).mockResolvedValue(
+        undefined
+      ) as typeof clientAuthentication.handleIncomingRedirect;
       clientAuthentication.login = jest.fn();
 
       const mySession = new Session({ clientAuthentication });
@@ -909,9 +903,7 @@ describe("Session", () => {
         sessionInfoManager: mockSessionInfoManager(mockedStorage),
       });
       clientAuthentication.validateCurrentSession = (
-        jest
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          .fn() as any
+        jest.fn() as any
       ).mockResolvedValue({
         issuer: "https://some.issuer",
         clientAppId: "some client ID",
@@ -919,9 +911,7 @@ describe("Session", () => {
         redirectUrl: "https://some.redirect/url",
       });
       clientAuthentication.handleIncomingRedirect = (
-        jest
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          .fn() as any
+        jest.fn() as any
       ).mockResolvedValue(undefined);
       clientAuthentication.login = jest.fn();
 
@@ -941,9 +931,7 @@ describe("Session", () => {
       const myCallback = jest.fn();
       const clientAuthentication = mockClientAuthentication();
       clientAuthentication.handleIncomingRedirect = (
-        jest
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          .fn() as any
+        jest.fn() as any
       ).mockResolvedValue({
         isLoggedIn: true,
         sessionId: "a session ID",
@@ -1038,9 +1026,7 @@ describe("Session", () => {
       // This pretends the login is successful.
       const clientAuthentication = mockClientAuthentication();
       clientAuthentication.handleIncomingRedirect = (
-        jest
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          .fn() as any
+        jest.fn() as any
       ).mockResolvedValue({
         isLoggedIn: true,
         sessionId: "a session ID",
@@ -1120,7 +1106,6 @@ describe("Session", () => {
       );
       // Check that second parameter is of type session
       expect(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (clientAuthentication.login as any).mock.calls[0][1]
       ).toBeInstanceOf(Session);
     });
@@ -1143,9 +1128,7 @@ describe("Session", () => {
       // ../src/iframe is mocked for other tests,
       // but we need `setupIframeListener` to actually be executed
       // so that the callback gets called:
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const iframeMock = jest.requireMock("../src/iframe") as any;
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const iframeActual = jest.requireActual("../src/iframe") as any;
       iframeMock.setupIframeListener.mockImplementationOnce(
         iframeActual.setupIframeListener
@@ -1188,9 +1171,7 @@ describe("Session", () => {
       // ../src/iframe is mocked for other tests,
       // but we need `setupIframeListener` to actually be executed
       // so that the callback gets called:
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const iframeMock = jest.requireMock("../src/iframe") as any;
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const iframeActual = jest.requireActual("../src/iframe") as any;
       iframeMock.setupIframeListener.mockImplementationOnce(
         iframeActual.setupIframeListener
@@ -1200,7 +1181,6 @@ describe("Session", () => {
       // be written to; we only do so for tests to pretend we have an existing
       // logged-in session that remains logged in after failed silent
       // authentication.
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (mySession as any).info = {
         isLoggedIn: true,
         webId: "https://some.pod/profile#me",

--- a/packages/browser/src/iframe.spec.ts
+++ b/packages/browser/src/iframe.spec.ts
@@ -86,7 +86,6 @@ describe("setupIframeListener", () => {
     const callback = jest.fn();
     const blockingPromise = mockEventListener();
     setupDom(false, true);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     setupIframeListener(callback as any);
 
     window.postMessage(
@@ -105,7 +104,6 @@ describe("setupIframeListener", () => {
     const callback = jest.fn();
     const blockingPromise = mockEventListener();
     setupDom(true, false);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     setupIframeListener(callback as any);
 
     window.postMessage(
@@ -124,7 +122,6 @@ describe("setupIframeListener", () => {
     const callback = jest.fn();
     const blockingPromise = mockEventListener();
     setupDom(true, true);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     setupIframeListener(callback as any);
 
     window.postMessage(
@@ -144,7 +141,6 @@ describe("setupIframeListener", () => {
     const callback = jest.fn();
     const blockingPromise = mockEventListener();
     setupDom(true, true);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     setupIframeListener(callback as any);
 
     window.postMessage(
@@ -163,7 +159,6 @@ describe("setupIframeListener", () => {
     const callback = jest.fn();
     const blockingPromise = mockEventListener();
     setupDom(true, true);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     setupIframeListener(callback as any);
 
     expect(document.getElementsByTagName("iframe")[0]).not.toBeUndefined();

--- a/packages/browser/src/login/oidc/ClientRegistrar.spec.ts
+++ b/packages/browser/src/login/oidc/ClientRegistrar.spec.ts
@@ -45,7 +45,6 @@ describe("ClientRegistrar", () => {
     it("properly performs dynamic registration", async () => {
       // FIXME: this should mock out oidc-client-ext, instead of mimicking the
       // actual OIDC provider response.
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const mockFetch = (jest.fn() as any).mockResolvedValueOnce(
         /* eslint-disable camelcase */
         new NodeResponse(
@@ -97,7 +96,6 @@ describe("ClientRegistrar", () => {
     });
 
     it("can register a public client without secret", async () => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const mockFetch = (jest.fn() as any).mockResolvedValueOnce(
         /* eslint-disable camelcase */
         new NodeResponse(
@@ -144,7 +142,6 @@ describe("ClientRegistrar", () => {
     });
 
     it("handles a failure to dynamically register elegantly", async () => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const mockFetch = (jest.fn() as any).mockResolvedValueOnce(
         /* eslint-disable camelcase */
         new NodeResponse('{"error":"bad stuff that\'s an error"}', {
@@ -203,7 +200,6 @@ describe("ClientRegistrar", () => {
         storage: mockStorageUtility({}),
       });
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const mockFetch = (jest.fn() as any).mockResolvedValueOnce(
         /* eslint-disable camelcase */
         new NodeResponse(
@@ -248,7 +244,6 @@ describe("ClientRegistrar", () => {
         ),
       });
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const mockFetch = (jest.fn() as any).mockResolvedValueOnce(
         /* eslint-disable camelcase */
         new NodeResponse(
@@ -281,7 +276,6 @@ describe("ClientRegistrar", () => {
     });
 
     it("saves dynamic registration information", async () => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const mockFetch = (jest.fn() as any).mockResolvedValueOnce(
         /* eslint-disable camelcase */
         new NodeResponse(

--- a/packages/browser/src/login/oidc/IssuerConfigFetcher.spec.ts
+++ b/packages/browser/src/login/oidc/IssuerConfigFetcher.spec.ts
@@ -52,7 +52,6 @@ describe("IssuerConfigFetcher", () => {
     const configFetcher = getIssuerConfigFetcher({
       storageUtility: mockStorageUtility({}),
     });
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const mockFetch = (jest.fn() as any).mockResolvedValueOnce(fetchResponse);
     window.fetch = mockFetch as typeof window.fetch;
     const fetchedConfig = await configFetcher.fetchConfig(
@@ -60,10 +59,8 @@ describe("IssuerConfigFetcher", () => {
     );
     expect(fetchedConfig.issuer.startsWith("https:")).toBeTruthy();
     expect(fetchedConfig.issuer).toBe("https://example.com");
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect((fetchedConfig as any).claim_types_supported).toBeUndefined();
     expect(fetchedConfig.claimTypesSupported).toBe("oidc");
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect((fetchedConfig as any).bleepBloop).toBeUndefined();
   });
 
@@ -94,7 +91,6 @@ describe("IssuerConfigFetcher", () => {
     const configFetcher = getIssuerConfigFetcher({
       storageUtility: mockStorageUtility({}),
     });
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const mockFetch = (jest.fn() as any).mockResolvedValueOnce(fetchResponse);
     window.fetch = mockFetch as typeof window.fetch;
     const fetchedConfig = await configFetcher.fetchConfig(

--- a/packages/browser/src/login/oidc/OidcLoginHandler.spec.ts
+++ b/packages/browser/src/login/oidc/OidcLoginHandler.spec.ts
@@ -102,9 +102,7 @@ describe("OidcLoginHandler", () => {
   });
 
   it("should lookup client ID if not provided, if not found do DCR", async () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const mockedOidcModule = jest.requireMock("@inrupt/oidc-client-ext") as any;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     mockedOidcModule.registerClient = (jest.fn() as any).mockResolvedValue({
       clientId: "some dynamically registered ID",
       clientSecret: "some dynamically registered secret",
@@ -133,9 +131,7 @@ describe("OidcLoginHandler", () => {
   });
 
   it("should perform DCR if a client WebID is provided, but the target IdP does not support Solid-OIDC", async () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const mockedOidcModule = jest.requireMock("@inrupt/oidc-client-ext") as any;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     mockedOidcModule.registerClient = (jest.fn() as any).mockResolvedValue({
       clientId: "some dynamically registered ID",
       clientSecret: "some dynamically registered secret",
@@ -298,7 +294,6 @@ describe("OidcLoginHandler", () => {
 
   it("should indicate it cannot handle logins without an issuer", async () => {
     const handler = getInitialisedHandler();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     await expect(handler.canHandle({} as any)).resolves.toBe(false);
   });
 

--- a/packages/browser/src/login/oidc/Redirector.spec.ts
+++ b/packages/browser/src/login/oidc/Redirector.spec.ts
@@ -77,7 +77,6 @@ describe("Redirector", () => {
 
     it("redirects in an iframe if specified", () => {
       const iframe = jest.requireMock("../../../src/iframe");
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const redirectInIframe = jest.spyOn(iframe as any, "redirectInIframe");
       const redirector = new Redirector();
       redirector.redirect("https://someUrl.com/redirect", {

--- a/packages/browser/src/login/oidc/oidcHandlers/AuthorizationCodeWithPkceOidcHandler.spec.ts
+++ b/packages/browser/src/login/oidc/oidcHandlers/AuthorizationCodeWithPkceOidcHandler.spec.ts
@@ -48,7 +48,6 @@ const mockOidcModule = (
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const oidcModule = jest.requireMock("@inrupt/oidc-client-ext") as any;
   oidcModule.OidcClient = jest.fn().mockReturnValue({
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     createSigninRequest: (jest.fn() as any).mockResolvedValue({
       url,
       state,
@@ -100,7 +99,6 @@ describe("AuthorizationCodeWithPkceOidcHandler", () => {
             );
           }
         ),
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } as any;
 
       const authorizationCodeWithPkceOidcHandler =

--- a/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
+++ b/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
@@ -395,7 +395,6 @@ describe("AuthCodeRedirectHandler", () => {
       mockOidcClient();
       mockLocalStorage({});
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       window.fetch = (jest.fn() as any).mockReturnValue(
         new Promise((resolve) => {
           resolve(
@@ -440,7 +439,6 @@ describe("AuthCodeRedirectHandler", () => {
       mockOidcClient();
       mockLocalStorage({});
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       window.fetch = (jest.fn() as any).mockReturnValue(
         new Promise((resolve) => {
           resolve(
@@ -490,7 +488,6 @@ describe("AuthCodeRedirectHandler", () => {
       mockOidcClient();
       mockLocalStorage({});
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       window.fetch = (jest.fn() as any).mockReturnValue(
         new Promise((resolve) => {
           resolve(
@@ -568,7 +565,6 @@ describe("AuthCodeRedirectHandler", () => {
       mockOidcClient();
       const mockedOidcClient = jest.requireMock(
         "@inrupt/oidc-client-ext"
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
       ) as any;
       jest.spyOn(mockedOidcClient, "getBearerToken").mockReturnValueOnce({
         accessToken: mockAccessTokenBearer(),
@@ -736,11 +732,7 @@ describe("AuthCodeRedirectHandler", () => {
   it("swallows the exception if the fetch to the session endpoint fails", async () => {
     mockOidcClient();
     mockLocalStorage({});
-    window.fetch = (
-      jest
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        .fn() as any
-    )
+    window.fetch = (jest.fn() as any)
       .mockResolvedValueOnce(
         new Response("https://my.webid", {
           status: 200,
@@ -812,7 +804,6 @@ describe("AuthCodeRedirectHandler", () => {
     const mockedStorage = mockDefaultRedirectStorage();
     const coreModule = jest.requireActual(
       "@inrupt/solid-client-authn-core"
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ) as any;
     const mockAuthenticatedFetchBuild = jest.spyOn(
       coreModule,

--- a/packages/browser/src/util/UUIDGenerator.spec.ts
+++ b/packages/browser/src/util/UUIDGenerator.spec.ts
@@ -26,7 +26,6 @@ jest.mock("uuid");
 
 describe("UuidGenerator", () => {
   it("should simply wrap the `uuid` module", () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const uuidMock: { v4: jest.Mock } = jest.requireMock("uuid") as any;
     uuidMock.v4.mockReturnValueOnce("some uuid");
 

--- a/packages/core/src/authenticatedFetch/fetchFactory.spec.ts
+++ b/packages/core/src/authenticatedFetch/fetchFactory.spec.ts
@@ -519,7 +519,6 @@ describe("buildAuthenticatedFetch", () => {
   it("emits the appropriate events when refreshing the token fails", async () => {
     const mockedFetch = jest.requireMock("cross-fetch") as jest.Mock;
     const mockedFreshener = mockTokenRefresher(mockDefaultTokenSet());
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     mockedFreshener.refresh = jest
       .fn()
       .mockRejectedValueOnce(
@@ -554,7 +553,6 @@ describe("buildAuthenticatedFetch", () => {
   it("emits the appropriate events when an unexpected response is received", async () => {
     const mockedFetch = jest.requireMock("cross-fetch") as jest.Mock;
     const mockedFreshener = mockTokenRefresher(mockDefaultTokenSet());
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     mockedFreshener.refresh = jest
       .fn()
       .mockRejectedValueOnce(new InvalidResponseError(["access_token"])) as any;

--- a/packages/core/src/errors/errors.spec.ts
+++ b/packages/core/src/errors/errors.spec.ts
@@ -28,7 +28,6 @@ import NotImplementedError from "./NotImplementedError";
 describe("errors", () => {
   const errors: {
     name: string;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     class: any;
     params: unknown[];
     message: string;

--- a/packages/core/src/login/oidc/redirectHandler/IRedirectHandler.spec.ts
+++ b/packages/core/src/login/oidc/redirectHandler/IRedirectHandler.spec.ts
@@ -85,11 +85,9 @@ describe("getWebidFromTokenPayload", () => {
     const mockedFetch = jest.fn(() =>
       Promise.resolve(new NodeResponse(payload, { status: statusCode }))
     );
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const crossFetch = jest.requireMock("cross-fetch") as any;
     crossFetch.fetch = mockedFetch;
     // To avoid having to duplicate the mocked fetch's type definition:
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return mockedFetch as any;
   };
 

--- a/packages/core/src/util/handlerPattern/AggregateHandler.spec.ts
+++ b/packages/core/src/util/handlerPattern/AggregateHandler.spec.ts
@@ -128,7 +128,6 @@ describe("AggregateHandler", () => {
       ]);
 
       // Cyclical object that references itself causes JSON.stringify to throw!
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const obj: any = {
         prop: {},
       };

--- a/packages/node/src/ClientAuthentication.spec.ts
+++ b/packages/node/src/ClientAuthentication.spec.ts
@@ -108,17 +108,14 @@ describe("ClientAuthentication", () => {
       const mockedLoginHandler: jest.Mocked<ILoginHandler> = {
         // jest's Mock types don't seem to align here after an update.
         // Not sure what happened; taking the `any` escape since the tests worked.
-        canHandle: jest.fn(
-          (_options: ILoginOptions) => Promise.resolve(true)
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        canHandle: jest.fn((_options: ILoginOptions) =>
+          Promise.resolve(true)
         ) as any,
-        handle: jest.fn(
-          (_options: ILoginOptions) =>
-            Promise.resolve({
-              fetch: mockedAuthFetch,
-              webId: "https://my.webid/",
-            })
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        handle: jest.fn((_options: ILoginOptions) =>
+          Promise.resolve({
+            fetch: mockedAuthFetch,
+            webId: "https://my.webid/",
+          })
         ) as any,
       };
       const clientAuthn = getClientAuthentication({

--- a/packages/node/src/Session.spec.ts
+++ b/packages/node/src/Session.spec.ts
@@ -65,7 +65,6 @@ describe("Session", () => {
     it("accepts legacy input storage", async () => {
       // Mocking the type definitions of the entire DI framework is a bit too
       // involved at this time, so settling for `any`:
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const dependencies = jest.requireMock("./dependencies") as any;
       dependencies.getClientAuthenticationWithDependencies = jest.fn();
       const insecureStorage = mockStorage({});
@@ -87,7 +86,6 @@ describe("Session", () => {
     it("accepts input storage", async () => {
       // Mocking the type definitions of the entire DI framework is a bit too
       // involved at this time, so settling for `any`:
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const dependencies = jest.requireMock("./dependencies") as any;
       dependencies.getClientAuthenticationWithDependencies = jest.fn();
       const storage = mockStorage({});
@@ -106,7 +104,6 @@ describe("Session", () => {
     it("ignores legacy input storage if new input storage is specified", async () => {
       // Mocking the type definitions of the entire DI framework is a bit too
       // involved at this time, so settling for `any`:
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const dependencies = jest.requireMock("./dependencies") as any;
       dependencies.getClientAuthenticationWithDependencies = jest.fn();
       const insecureStorage = mockStorage({});
@@ -207,7 +204,6 @@ describe("Session", () => {
           ReturnType<typeof clientAuthentication.fetch>,
           Parameters<typeof clientAuthentication.fetch>
         >()
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         .mockResolvedValueOnce({} as any);
       const mySession = new Session({ clientAuthentication });
       await mySession.login({});
@@ -450,7 +446,6 @@ describe("getSessionFromStorage", () => {
       });
     // Mocking the type definitions of the entire DI framework is a bit too
     // involved at this time, so settling for `any`:
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const dependencies = jest.requireMock("./dependencies") as any;
     dependencies.getClientAuthenticationWithDependencies = jest
       .fn()
@@ -484,7 +479,6 @@ describe("getSessionFromStorage", () => {
       .mockResolvedValueOnce();
     // Mocking the type definitions of the entire DI framework is a bit too
     // involved at this time, so settling for `any`:
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const dependencies = jest.requireMock("./dependencies") as any;
     dependencies.getClientAuthenticationWithDependencies = jest
       .fn()
@@ -507,7 +501,6 @@ describe("getSessionFromStorage", () => {
       .mockResolvedValueOnce(undefined);
     // Mocking the type definitions of the entire DI framework is a bit too
     // involved at this time, so settling for `any`:
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const dependencies = jest.requireMock("./dependencies") as any;
     dependencies.getClientAuthenticationWithDependencies = jest
       .fn()
@@ -526,7 +519,6 @@ describe("getSessionFromStorage", () => {
       .mockResolvedValueOnce(undefined);
     // Mocking the type definitions of the entire DI framework is a bit too
     // involved at this time, so settling for `any`:
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const dependencies = jest.requireMock("./dependencies") as any;
     dependencies.getClientAuthenticationWithDependencies = jest
       .fn()
@@ -556,7 +548,6 @@ describe("getStoredSessionIdAll", () => {
     });
     // Mocking the type definitions of the entire DI framework is a bit too
     // involved at this time, so settling for `any`:
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const dependencies = jest.requireMock("./dependencies") as any;
     dependencies.getClientAuthenticationWithDependencies = jest
       .fn()
@@ -578,7 +569,6 @@ describe("getStoredSessionIdAll", () => {
     });
     // Mocking the type definitions of the entire DI framework is a bit too
     // involved at this time, so settling for `any`:
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const dependencies = jest.requireMock("./dependencies") as any;
     dependencies.getClientAuthenticationWithDependencies = jest
       .fn()
@@ -608,7 +598,6 @@ describe("clearSessionAll", () => {
     });
     // Mocking the type definitions of the entire DI framework is a bit too
     // involved at this time, so settling for `any`:
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const dependencies = jest.requireMock("./dependencies") as any;
     dependencies.getClientAuthenticationWithDependencies = jest
       .fn()
@@ -627,7 +616,6 @@ describe("clearSessionAll", () => {
     });
     // Mocking the type definitions of the entire DI framework is a bit too
     // involved at this time, so settling for `any`:
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const dependencies = jest.requireMock("./dependencies") as any;
     dependencies.getClientAuthenticationWithDependencies = jest
       .fn()

--- a/packages/node/src/authenticatedFetch/headers/HeadersUtils.spec.ts
+++ b/packages/node/src/authenticatedFetch/headers/HeadersUtils.spec.ts
@@ -53,7 +53,6 @@ describe("Headers interoperability function", () => {
   });
 
   it("supports non-iterable headers if they provide a reasonably standard way of browsing them", () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const myHeaders: any = {};
     myHeaders.forEach = (
       callback: (value: string, key: string) => void

--- a/packages/node/src/dependencies.spec.ts
+++ b/packages/node/src/dependencies.spec.ts
@@ -46,7 +46,6 @@ jest.mock("openid-client");
 jest.mock("@inrupt/solid-client-authn-core", () => {
   const actualCoreModule = jest.requireActual(
     "@inrupt/solid-client-authn-core"
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ) as any;
   return {
     ...actualCoreModule,
@@ -71,7 +70,6 @@ const setupOidcClientMock = () => {
       token_type: "Bearer",
       expired: () => false,
       claims: jest.fn(),
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any);
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
@@ -137,7 +135,6 @@ describe("resolution order", () => {
     const handlerSelectSpy = jest.spyOn(
       // The easiest way to test this is to look into the injected dependencies
       // (which is why we look up private attributes).
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (clientAuthn as any).loginHandler.oidcHandler,
       "getProperHandler"
     );
@@ -162,7 +159,6 @@ describe("resolution order", () => {
     const handlerSelectSpy = jest.spyOn(
       // The easiest way to test this is to look into the injected dependencies
       // (which is why we look up private attributes).
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (clientAuthn as any).loginHandler.oidcHandler,
       "getProperHandler"
     );
@@ -186,7 +182,6 @@ describe("resolution order", () => {
     const handlerSelectSpy = jest.spyOn(
       // The easiest way to test this is to look into the injected dependencies
       // (which is why we look up private attributes).
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (clientAuthn as any).loginHandler.oidcHandler,
       "getProperHandler"
     );

--- a/packages/node/src/login/oidc/ClientRegistrar.spec.ts
+++ b/packages/node/src/login/oidc/ClientRegistrar.spec.ts
@@ -50,7 +50,6 @@ describe("ClientRegistrar", () => {
   describe("getClient", () => {
     it("fails if there is not registration endpoint", async () => {
       // Sets up the mock-up for DCR
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const { Issuer } = jest.requireMock("openid-client") as any;
       const mockedIssuerConfig = mockIssuerMetadata({
         registration_endpoint: undefined,
@@ -108,12 +107,10 @@ describe("ClientRegistrar", () => {
 
     it("properly performs dynamic registration and saves client information", async () => {
       // Sets up the mock-up for DCR
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const { Issuer } = jest.requireMock("openid-client") as any;
       const mockedIssuer = {
         metadata: mockDefaultIssuerMetadata(),
         Client: {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
           register: (jest.fn() as any).mockResolvedValueOnce({
             metadata: mockDefaultClientConfig(),
           }),
@@ -161,12 +158,10 @@ describe("ClientRegistrar", () => {
 
     it("throws if the issuer doesn't avertise for supported signing algorithms", async () => {
       // Sets up the mock-up for DCR
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const { Issuer } = jest.requireMock("openid-client") as any;
       const mockedIssuer = {
         metadata: mockDefaultIssuerMetadata(),
         Client: {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
           register: (jest.fn() as any).mockResolvedValueOnce({
             metadata: mockDefaultClientConfig(),
           }),
@@ -196,12 +191,10 @@ describe("ClientRegistrar", () => {
 
     it("throws if no signing algorithm supported by the issuer match the client preferences", async () => {
       // Sets up the mock-up for DCR
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const { Issuer } = jest.requireMock("openid-client") as any;
       const mockedIssuer = {
         metadata: mockDefaultIssuerMetadata(),
         Client: {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
           register: (jest.fn() as any).mockResolvedValueOnce({
             metadata: mockDefaultClientConfig(),
           }),
@@ -232,16 +225,11 @@ describe("ClientRegistrar", () => {
 
     it("retrieves client information from storage after dynamic registration", async () => {
       // Sets up the mock-up for DCR
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const { Issuer } = jest.requireMock("openid-client") as any;
       const mockedIssuer = {
         metadata: mockDefaultIssuerMetadata(),
         Client: {
-          register: (
-            jest
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              .fn() as any
-          )
+          register: (jest.fn() as any)
             .mockResolvedValueOnce({
               metadata: mockDefaultClientConfig(),
             })
@@ -281,12 +269,10 @@ describe("ClientRegistrar", () => {
 
     it("retrieves a registration bearer token if present in storage", async () => {
       // Sets up the mock-up for DCR
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const { Issuer } = jest.requireMock("openid-client") as any;
       const mockedIssuer = {
         metadata: mockDefaultIssuerMetadata(),
         Client: {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
           register: (jest.fn() as any).mockResolvedValueOnce({
             metadata: mockDefaultClientConfig(),
           }),
@@ -327,12 +313,10 @@ describe("ClientRegistrar", () => {
 
     it("uses a registration bearer token if provided", async () => {
       // Sets up the mock-up for DCR
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const { Issuer } = jest.requireMock("openid-client") as any;
       const mockedIssuer = {
         metadata: mockDefaultIssuerMetadata(),
         Client: {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
           register: (jest.fn() as any).mockResolvedValueOnce({
             metadata: mockDefaultClientConfig(),
           }),
@@ -364,7 +348,6 @@ describe("ClientRegistrar", () => {
 
     it("saves the registered client information for a public client in storage", async () => {
       // Sets up the mock-up for DCR
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const { Issuer } = jest.requireMock("openid-client") as any;
       const mockedClientConfig = mockClientConfig({
         client_secret: undefined,
@@ -372,7 +355,6 @@ describe("ClientRegistrar", () => {
       const mockedIssuer = {
         metadata: mockDefaultIssuerMetadata(),
         Client: {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
           register: (jest.fn() as any).mockResolvedValueOnce({
             metadata: mockedClientConfig,
           }),
@@ -404,14 +386,12 @@ describe("ClientRegistrar", () => {
 
     it("uses stores the signing algorithm preferred by the client when the registration didn't return the used algorithm", async () => {
       // Sets up the mock-up for DCR
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const { Issuer } = jest.requireMock("openid-client") as any;
       const metadata = mockDefaultClientConfig();
       delete metadata.id_token_signed_response_alg;
       const mockedIssuer = {
         metadata: mockDefaultIssuerMetadata(),
         Client: {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
           register: (jest.fn() as any).mockResolvedValueOnce({
             metadata,
           }),

--- a/packages/node/src/login/oidc/IssuerConfigFetcher.spec.ts
+++ b/packages/node/src/login/oidc/IssuerConfigFetcher.spec.ts
@@ -46,10 +46,8 @@ describe("IssuerConfigFetcher", () => {
   }
 
   it("should return a config based on the fetched config if none was stored in the storage", async () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const { Issuer } = jest.requireMock("openid-client") as any;
     const mockedIssuerConfig = mockDefaultIssuerMetadata();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     Issuer.discover = (jest.fn() as any).mockResolvedValueOnce({
       metadata: mockedIssuerConfig,
     });
@@ -75,12 +73,10 @@ describe("IssuerConfigFetcher", () => {
   });
 
   it("throws an error if authorization_endpoint is missing", async () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const { Issuer } = jest.requireMock("openid-client") as any;
     const mockedIssuerConfig = mockIssuerMetadata({
       authorization_endpoint: undefined,
     });
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     Issuer.discover = (jest.fn() as any).mockResolvedValueOnce({
       metadata: mockedIssuerConfig,
     });
@@ -95,12 +91,10 @@ describe("IssuerConfigFetcher", () => {
   });
 
   it("throws an error if token_endpoint is missing", async () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const { Issuer } = jest.requireMock("openid-client") as any;
     const mockedIssuerConfig = mockIssuerMetadata({
       token_endpoint: undefined,
     });
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     Issuer.discover = (jest.fn() as any).mockResolvedValueOnce({
       metadata: mockedIssuerConfig,
     });
@@ -115,12 +109,10 @@ describe("IssuerConfigFetcher", () => {
   });
 
   it("throws an error if jwks_uri is missing", async () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const { Issuer } = jest.requireMock("openid-client") as any;
     const mockedIssuerConfig = mockIssuerMetadata({
       jwks_uri: undefined,
     });
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     Issuer.discover = (jest.fn() as any).mockResolvedValueOnce({
       metadata: mockedIssuerConfig,
     });
@@ -135,12 +127,10 @@ describe("IssuerConfigFetcher", () => {
   });
 
   it("throws an error if claims_supported is missing", async () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const { Issuer } = jest.requireMock("openid-client") as any;
     const mockedIssuerConfig = mockIssuerMetadata({
       claims_supported: undefined,
     });
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     Issuer.discover = (jest.fn() as any).mockResolvedValueOnce({
       metadata: mockedIssuerConfig,
     });
@@ -155,12 +145,10 @@ describe("IssuerConfigFetcher", () => {
   });
 
   it("throws an error if subject_types_supported is missing", async () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const { Issuer } = jest.requireMock("openid-client") as any;
     const mockedIssuerConfig = mockIssuerMetadata({
       subject_types_supported: undefined,
     });
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     Issuer.discover = (jest.fn() as any).mockResolvedValueOnce({
       metadata: mockedIssuerConfig,
     });
@@ -175,12 +163,10 @@ describe("IssuerConfigFetcher", () => {
   });
 
   it("should return a config including the support for solid-oidc if present in the discovery profile", async () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const { Issuer } = jest.requireMock("openid-client") as any;
     const mockedIssuerConfig = mockIssuerMetadata({
       solid_oidc_supported: "https://solidproject.org/TR/solid-oidc",
     });
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     Issuer.discover = (jest.fn() as any).mockResolvedValueOnce({
       metadata: mockedIssuerConfig,
     });

--- a/packages/node/src/login/oidc/OidcLoginHandler.spec.ts
+++ b/packages/node/src/login/oidc/OidcLoginHandler.spec.ts
@@ -123,11 +123,9 @@ describe("OidcLoginHandler", () => {
     it("performs DCR if client ID and secret aren't specified", async () => {
       const { oidcHandler } = defaultMocks;
       const clientRegistrar = mockDefaultClientRegistrar();
-      clientRegistrar.getClient = (
-        jest
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          .fn() as any
-      ).mockResolvedValueOnce(mockDefaultClient());
+      clientRegistrar.getClient = (jest.fn() as any).mockResolvedValueOnce(
+        mockDefaultClient()
+      );
       const handler = getInitialisedHandler({ oidcHandler, clientRegistrar });
       await handler.handle({
         sessionId: "mySession",
@@ -142,11 +140,9 @@ describe("OidcLoginHandler", () => {
       const { oidcHandler } = defaultMocks;
       const mockedStorage = mockStorageUtility({});
       const clientRegistrar = mockDefaultClientRegistrar();
-      clientRegistrar.getClient = (
-        jest
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          .fn() as any
-      ).mockResolvedValueOnce(mockDefaultClient());
+      clientRegistrar.getClient = (jest.fn() as any).mockResolvedValueOnce(
+        mockDefaultClient()
+      );
       const handler = getInitialisedHandler({
         oidcHandler,
         clientRegistrar,
@@ -213,7 +209,6 @@ describe("OidcLoginHandler", () => {
     it("should perform DCR if a client WebID is provided, but the target IdP does not support Solid-OIDC", async () => {
       const { oidcHandler } = defaultMocks;
       const clientRegistrar = mockDefaultClientRegistrar();
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       clientRegistrar.getClient = (jest.fn() as any).mockResolvedValueOnce({
         clientId: "a dynamically registered client id",
         clientSecret: "a dynamically registered client secret",
@@ -254,11 +249,9 @@ describe("OidcLoginHandler", () => {
       const { oidcHandler } = defaultMocks;
       const mockedStorage = mockStorageUtility({});
       const clientRegistrar = mockDefaultClientRegistrar();
-      clientRegistrar.getClient = (
-        jest
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          .fn() as any
-      ).mockResolvedValueOnce(mockDefaultClient());
+      clientRegistrar.getClient = (jest.fn() as any).mockResolvedValueOnce(
+        mockDefaultClient()
+      );
       const handler = getInitialisedHandler({
         oidcHandler,
         clientRegistrar,
@@ -284,11 +277,9 @@ describe("OidcLoginHandler", () => {
         refreshToken: "some token",
       });
       const clientRegistrar = mockDefaultClientRegistrar();
-      clientRegistrar.getClient = (
-        jest
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          .fn() as any
-      ).mockResolvedValueOnce(mockDefaultClient());
+      clientRegistrar.getClient = (jest.fn() as any).mockResolvedValueOnce(
+        mockDefaultClient()
+      );
       const handler = getInitialisedHandler({
         oidcHandler,
         clientRegistrar,
@@ -314,11 +305,9 @@ describe("OidcLoginHandler", () => {
         refreshToken: "some token",
       });
       const clientRegistrar = mockDefaultClientRegistrar();
-      clientRegistrar.getClient = (
-        jest
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          .fn() as any
-      ).mockResolvedValueOnce(mockDefaultClient());
+      clientRegistrar.getClient = (jest.fn() as any).mockResolvedValueOnce(
+        mockDefaultClient()
+      );
       const handler = getInitialisedHandler({
         oidcHandler,
         clientRegistrar,

--- a/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.spec.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.spec.ts
@@ -44,7 +44,6 @@ jest.mock("cross-fetch");
 jest.mock("@inrupt/solid-client-authn-core", () => {
   const actualCoreModule = jest.requireActual(
     "@inrupt/solid-client-authn-core"
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ) as any;
   return {
     ...actualCoreModule,
@@ -321,7 +320,6 @@ describe("handle", () => {
     setupOidcClientMock(tokens);
     const coreModule = jest.requireMock(
       "@inrupt/solid-client-authn-core"
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ) as any;
     const mockAuthenticatedFetchBuild = jest.spyOn(
       coreModule,

--- a/packages/node/src/login/oidc/oidcHandlers/RefreshTokenOidcHandler.spec.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/RefreshTokenOidcHandler.spec.ts
@@ -53,7 +53,6 @@ jest.mock("cross-fetch");
 jest.mock("@inrupt/solid-client-authn-core", () => {
   const actualCoreModule = jest.requireActual(
     "@inrupt/solid-client-authn-core"
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ) as any;
   return {
     ...actualCoreModule,
@@ -351,7 +350,6 @@ describe("RefreshTokenOidcHandler", () => {
     const mockedTokenRefresher = mockTokenRefresher(tokenSet);
     const coreModule = jest.requireMock(
       "@inrupt/solid-client-authn-core"
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ) as any;
     const mockAuthenticatedFetchBuild = jest.spyOn(
       coreModule,
@@ -424,7 +422,6 @@ describe("RefreshTokenOidcHandler", () => {
     });
     tokenRefresher.refresh = jest
       .fn()
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       .mockRejectedValue("Invalid credentials") as any;
     const refreshTokenOidcHandler = new RefreshTokenOidcHandler(
       tokenRefresher,

--- a/packages/node/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
+++ b/packages/node/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
@@ -51,7 +51,6 @@ jest.mock("cross-fetch");
 jest.mock("@inrupt/solid-client-authn-core", () => {
   const actualCoreModule = jest.requireActual(
     "@inrupt/solid-client-authn-core"
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ) as any;
   return {
     ...actualCoreModule,
@@ -220,7 +219,6 @@ describe("AuthCodeRedirectHandler", () => {
     });
 
   const setupOidcClientMock = (tokenSet?: TokenSet, callback?: unknown) => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const { Issuer } = jest.requireMock("openid-client") as any;
     function clientConstructor() {
       // this is untyped, which makes TS complain
@@ -325,7 +323,6 @@ describe("AuthCodeRedirectHandler", () => {
 
     it("cleans up the redirect IRI from the OIDC parameters", async () => {
       // This function represents the openid-client callback
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const callback = (jest.fn() as any).mockResolvedValueOnce(
         mockDpopTokens()
       );

--- a/packages/node/src/multiSession.spec.ts
+++ b/packages/node/src/multiSession.spec.ts
@@ -66,7 +66,6 @@ describe("getSessionFromStorage", () => {
       });
     // Mocking the type definitions of the entire DI framework is a bit too
     // involved at this time, so settling for `any`:
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const dependencies = jest.requireMock("./dependencies") as any;
     dependencies.getClientAuthenticationWithDependencies = jest
       .fn()
@@ -100,7 +99,6 @@ describe("getSessionFromStorage", () => {
       .mockResolvedValueOnce();
     // Mocking the type definitions of the entire DI framework is a bit too
     // involved at this time, so settling for `any`:
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const dependencies = jest.requireMock("./dependencies") as any;
     dependencies.getClientAuthenticationWithDependencies = jest
       .fn()
@@ -123,7 +121,6 @@ describe("getSessionFromStorage", () => {
       .mockResolvedValueOnce(undefined);
     // Mocking the type definitions of the entire DI framework is a bit too
     // involved at this time, so settling for `any`:
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const dependencies = jest.requireMock("./dependencies") as any;
     dependencies.getClientAuthenticationWithDependencies = jest
       .fn()
@@ -142,7 +139,6 @@ describe("getSessionFromStorage", () => {
       .mockResolvedValueOnce(undefined);
     // Mocking the type definitions of the entire DI framework is a bit too
     // involved at this time, so settling for `any`:
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const dependencies = jest.requireMock("./dependencies") as any;
     dependencies.getClientAuthenticationWithDependencies = jest
       .fn()
@@ -172,7 +168,6 @@ describe("getStoredSessionIdAll", () => {
     });
     // Mocking the type definitions of the entire DI framework is a bit too
     // involved at this time, so settling for `any`:
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const dependencies = jest.requireMock("./dependencies") as any;
     dependencies.getClientAuthenticationWithDependencies = jest
       .fn()
@@ -194,7 +189,6 @@ describe("getStoredSessionIdAll", () => {
     });
     // Mocking the type definitions of the entire DI framework is a bit too
     // involved at this time, so settling for `any`:
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const dependencies = jest.requireMock("./dependencies") as any;
     dependencies.getClientAuthenticationWithDependencies = jest
       .fn()
@@ -224,7 +218,6 @@ describe("clearSessionAll", () => {
     });
     // Mocking the type definitions of the entire DI framework is a bit too
     // involved at this time, so settling for `any`:
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const dependencies = jest.requireMock("./dependencies") as any;
     dependencies.getClientAuthenticationWithDependencies = jest
       .fn()
@@ -243,7 +236,6 @@ describe("clearSessionAll", () => {
     });
     // Mocking the type definitions of the entire DI framework is a bit too
     // involved at this time, so settling for `any`:
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const dependencies = jest.requireMock("./dependencies") as any;
     dependencies.getClientAuthenticationWithDependencies = jest
       .fn()

--- a/packages/node/src/util/UuidGenerator.spec.ts
+++ b/packages/node/src/util/UuidGenerator.spec.ts
@@ -26,7 +26,6 @@ jest.mock("uuid");
 
 describe("UuidGenerator", () => {
   it("should simply wrap the `uuid` module", () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const uuidMock: { v4: jest.Mock } = jest.requireMock("uuid") as any;
     uuidMock.v4.mockReturnValueOnce("some uuid");
 

--- a/packages/oidc/src/dpop/tokenExchange.spec.ts
+++ b/packages/oidc/src/dpop/tokenExchange.spec.ts
@@ -46,7 +46,6 @@ import {
 jest.mock("@inrupt/solid-client-authn-core", () => {
   const actualCoreModule = jest.requireActual(
     "@inrupt/solid-client-authn-core"
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ) as any;
   return {
     ...actualCoreModule,

--- a/packages/oidc/src/refresh/refreshGrant.spec.ts
+++ b/packages/oidc/src/refresh/refreshGrant.spec.ts
@@ -37,7 +37,6 @@ import { refresh } from "./refreshGrant";
 jest.mock("@inrupt/solid-client-authn-core", () => {
   const actualCoreModule = jest.requireActual(
     "@inrupt/solid-client-authn-core"
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ) as any;
   return {
     ...actualCoreModule,


### PR DESCRIPTION
This updates ESLint rules to allow for explicit any in test files,
because it's usually a legitimate use case.