### PR TITLE
Fix authn when using client identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Bugfixes
 
+#### node
+
+- Using a Client Identifier caused authentication issues at the token endpoint.
+
 #### node and browser
 
 - Passing custom headers to a session's fetch as a Headers object would result in the headers

--- a/packages/node/src/constant.ts
+++ b/packages/node/src/constant.ts
@@ -22,5 +22,3 @@
 import { SOLID_CLIENT_AUTHN_KEY_PREFIX } from "@inrupt/solid-client-authn-core";
 
 export const KEY_REGISTERED_SESSIONS = `${SOLID_CLIENT_AUTHN_KEY_PREFIX}registeredSessions`;
-// Currently required, pending a response to https://github.com/panva/node-openid-client/discussions/430.
-export const TMP_ARBITRARY_SECRET = "some arbitrary secret";

--- a/packages/node/src/constant.ts
+++ b/packages/node/src/constant.ts
@@ -22,3 +22,5 @@
 import { SOLID_CLIENT_AUTHN_KEY_PREFIX } from "@inrupt/solid-client-authn-core";
 
 export const KEY_REGISTERED_SESSIONS = `${SOLID_CLIENT_AUTHN_KEY_PREFIX}registeredSessions`;
+// Currently required, pending a response to https://github.com/panva/node-openid-client/discussions/430.
+export const TMP_ARBITRARY_SECRET = "some arbitrary secret";

--- a/packages/node/src/login/oidc/ClientRegistrar.spec.ts
+++ b/packages/node/src/login/oidc/ClientRegistrar.spec.ts
@@ -105,6 +105,31 @@ describe("ClientRegistrar", () => {
       expect(client.idTokenSignedResponseAlg).toEqual("ES256");
     });
 
+    it("negotiates signing alg if not found in storage", async () => {
+      const clientRegistrar = getClientRegistrar({
+        storage: mockStorageUtility(
+          {
+            "solidClientAuthenticationUser:mySession": {
+              clientId: "an id",
+              clientSecret: "a secret",
+              clientName: "my client name",
+            },
+          },
+          false
+        ),
+      });
+      const client = await clientRegistrar.getClient(
+        {
+          sessionId: "mySession",
+          redirectUrl: "https://example.com",
+        },
+        {
+          ...IssuerConfigFetcherFetchConfigResponse,
+        }
+      );
+      expect(client.idTokenSignedResponseAlg).toEqual("ES256");
+    });
+
     it("properly performs dynamic registration and saves client information", async () => {
       // Sets up the mock-up for DCR
       const { Issuer } = jest.requireMock("openid-client") as any;

--- a/packages/node/src/login/oidc/ClientRegistrar.ts
+++ b/packages/node/src/login/oidc/ClientRegistrar.ts
@@ -95,7 +95,9 @@ export default class ClientRegistrar implements IClientRegistrar {
         clientId: storedClientId,
         clientSecret: storedClientSecret,
         clientName: storedClientName as string | undefined,
-        idTokenSignedResponseAlg: storedIdTokenSignedResponseAlg,
+        idTokenSignedResponseAlg:
+          storedIdTokenSignedResponseAlg ??
+          negotiateClientSigningAlg(issuerConfig, PREFERRED_SIGNING_ALG),
         clientType: "dynamic",
       };
     }

--- a/packages/node/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
+++ b/packages/node/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
@@ -284,7 +284,7 @@ describe("AuthCodeRedirectHandler", () => {
       expect(headers.get("Authorization")).toContain("DPoP");
     });
 
-    it("uses client_secret_post authentication if using Solid-OIDC client identifiers", async () => {
+    it("uses 'none' client authentication if using Solid-OIDC client identifiers", async () => {
       const mockedIssuer = setupDefaultOidcClientMock();
       const mockedStorage = mockDefaultRedirectStorage();
 
@@ -307,7 +307,7 @@ describe("AuthCodeRedirectHandler", () => {
 
       expect(mockedIssuer.Client).toHaveBeenCalledWith(
         expect.objectContaining({
-          token_endpoint_auth_method: "client_secret_post",
+          token_endpoint_auth_method: "none",
         })
       );
     });

--- a/packages/node/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
+++ b/packages/node/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
@@ -51,6 +51,7 @@ import { fetch as globalFetch } from "cross-fetch";
 
 import { EventEmitter } from "events";
 import { configToIssuerMetadata } from "../IssuerConfigFetcher";
+import { TMP_ARBITRARY_SECRET } from "../../../constant";
 
 /**
  * @hidden
@@ -119,7 +120,10 @@ export class AuthCodeRedirectHandler implements IRedirectHandler {
     );
     const client = new issuer.Client({
       client_id: clientInfo.clientId,
-      client_secret: clientInfo.clientSecret,
+      client_secret: clientInfo.clientSecret ?? TMP_ARBITRARY_SECRET,
+      token_endpoint_auth_method: clientInfo.clientSecret
+        ? "client_secret_basic"
+        : "client_secret_post",
       id_token_signed_response_alg: clientInfo.idTokenSignedResponseAlg,
     });
 

--- a/packages/node/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
+++ b/packages/node/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
@@ -51,7 +51,6 @@ import { fetch as globalFetch } from "cross-fetch";
 
 import { EventEmitter } from "events";
 import { configToIssuerMetadata } from "../IssuerConfigFetcher";
-import { TMP_ARBITRARY_SECRET } from "../../../constant";
 
 /**
  * @hidden
@@ -120,10 +119,10 @@ export class AuthCodeRedirectHandler implements IRedirectHandler {
     );
     const client = new issuer.Client({
       client_id: clientInfo.clientId,
-      client_secret: clientInfo.clientSecret ?? TMP_ARBITRARY_SECRET,
+      client_secret: clientInfo.clientSecret,
       token_endpoint_auth_method: clientInfo.clientSecret
         ? "client_secret_basic"
-        : "client_secret_post",
+        : "none",
       id_token_signed_response_alg: clientInfo.idTokenSignedResponseAlg,
     });
 

--- a/packages/node/src/login/oidc/refresh/TokenRefresher.spec.ts
+++ b/packages/node/src/login/oidc/refresh/TokenRefresher.spec.ts
@@ -209,6 +209,7 @@ describe("TokenRefresher", () => {
     mockedModule.negotiateClientSigningAlg = jest
       .fn(negotiateClientSigningAlg)
       .mockReturnValue("ES256");
+
     const mockedStorage = mockRefresherDefaultStorageUtility();
 
     const refresher = getTokenRefresher({
@@ -266,7 +267,7 @@ describe("TokenRefresher", () => {
     expect(mockedModule.negotiateClientSigningAlg).not.toHaveBeenCalled();
   });
 
-  it("uses client_secret_post authentication if using Solid-OIDC client identifiers", async () => {
+  it("uses 'none' authentication if using Solid-OIDC client identifiers", async () => {
     const mockedIssuer = setupDefaultOidcClientMock();
     const refresher = getTokenRefresher({
       clientRegistrar: mockClientRegistrar({
@@ -284,7 +285,7 @@ describe("TokenRefresher", () => {
 
     expect(mockedIssuer.Client).toHaveBeenCalledWith(
       expect.objectContaining({
-        token_endpoint_auth_method: "client_secret_post",
+        token_endpoint_auth_method: "none",
       })
     );
   });

--- a/packages/node/src/login/oidc/refresh/TokenRefresher.spec.ts
+++ b/packages/node/src/login/oidc/refresh/TokenRefresher.spec.ts
@@ -43,8 +43,10 @@ import {
   mockDefaultIssuerConfig,
   mockIssuerConfigFetcher,
 } from "../__mocks__/IssuerConfigFetcher";
+import { negotiateClientSigningAlg } from "../ClientRegistrar";
 
 jest.mock("openid-client");
+jest.mock("../ClientRegistrar");
 
 const mockJwk = (): JWK => {
   return {
@@ -119,22 +121,17 @@ const mockDpopTokens = (): TokenSet => {
 const setupOidcClientMock = (tokenSet: TokenSet) => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const { Issuer } = jest.requireMock("openid-client") as any;
-  function clientConstructor() {
-    // this is untyped, which makes TS complain
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    this.refresh = jest.fn().mockResolvedValueOnce(tokenSet);
-  }
   const mockedIssuer = {
     metadata: mockDefaultIssuerConfig(),
-    Client: clientConstructor,
+    Client: jest.fn().mockReturnValue({
+      refresh: jest.fn().mockResolvedValueOnce(tokenSet as never),
+    }),
   };
   Issuer.mockReturnValueOnce(mockedIssuer);
+  return mockedIssuer;
 };
 
-const setupDefaultOidcClientMock = () => {
-  setupOidcClientMock(mockDpopTokens());
-};
+const setupDefaultOidcClientMock = () => setupOidcClientMock(mockDpopTokens());
 
 const mockDefaultStorageContent = {
   "solidClientAuthenticationUser:mySession": {
@@ -206,6 +203,12 @@ describe("TokenRefresher", () => {
 
   it("throws if a refresh token isn't provided", async () => {
     setupDefaultOidcClientMock();
+    const mockedModule = jest.requireMock("../ClientRegistrar") as {
+      negotiateClientSigningAlg: typeof negotiateClientSigningAlg;
+    };
+    mockedModule.negotiateClientSigningAlg = jest
+      .fn(negotiateClientSigningAlg)
+      .mockReturnValue("ES256");
     const mockedStorage = mockRefresherDefaultStorageUtility();
 
     const refresher = getTokenRefresher({
@@ -219,6 +222,12 @@ describe("TokenRefresher", () => {
 
   it("throws if a DPoP token is expected, but no DPoP key is provided", async () => {
     setupDefaultOidcClientMock();
+    const mockedModule = jest.requireMock("../ClientRegistrar") as {
+      negotiateClientSigningAlg: typeof negotiateClientSigningAlg;
+    };
+    mockedModule.negotiateClientSigningAlg = jest
+      .fn(negotiateClientSigningAlg)
+      .mockReturnValue("ES256");
     const mockedStorage = mockRefresherDefaultStorageUtility();
 
     const refresher = getTokenRefresher({
@@ -232,10 +241,12 @@ describe("TokenRefresher", () => {
     );
   });
 
-  // FIXME: this test brings coverage to 100%, but has no meaningful expect.
-  // For the time being, it is sufficient, but to be fixed soon.
   it("does not negotiate the signing algorithm if it is already set for the client", async () => {
     setupDefaultOidcClientMock();
+    const mockedModule = jest.requireMock("../ClientRegistrar") as {
+      negotiateClientSigningAlg: typeof negotiateClientSigningAlg;
+    };
+    mockedModule.negotiateClientSigningAlg = jest.fn();
     const refresher = getTokenRefresher({
       storageUtility: mockRefresherDefaultStorageUtility(),
       clientRegistrar: mockClientRegistrar({
@@ -246,13 +257,36 @@ describe("TokenRefresher", () => {
       }),
     });
 
-    const refreshedTokens = await refresher.refresh(
+    await refresher.refresh(
       "mySession",
       "some refresh token",
       await mockKeyPair()
     );
 
-    expect(refreshedTokens.accessToken).toBe(mockDpopTokens().access_token);
+    expect(mockedModule.negotiateClientSigningAlg).not.toHaveBeenCalled();
+  });
+
+  it("uses client_secret_post authentication if using Solid-OIDC client identifiers", async () => {
+    const mockedIssuer = setupDefaultOidcClientMock();
+    const refresher = getTokenRefresher({
+      clientRegistrar: mockClientRegistrar({
+        clientId: "https://some.client.identifier",
+        clientType: "solid-oidc",
+        idTokenSignedResponseAlg: "ES256",
+      }),
+    });
+
+    await refresher.refresh(
+      "mySession",
+      "some refresh token",
+      await mockKeyPair()
+    );
+
+    expect(mockedIssuer.Client).toHaveBeenCalledWith(
+      expect.objectContaining({
+        token_endpoint_auth_method: "client_secret_post",
+      })
+    );
   });
 
   it("refreshes a DPoP token properly", async () => {

--- a/packages/node/src/login/oidc/refresh/TokenRefresher.ts
+++ b/packages/node/src/login/oidc/refresh/TokenRefresher.ts
@@ -41,7 +41,6 @@ import { KeyObject } from "crypto";
 import { EventEmitter } from "events";
 import { configToIssuerMetadata } from "../IssuerConfigFetcher";
 import { negotiateClientSigningAlg } from "../ClientRegistrar";
-import { TMP_ARBITRARY_SECRET } from "../../../constant";
 
 // Some identifiers are not in camelcase on purpose, as they are named using the
 // official names from the OIDC/OAuth2 specifications.
@@ -108,10 +107,10 @@ export default class TokenRefresher implements ITokenRefresher {
     }
     const client = new issuer.Client({
       client_id: clientInfo.clientId,
-      client_secret: clientInfo.clientSecret ?? TMP_ARBITRARY_SECRET,
+      client_secret: clientInfo.clientSecret,
       token_endpoint_auth_method: clientInfo.clientSecret
         ? "client_secret_basic"
-        : "client_secret_post",
+        : "none",
       id_token_signed_response_alg: clientInfo.idTokenSignedResponseAlg,
     });
 

--- a/packages/node/src/login/oidc/refresh/TokenRefresher.ts
+++ b/packages/node/src/login/oidc/refresh/TokenRefresher.ts
@@ -41,6 +41,7 @@ import { KeyObject } from "crypto";
 import { EventEmitter } from "events";
 import { configToIssuerMetadata } from "../IssuerConfigFetcher";
 import { negotiateClientSigningAlg } from "../ClientRegistrar";
+import { TMP_ARBITRARY_SECRET } from "../../../constant";
 
 // Some identifiers are not in camelcase on purpose, as they are named using the
 // official names from the OIDC/OAuth2 specifications.
@@ -107,7 +108,10 @@ export default class TokenRefresher implements ITokenRefresher {
     }
     const client = new issuer.Client({
       client_id: clientInfo.clientId,
-      client_secret: clientInfo.clientSecret,
+      client_secret: clientInfo.clientSecret ?? TMP_ARBITRARY_SECRET,
+      token_endpoint_auth_method: clientInfo.clientSecret
+        ? "client_secret_basic"
+        : "client_secret_post",
       id_token_signed_response_alg: clientInfo.idTokenSignedResponseAlg,
     });
 


### PR DESCRIPTION
This fixes #1767.

When using a Client Identifier as defined in Solid-OIDC, a client does not have a secret. Based on https://datatracker.ietf.org/doc/html/rfc6749#section-2.3.1, it looks like it is acceptable to only provide a client id, but no secret, in the authentication information stored in the body of the request to the token endpoint.

However, this is currently running into an issue with the underlying OIDC library. A conversation is happening at https://github.com/panva/node-openid-client/discussions/430. In the meantime, an arbitrary secret is given to the library, which works around the issue and is ignored by the server.

- [X] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).