### PR TITLE
Add the webid scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 - Passing custom headers to a session's fetch as a Headers object would result in the headers
 being overlooked.
+- As per [the spec](https://solid.github.io/solid-oidc/#webid-scope), the `webid`
+scope is not added to token requests.
 
 #### oidc
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - Passing custom headers to a session's fetch as a Headers object would result in the headers
 being overlooked.
 - As per [the Solid-OIDC spec](https://solid.github.io/solid-oidc/#webid-scope), the `webid`
-scope is not added to token requests.
+scope is now added to token requests.
 
 #### oidc
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 - Passing custom headers to a session's fetch as a Headers object would result in the headers
 being overlooked.
-- As per [the spec](https://solid.github.io/solid-oidc/#webid-scope), the `webid`
+- As per [the Solid-OIDC spec](https://solid.github.io/solid-oidc/#webid-scope), the `webid`
 scope is not added to token requests.
 
 #### oidc

--- a/packages/browser/src/login/oidc/oidcHandlers/AuthorizationCodeWithPkceOidcHandler.spec.ts
+++ b/packages/browser/src/login/oidc/oidcHandlers/AuthorizationCodeWithPkceOidcHandler.spec.ts
@@ -209,7 +209,7 @@ describe("AuthorizationCodeWithPkceOidcHandler", () => {
       );
     });
 
-    it("requests both openid and offline_access scopes", async () => {
+    it("requests both openid, offline_access and webid scopes", async () => {
       const oidcModule = mockOidcModule();
       const authorizationCodeWithPkceOidcHandler =
         getAuthorizationCodeWithPkceOidcHandler();
@@ -223,7 +223,7 @@ describe("AuthorizationCodeWithPkceOidcHandler", () => {
       await authorizationCodeWithPkceOidcHandler.handle(oidcOptions);
       expect(oidcModule.OidcClient).toHaveBeenCalledWith(
         expect.objectContaining({
-          scope: "openid offline_access",
+          scope: "openid offline_access webid",
         })
       );
     });

--- a/packages/browser/src/login/oidc/oidcHandlers/AuthorizationCodeWithPkceOidcHandler.ts
+++ b/packages/browser/src/login/oidc/oidcHandlers/AuthorizationCodeWithPkceOidcHandler.ts
@@ -68,7 +68,8 @@ export default class AuthorizationCodeWithPkceOidcHandler
       post_logout_redirect_uri: oidcLoginOptions.redirectUrl.toString(),
       response_type: "code",
       // The offline_access scope requests that a refresh token be returned.
-      scope: "openid offline_access",
+      // The webid scope is required as per https://solid.github.io/solid-oidc/#webid-scope
+      scope: "openid offline_access webid",
       filterProtocolClaims: true,
       // The userinfo endpoint on NSS fails, so disable this for now
       // Note that in Solid, information should be retrieved from the

--- a/packages/node/src/login/oidc/oidcHandlers/AuthorizationCodeWithPkceOidcHandler.spec.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/AuthorizationCodeWithPkceOidcHandler.spec.ts
@@ -110,6 +110,9 @@ describe("AuthorizationCodeWithPkceOidcHandler", () => {
       );
       expect(builtUrl.searchParams.get("code_challenge")).not.toBeNull();
       expect(builtUrl.searchParams.get("prompt")).toBe("consent");
+      expect(builtUrl.searchParams.get("scope")).toBe(
+        "openid offline_access webid"
+      );
     });
 
     it("saves relevant information in storage", async () => {

--- a/packages/node/src/login/oidc/oidcHandlers/AuthorizationCodeWithPkceOidcHandler.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/AuthorizationCodeWithPkceOidcHandler.ts
@@ -79,7 +79,8 @@ export default class AuthorizationCodeWithPkceOidcHandler
       code_challenge_method: "S256",
       prompt: "consent",
       // The offline_access scope asks the provider to issue a refresh token.
-      scope: "openid offline_access",
+      // The webid scope is required as per https://solid.github.io/solid-oidc/#webid-scope
+      scope: "openid offline_access webid",
     });
 
     // Stores information to be reused after reload

--- a/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.ts
@@ -83,6 +83,7 @@ export default class ClientCredentialsOidcHandler implements IOidcHandler {
       {
         grant_type: "client_credentials",
         token_endpoint_auth_method: "client_secret_basic",
+        scope: "openid offline_access webid",
       },
       {
         DPoP:


### PR DESCRIPTION
As per https://solid.github.io/solid-oidc/#webid-scope, the request to the token endpoint includes a `webid` scope so that the returned token will have a webid claim.

# Checklist

- [X] All acceptance criteria are met.
- [x] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).