### PR TITLE
Use subject_type public during DCR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased
 
+### Bugfixes
+
+#### oidc
+
+- When dynamically registering a Client to a Solid Identity Provider, the subject
+type was incorrectly set to `pairwise`, instead of `public`. Only `public` makes
+sense in the context of Solid, where subjects (in this case, users) are uniquely
+identified by their WebID. This was disregarded by current Solid Identity Providers, 
+so it should not have affected dependants, but it's technically more correct.
+
 The following sections document changes that have been released already:
 
 ## 1.11.0 - 2021-08-12

--- a/packages/browser/src/login/oidc/ClientRegistrar.spec.ts
+++ b/packages/browser/src/login/oidc/ClientRegistrar.spec.ts
@@ -86,7 +86,7 @@ describe("ClientRegistrar", () => {
           /* eslint-disable camelcase */
           application_type: "web",
           redirect_uris: ["https://example.com"],
-          subject_type: "pairwise",
+          subject_type: "public",
           token_endpoint_auth_method: "client_secret_basic",
           id_token_signed_response_alg: "RS256",
           grant_types: ["authorization_code", "refresh_token"],

--- a/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
+++ b/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
@@ -82,7 +82,7 @@ const mockIssuer = (): IIssuerConfig => {
     tokenEndpoint: "https://some.issuer/token",
     jwksUri: "https://some.issuer/keys",
     claimsSupported: ["code", "openid"],
-    subjectTypesSupported: ["public", "pairwise"],
+    subjectTypesSupported: ["public"],
     registrationEndpoint: "https://some.issuer/registration",
     grantTypesSupported: ["authorization_code"],
   };

--- a/packages/node/src/login/oidc/__mocks__/IssuerConfigFetcher.ts
+++ b/packages/node/src/login/oidc/__mocks__/IssuerConfigFetcher.ts
@@ -55,7 +55,7 @@ export const mockDefaultIssuerMetadata = (): IssuerMetadata => {
     registration_endpoint: "https://my.idp/register",
     jwks_uri: "https://my.idp/jwks",
     claims_supported: ["sub"],
-    subject_types_supported: ["public", "pairwise"],
+    subject_types_supported: ["public"],
     id_token_signing_alg_values_supported: ["ES256", "RS256"],
     grant_types_supported: [
       "authorization_code",

--- a/packages/oidc/src/dcr/clientRegistrar.spec.ts
+++ b/packages/oidc/src/dcr/clientRegistrar.spec.ts
@@ -35,7 +35,7 @@ const getMockIssuer = (): IIssuerConfig => {
     tokenEndpoint: "https://some.issuer/token",
     jwksUri: "https://some.issuer/keys",
     claimsSupported: ["code", "openid"],
-    subjectTypesSupported: ["public", "pairwise"],
+    subjectTypesSupported: ["public"],
     registrationEndpoint: "https://some.issuer/registration",
     idTokenSigningAlgValuesSupported: ["RS256"],
   };
@@ -134,7 +134,7 @@ describe("registerClient", () => {
         client_name: options.clientName,
         application_type: "web",
         redirect_uris: [options.redirectUrl?.toString()],
-        subject_type: "pairwise",
+        subject_type: "public",
         token_endpoint_auth_method: "client_secret_basic",
         id_token_signed_response_alg: "RS256",
         grant_types: ["authorization_code", "refresh_token"],

--- a/packages/oidc/src/dcr/clientRegistrar.ts
+++ b/packages/oidc/src/dcr/clientRegistrar.ts
@@ -116,7 +116,7 @@ export async function registerClient(
     client_name: options.clientName,
     application_type: "web",
     redirect_uris: [options.redirectUrl?.toString()],
-    subject_type: "pairwise",
+    subject_type: "public",
     token_endpoint_auth_method: "client_secret_basic",
     id_token_signed_response_alg: signingAlg,
     grant_types: ["authorization_code", "refresh_token"],

--- a/packages/oidc/src/dpop/tokenExchange.spec.ts
+++ b/packages/oidc/src/dpop/tokenExchange.spec.ts
@@ -159,7 +159,7 @@ describe("getTokens", () => {
       authorizationEndpoint: "https://some.issuer/autorization",
       jwksUri: "https://some.issuer/keys",
       claimsSupported: ["code", "openid"],
-      subjectTypesSupported: ["public", "pairwise"],
+      subjectTypesSupported: ["public"],
       registrationEndpoint: "https://some.issuer/registration",
       grantTypesSupported: ["authorization_code"],
       // Note that the token endpoint is missing, which mandates the type assertion


### PR DESCRIPTION
This fixes https://github.com/inrupt/solid-client-authn-js/issues/1551,
and ensures that during Dynamic Client Registration, the
`subject_type` parameter is properly set to `public`, and not to
`pairwise`. Indeed, in Solid, the subject identifier is the WebID, which
is global and unique: it should be shared among all clients. Having the
OP generate a different subject claim for each client for a given
subject does not make sense in the context of Solid.

- [X] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).