### PR TITLE
Fix/node/prompt consent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased
 
+### Bugfixes
+
+#### node
+
+- The `prompt=consent` parameter was missing when redirecting the user to the Solid
+Identity Provider authorization endpoint. This prevented working with the Community
+Solid Server Identity Provider.
+
 The following sections document changes that have been released already:
 
 ## 1.11.0 - 2021-08-12

--- a/packages/node/src/login/oidc/oidcHandlers/AuthorizationCodeWithPkceOidcHandler.spec.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/AuthorizationCodeWithPkceOidcHandler.spec.ts
@@ -109,6 +109,7 @@ describe("AuthorizationCodeWithPkceOidcHandler", () => {
         oidcOptions.redirectUrl
       );
       expect(builtUrl.searchParams.get("code_challenge")).not.toBeNull();
+      expect(builtUrl.searchParams.get("prompt")).toBe("consent");
     });
 
     it("saves relevant information in storage", async () => {

--- a/packages/node/src/login/oidc/oidcHandlers/AuthorizationCodeWithPkceOidcHandler.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/AuthorizationCodeWithPkceOidcHandler.ts
@@ -77,6 +77,7 @@ export default class AuthorizationCodeWithPkceOidcHandler
       response_type: "code",
       redirect_uri: oidcLoginOptions.redirectUrl,
       code_challenge_method: "S256",
+      prompt: "consent",
       // The offline_access scope asks the provider to issue a refresh token.
       scope: "openid offline_access",
     });


### PR DESCRIPTION
This fixes a bug in @inrupt/solid-client-authn-node, where the request
to the authorization endpoint omitted the 'prompt' parameter, while
including the 'offline_access' scope. The specification mandates that in
this case, 'prompt=consent' is present.

The bug has been discovered thanks to https://github.com/joachimvh in https://github.com/solid/community-server/issues/909.

- [X] I've added a unit test to test for potential regressions of this bug.
- [X] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).