### PR TITLE
Expose authenticateHeaders method and helpers for Web workers in browsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased
 
+### New features
+
+#### node and browser
+
+- Expose `Session#authenticateHeaders` method that constructs the necessary headers to perform a given request using
+this session's authentication.
+
+#### browser
+
+- The `WindowToWorkerHandler` and `WorkerToWindowHandler` helpers can be used to setup a communication channel between
+the main window and a Web worker, so that the worker can perform authenticated requests, without any secrets having to
+be shared with this worker. The actual fetch requests still happen within the Web worker for optimal performance.
+
 ### Bugfixes
 
 #### node and browser

--- a/packages/browser/examples/single/bundle/src/App.js
+++ b/packages/browser/examples/single/bundle/src/App.js
@@ -39,6 +39,7 @@ export default function App() {
   const [issuer, setIssuer] = useState("https://broker.pod.inrupt.com/");
   const [resource, setResource] = useState(webId);
   const [data, setData] = useState(null);
+  const worker = new Worker(new URL("./worker.js", import.meta.url));
 
   // The useEffect hook is executed on page load, and in particular when the user
   // is redirected to the page after logging in the identity provider.
@@ -87,6 +88,13 @@ export default function App() {
       .then(setData);
   };
 
+  const handleFetchWorker = (e) => {
+    e.preventDefault();
+
+    worker.postMessage({ resource });
+    worker.onmessage = ({ data: { text } }) => setData(text);
+  };
+
   return (
     <div>
       <main>
@@ -115,6 +123,9 @@ export default function App() {
             }}
           />
           <button onClick={(e) => handleFetch(e)}>Fetch</button>
+          <button onClick={(e) => handleFetchWorker(e)}>
+            Fetch with Web Worker
+          </button>
         </div>
         <pre>{data}</pre>
       </main>

--- a/packages/browser/examples/single/bundle/src/App.js
+++ b/packages/browser/examples/single/bundle/src/App.js
@@ -91,8 +91,22 @@ export default function App() {
   const handleFetchWorker = (e) => {
     e.preventDefault();
 
+    const session = getDefaultSession();
+
     worker.postMessage({ resource });
-    worker.onmessage = ({ data: { text } }) => setData(text);
+    worker.onmessage = async ({ data }) => {
+      if (data.text) {
+        setData(data.text);
+      } else if (data.headersRaw) {
+        const headersUnauthenticated = new Headers(data.headersRaw);
+        const headersAuthenticated = await session.authenticateHeaders(
+          data.resource,
+          data.method,
+          headersUnauthenticated
+        );
+        worker.postMessage({ headersRaw: [...headersAuthenticated.entries()] });
+      }
+    };
   };
 
   return (

--- a/packages/browser/examples/single/bundle/src/App.js
+++ b/packages/browser/examples/single/bundle/src/App.js
@@ -28,6 +28,7 @@ import {
   handleIncomingRedirect,
   fetch,
   getDefaultSession,
+  WindowToWorkerHandler,
 } from "../../../../dist/index";
 
 const REDIRECT_URL = "http://localhost:3113/";
@@ -93,18 +94,18 @@ export default function App() {
 
     const session = getDefaultSession();
 
+    // Setup worker communication
+    const windowToWorkerHandler = new WindowToWorkerHandler(
+      this,
+      worker,
+      session
+    );
     worker.postMessage({ resource });
-    worker.onmessage = async ({ data }) => {
-      if (data.text) {
-        setData(data.text);
-      } else if (data.headersRaw) {
-        const headersUnauthenticated = new Headers(data.headersRaw);
-        const headersAuthenticated = await session.authenticateHeaders(
-          data.resource,
-          data.method,
-          headersUnauthenticated
-        );
-        worker.postMessage({ headersRaw: [...headersAuthenticated.entries()] });
+    worker.onmessage = async (message) => {
+      if (windowToWorkerHandler.onmessage(message)) {
+        // This means that the message was taken care of by the handler
+      } else if (message.data.text) {
+        setData(message.data.text);
       }
     };
   };

--- a/packages/browser/examples/single/bundle/src/worker.js
+++ b/packages/browser/examples/single/bundle/src/worker.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2021 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+self.onmessage = ({ data: { resource } }) => {
+  fetch(resource, { headers: new Headers({ Accept: "text/turtle" }) })
+    .then((response) => response.text())
+    .catch((error) => self.postMessage({ text: error.message }))
+    .then((text) => self.postMessage({ text }));
+};

--- a/packages/browser/src/ClientAuthentication.spec.ts
+++ b/packages/browser/src/ClientAuthentication.spec.ts
@@ -262,6 +262,19 @@ describe("ClientAuthentication", () => {
     });
   });
 
+  describe("headersAuthenticator", () => {
+    it("rejects", async () => {
+      const clientAuthn = getClientAuthentication();
+      await expect(
+        clientAuthn.headersAuthenticator(
+          "https://html5zombo.com",
+          "GET",
+          new Headers()
+        )
+      ).rejects.toThrow("headersAuthenticator is not initialized yet");
+    });
+  });
+
   describe("logout", () => {
     const mockEmitter = new EventEmitter();
 
@@ -290,6 +303,32 @@ describe("ClientAuthentication", () => {
       expect(spyFetch).toHaveBeenCalledWith("https://example.com", {
         credentials: "omit",
       });
+    });
+
+    it("reverts back to un-authenticated headersAuthenticator on logout", async () => {
+      const clientAuthn = getClientAuthentication();
+
+      const unauthHeadersAuthenticator = clientAuthn.headersAuthenticator;
+
+      const url =
+        "https://coolapp.com/redirect?state=userId&id_token=idToken&access_token=accessToken";
+      await clientAuthn.handleIncomingRedirect(url, mockEmitter);
+
+      // Calling the redirect handler should give us an authenticated fetch.
+      expect(clientAuthn.headersAuthenticator).not.toBe(
+        unauthHeadersAuthenticator
+      );
+
+      await clientAuthn.logout("mySession");
+      await expect(
+        clientAuthn.headersAuthenticator(
+          "https://example.com",
+          "GET",
+          new Headers()
+        )
+      ).rejects.toThrow("headersAuthenticator is not initialized yet");
+      // Calling logout should revert back to our un-authenticated headersAuthenticator.
+      expect(clientAuthn.headersAuthenticator).toBe(unauthHeadersAuthenticator);
     });
   });
 
@@ -337,6 +376,7 @@ describe("ClientAuthentication", () => {
       history.replaceState = jest.fn();
       const clientAuthn = getClientAuthentication();
       const unauthFetch = clientAuthn.fetch;
+      const unauthHeadersAuthenticator = clientAuthn.headersAuthenticator;
       const url =
         "https://coolapp.com/redirect?state=userId&id_token=idToken&access_token=accessToken";
       const redirectInfo = await clientAuthn.handleIncomingRedirect(
@@ -364,8 +404,11 @@ describe("ClientAuthentication", () => {
         mockEmitter
       );
 
-      // Calling the redirect handler should have updated the fetch.
+      // Calling the redirect handler should have updated the fetch and headersAuthenticator.
       expect(clientAuthn.fetch).not.toBe(unauthFetch);
+      expect(clientAuthn.headersAuthenticator).not.toBe(
+        unauthHeadersAuthenticator
+      );
     });
 
     it("clears the current IRI from OAuth query parameters in the auth code flow", async () => {

--- a/packages/browser/src/ClientAuthentication.ts
+++ b/packages/browser/src/ClientAuthentication.ts
@@ -34,6 +34,7 @@ import {
   ISessionInternalInfo,
   ILoginOptions,
   fetchJwks,
+  HeadersAuthenticator,
 } from "@inrupt/solid-client-authn-core";
 import { removeOidcQueryParam } from "@inrupt/oidc-client-ext";
 import { jwtVerify, parseJwk } from "@inrupt/jose-legacy-modules";
@@ -45,6 +46,9 @@ import { KEY_CURRENT_SESSION } from "./constant";
 // ClientAuthentication:
 const globalFetch: typeof window.fetch = (request, init) =>
   window.fetch(request, init);
+
+const headersAuthenticatorDefault: HeadersAuthenticator = () =>
+  Promise.reject(new Error("headersAuthenticator is not initialized yet"));
 
 /**
  * @hidden
@@ -91,12 +95,16 @@ export default class ClientAuthentication {
   // By default, our fetch() resolves to the environment fetch() function.
   fetch = globalFetch;
 
+  // Headers for auxiliary fetching
+  headersAuthenticator: HeadersAuthenticator = headersAuthenticatorDefault;
+
   logout = async (sessionId: string): Promise<void> => {
     await this.logoutHandler.handle(sessionId);
 
     // Restore our fetch() function back to the environment fetch(), effectively
     // leaving us with un-authenticated fetches from now on.
     this.fetch = globalFetch;
+    this.headersAuthenticator = headersAuthenticatorDefault;
   };
 
   getSessionInfo = async (
@@ -157,6 +165,7 @@ export default class ClientAuthentication {
     // ClientAuthentication, to avoid the following error:
     // > 'fetch' called on an object that does not implement interface Window.
     this.fetch = redirectInfo.fetch.bind(window);
+    this.headersAuthenticator = redirectInfo.headersAuthenticator;
 
     const cleanedUpUrl = new URL(url);
     cleanedUpUrl.searchParams.delete("state");

--- a/packages/browser/src/Session.spec.ts
+++ b/packages/browser/src/Session.spec.ts
@@ -71,19 +71,19 @@ describe("Session", () => {
   describe("constructor", () => {
     it("accepts an empty config", async () => {
       const mySession = new Session({});
-      expect(mySession.info.isLoggedIn).toEqual(false);
+      expect(mySession.info.isLoggedIn).toBe(false);
       expect(mySession.info.sessionId).toBeDefined();
     });
 
     it("accepts no config", async () => {
       const mySession = new Session();
-      expect(mySession.info.isLoggedIn).toEqual(false);
+      expect(mySession.info.isLoggedIn).toBe(false);
       expect(mySession.info.sessionId).toBeDefined();
     });
 
     it("does not generate a session ID if one is provided", () => {
       const mySession = new Session({}, "mySession");
-      expect(mySession.info.sessionId).toEqual("mySession");
+      expect(mySession.info.sessionId).toBe("mySession");
     });
 
     it("accepts input storage", async () => {
@@ -108,9 +108,9 @@ describe("Session", () => {
           webId: "https://some.webid",
         },
       });
-      expect(mySession.info.isLoggedIn).toEqual(false);
-      expect(mySession.info.sessionId).toEqual("mySession");
-      expect(mySession.info.webId).toEqual("https://some.webid");
+      expect(mySession.info.isLoggedIn).toBe(false);
+      expect(mySession.info.sessionId).toBe("mySession");
+      expect(mySession.info.webId).toBe("https://some.webid");
     });
   });
 
@@ -184,7 +184,7 @@ describe("Session", () => {
       const mySession = new Session({ clientAuthentication });
       mySession.info.isLoggedIn = true;
       await mySession.logout();
-      expect(mySession.info.isLoggedIn).toEqual(false);
+      expect(mySession.info.isLoggedIn).toBe(false);
     });
   });
 
@@ -263,11 +263,11 @@ describe("Session", () => {
         }
       );
       const mySession = new Session({ clientAuthentication });
-      expect(mySession.info.isLoggedIn).toEqual(false);
+      expect(mySession.info.isLoggedIn).toBe(false);
       await mySession.handleIncomingRedirect("https://some.url");
-      expect(mySession.info.isLoggedIn).toEqual(true);
-      expect(mySession.info.sessionId).toEqual("a session ID");
-      expect(mySession.info.webId).toEqual("https://some.webid#them");
+      expect(mySession.info.isLoggedIn).toBe(true);
+      expect(mySession.info.sessionId).toBe("a session ID");
+      expect(mySession.info.webId).toBe("https://some.webid#them");
     });
 
     it("directly returns the session's info if already logged in", async () => {
@@ -283,7 +283,7 @@ describe("Session", () => {
       );
       const mySession = new Session({ clientAuthentication });
       await mySession.handleIncomingRedirect("https://some.url");
-      expect(mySession.info.isLoggedIn).toEqual(true);
+      expect(mySession.info.isLoggedIn).toBe(true);
       await mySession.handleIncomingRedirect("https://some.url");
       // The second request should not hit the wrapped function
       expect(clientAuthentication.handleIncomingRedirect).toHaveBeenCalledTimes(
@@ -321,8 +321,8 @@ describe("Session", () => {
       );
       const mySession = new Session({ clientAuthentication }, "mySession");
       await mySession.handleIncomingRedirect("https://some.url");
-      expect(mySession.info.isLoggedIn).toEqual(false);
-      expect(mySession.info.sessionId).toEqual("mySession");
+      expect(mySession.info.isLoggedIn).toBe(false);
+      expect(mySession.info.sessionId).toBe("mySession");
     });
 
     it("prevents from hitting the token endpoint twice with the same auth code", async () => {
@@ -390,7 +390,7 @@ describe("Session", () => {
           url: "https://some.url",
           useEssSession: true,
         });
-        expect(mySession.info.isLoggedIn).toEqual(false);
+        expect(mySession.info.isLoggedIn).toBe(false);
         expect(mySession.info.webId).toBeUndefined();
         expect(
           clientAuthentication.handleIncomingRedirect
@@ -398,7 +398,7 @@ describe("Session", () => {
         // The workaround should be enabled by default
         expect(
           window.localStorage.getItem("tmp-resource-server-session-enabled")
-        ).toEqual("true");
+        ).toBe("true");
       });
 
       it("re-initialises the user's WebID without redirection if the proper cookie is set", async () => {
@@ -417,15 +417,15 @@ describe("Session", () => {
           url: "https://some.url",
           useEssSession: true,
         });
-        expect(mySession.info.isLoggedIn).toEqual(true);
-        expect(mySession.info.webId).toEqual("https://my.pod/profile#me");
+        expect(mySession.info.isLoggedIn).toBe(true);
+        expect(mySession.info.webId).toBe("https://my.pod/profile#me");
         expect(
           clientAuthentication.handleIncomingRedirect
         ).toHaveBeenCalledTimes(0);
         // The workaround should be enabled by default
         expect(
           window.localStorage.getItem("tmp-resource-server-session-enabled")
-        ).toEqual("true");
+        ).toBe("true");
       });
 
       it("does not attempt to use the workaround if the long-term solution (silent refresh) is enabled", async () => {
@@ -451,7 +451,7 @@ describe("Session", () => {
         ).toHaveBeenCalledTimes(1);
         expect(
           window.localStorage.getItem("tmp-resource-server-session-enabled")
-        ).toEqual("false");
+        ).toBe("false");
       });
 
       it("overrides the workaround if both silent refresh and the ESS session are enabled", async () => {
@@ -478,7 +478,7 @@ describe("Session", () => {
         ).toHaveBeenCalledTimes(1);
         expect(
           window.localStorage.getItem("tmp-resource-server-session-enabled")
-        ).toEqual("false");
+        ).toBe("false");
       });
 
       it("does not attempt to use the workaround if it is not explicitly enabled", async () => {
@@ -503,7 +503,7 @@ describe("Session", () => {
         ).toHaveBeenCalledTimes(1);
         expect(
           window.localStorage.getItem("tmp-resource-server-session-enabled")
-        ).toEqual("false");
+        ).toBe("false");
       });
 
       it("does not attempt to use the workaround if it is explicitly disabled", async () => {
@@ -529,7 +529,7 @@ describe("Session", () => {
         ).toHaveBeenCalledTimes(1);
         expect(
           window.localStorage.getItem("tmp-resource-server-session-enabled")
-        ).toEqual("false");
+        ).toBe("false");
       });
 
       it("does not mark an almost-expired session as logged in", async () => {
@@ -549,7 +549,7 @@ describe("Session", () => {
           url: "https://some.url",
           useEssSession: true,
         });
-        expect(mySession.info.isLoggedIn).toEqual(false);
+        expect(mySession.info.isLoggedIn).toBe(false);
         expect(mySession.info.webId).toBeUndefined();
         expect(
           clientAuthentication.handleIncomingRedirect
@@ -572,8 +572,8 @@ describe("Session", () => {
           url: "https://some.url",
           useEssSession: true,
         });
-        expect(mySession.info.isLoggedIn).toEqual(true);
-        expect(mySession.info.webId).toEqual("https://my.pod/profile#me");
+        expect(mySession.info.isLoggedIn).toBe(true);
+        expect(mySession.info.webId).toBe("https://my.pod/profile#me");
         expect(
           clientAuthentication.handleIncomingRedirect
         ).toHaveBeenCalledTimes(0);
@@ -593,7 +593,7 @@ describe("Session", () => {
           url: "https://some.url",
           useEssSession: true,
         });
-        expect(mySession.info.isLoggedIn).toEqual(false);
+        expect(mySession.info.isLoggedIn).toBe(false);
         expect(mySession.info.webId).toBeUndefined();
         expect(
           clientAuthentication.handleIncomingRedirect
@@ -701,7 +701,7 @@ describe("Session", () => {
       });
       await incomingRedirectPromise;
       await validateCurrentSessionPromise;
-      expect(window.localStorage.getItem(KEY_CURRENT_URL)).toEqual(
+      expect(window.localStorage.getItem(KEY_CURRENT_URL)).toBe(
         "https://mock.current/location"
       );
     });

--- a/packages/browser/src/Session.spec.ts
+++ b/packages/browser/src/Session.spec.ts
@@ -222,6 +222,22 @@ describe("Session", () => {
     });
   });
 
+  describe("authenticateHeaders", () => {
+    it("wraps up ClientAuthentication fetch if logged in", async () => {
+      const clientAuthentication = mockClientAuthentication();
+      const clientAuthnHeadersAuthenticator = jest.spyOn(
+        clientAuthentication,
+        "headersAuthenticator"
+      );
+      const mySession = new Session({ clientAuthentication });
+      mySession.info.isLoggedIn = true;
+      await expect(
+        mySession.authenticateHeaders("https://some.url", "GET", new Headers())
+      ).rejects.toThrow("headersAuthenticator is not initialized yet");
+      expect(clientAuthnHeadersAuthenticator).toHaveBeenCalled();
+    });
+  });
+
   describe("handleIncomingRedirect", () => {
     it("uses current window location as default redirect URL", async () => {
       mockLocation("https://some.url");

--- a/packages/browser/src/Session.ts
+++ b/packages/browser/src/Session.ts
@@ -274,6 +274,25 @@ export class Session extends EventEmitter {
   };
 
   /**
+   * Provides the necessary headers to perform the given request using this
+   * session's authentication.
+   * @param resource The resource URL to request.
+   * @param method The request method.
+   * @param headersUnauthenticated The headers for the request.
+   */
+  authenticateHeaders = (
+    resource: string,
+    method: string,
+    headersUnauthenticated: Headers
+  ): Promise<Headers> => {
+    return this.clientAuthentication.headersAuthenticator(
+      resource,
+      method,
+      headersUnauthenticated
+    );
+  };
+
+  /**
    * Logs the user out of the application. This does not log the user out of their Solid identity provider, and should not redirect the user away.
    */
   logout = async (): Promise<void> => {

--- a/packages/browser/src/iframe.spec.ts
+++ b/packages/browser/src/iframe.spec.ts
@@ -34,7 +34,7 @@ describe("redirectInIframe", () => {
 
     // This verifies that the iframe has been added to the DOM, i.e. that
     // window.document.body.appendChild has been called.
-    expect(iframe).not.toBeUndefined();
+    expect(iframe).toBeDefined();
 
     // The iframe has the appropriate attributes.
     expect(iframe.getAttribute("hidden")).toBe("true");
@@ -161,7 +161,7 @@ describe("setupIframeListener", () => {
     setupDom(true, true);
     setupIframeListener(callback as any);
 
-    expect(document.getElementsByTagName("iframe")[0]).not.toBeUndefined();
+    expect(document.getElementsByTagName("iframe")[0]).toBeDefined();
 
     window.postMessage(
       {

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -25,6 +25,9 @@ export { getClientAuthenticationWithDependencies } from "./dependencies";
 
 export * from "./defaultSession";
 
+export * from "./util/worker/WindowToWorkerHandler";
+export * from "./util/worker/WorkerToWindowHandler";
+
 // Re-export of types defined in the core module and produced/consumed by our API
 
 export {

--- a/packages/browser/src/login/oidc/ClientRegistrar.spec.ts
+++ b/packages/browser/src/login/oidc/ClientRegistrar.spec.ts
@@ -191,8 +191,8 @@ describe("ClientRegistrar", () => {
           ...IssuerConfigFetcherFetchConfigResponse,
         }
       );
-      expect(client.clientId).toEqual("an id");
-      expect(client.clientSecret).toEqual("a secret");
+      expect(client.clientId).toBe("an id");
+      expect(client.clientSecret).toBe("a secret");
     });
 
     it("passes the registration token if provided", async () => {
@@ -229,7 +229,7 @@ describe("ClientRegistrar", () => {
         string,
         string
       >;
-      expect(registrationHeaders.Authorization).toEqual("Bearer some token");
+      expect(registrationHeaders.Authorization).toBe("Bearer some token");
     });
 
     it("retrieves the registration token from storage if present", async () => {
@@ -272,7 +272,7 @@ describe("ClientRegistrar", () => {
         string,
         string
       >;
-      expect(registrationHeaders.Authorization).toEqual("Bearer some token");
+      expect(registrationHeaders.Authorization).toBe("Bearer some token");
     });
 
     it("saves dynamic registration information", async () => {
@@ -307,10 +307,10 @@ describe("ClientRegistrar", () => {
 
       await expect(
         myStorage.getForUser("mySession", "clientId", { secure: false })
-      ).resolves.toEqual("some id");
+      ).resolves.toBe("some id");
       await expect(
         myStorage.getForUser("mySession", "clientSecret", { secure: false })
-      ).resolves.toEqual("some secret");
+      ).resolves.toBe("some secret");
     });
   });
 });

--- a/packages/browser/src/login/oidc/OidcLoginHandler.spec.ts
+++ b/packages/browser/src/login/oidc/OidcLoginHandler.spec.ts
@@ -98,7 +98,7 @@ describe("OidcLoginHandler", () => {
     expect(actualHandler.handle.mock.calls).toHaveLength(1);
 
     const calledWith = actualHandler.handle.mock.calls[0][0];
-    expect(calledWith.client.clientId).toEqual("some client ID");
+    expect(calledWith.client.clientId).toBe("some client ID");
   });
 
   it("should lookup client ID if not provided, if not found do DCR", async () => {
@@ -164,9 +164,7 @@ describe("OidcLoginHandler", () => {
     });
 
     const calledWith = actualHandler.handle.mock.calls[0][0];
-    expect(calledWith.client.clientId).toEqual(
-      "some dynamically registered ID"
-    );
+    expect(calledWith.client.clientId).toBe("some dynamically registered ID");
   });
 
   it("should save statically registered client ID if given one as an input option", async () => {
@@ -221,7 +219,7 @@ describe("OidcLoginHandler", () => {
       "mySession",
       "clientId"
     );
-    expect(storedClientId).toEqual("https://my.app/registration#app");
+    expect(storedClientId).toBe("https://my.app/registration#app");
   });
 
   it("should save client ID, secret and name if given as input options", async () => {

--- a/packages/browser/src/login/oidc/oidcHandlers/AuthorizationCodeWithPkceOidcHandler.spec.ts
+++ b/packages/browser/src/login/oidc/oidcHandlers/AuthorizationCodeWithPkceOidcHandler.spec.ts
@@ -162,7 +162,7 @@ describe("AuthorizationCodeWithPkceOidcHandler", () => {
         mockedStorage.getForUser("mySession", "redirectUrl", {
           secure: false,
         })
-      ).resolves.toStrictEqual("https://app.example.com?someQuery=someValue");
+      ).resolves.toBe("https://app.example.com?someQuery=someValue");
       await expect(
         mockedStorage.getForUser("mySession", "codeVerifier", {
           secure: false,

--- a/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
+++ b/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
@@ -455,16 +455,14 @@ describe("AuthCodeRedirectHandler", () => {
       );
       // Check that the current session is stored correctly __specifically__ in
       // 'localStorage'.
-      expect(window.localStorage.getItem(KEY_CURRENT_SESSION)).toEqual(
+      expect(window.localStorage.getItem(KEY_CURRENT_SESSION)).toBe(
         "mySession"
       );
       await expect(
         mockedStorage.getForUser("mySession", "redirectUrl", {
           secure: false,
         })
-      ).resolves.toStrictEqual(
-        "https://coolsite.com/redirect?state=oauth2StateValue"
-      );
+      ).resolves.toBe("https://coolsite.com/redirect?state=oauth2StateValue");
     });
 
     it("preserves any query strings from the redirect URI", async () => {
@@ -506,7 +504,7 @@ describe("AuthCodeRedirectHandler", () => {
         mockedStorage.getForUser("mySession", "redirectUrl", {
           secure: false,
         })
-      ).resolves.toStrictEqual(
+      ).resolves.toBe(
         "https://coolsite.com/redirect?state=oauth2StateValue&someKey=someValue"
       );
     });

--- a/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
+++ b/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
@@ -26,6 +26,7 @@
 
 import {
   buildAuthenticatedFetch,
+  buildHeadersAuthenticator,
   IClient,
   IClientRegistrar,
   IIssuerConfigFetcher,
@@ -35,6 +36,7 @@ import {
   IStorageUtility,
   ITokenRefresher,
   RefreshOptions,
+  HeadersAuthenticator,
 } from "@inrupt/solid-client-authn-core";
 import {
   getDpopToken,
@@ -129,7 +131,12 @@ export class AuthCodeRedirectHandler implements IRedirectHandler {
   async handle(
     redirectUrl: string,
     eventEmitter?: EventEmitter
-  ): Promise<ISessionInfo & { fetch: typeof fetch }> {
+  ): Promise<
+    ISessionInfo & {
+      fetch: typeof fetch;
+      headersAuthenticator: HeadersAuthenticator;
+    }
+  > {
     if (!(await this.canHandle(redirectUrl))) {
       throw new Error(
         `AuthCodeRedirectHandler cannot handle [${redirectUrl}]: it is missing one of [code, state].`
@@ -211,6 +218,12 @@ export class AuthCodeRedirectHandler implements IRedirectHandler {
       eventEmitter,
       expiresIn: tokens.expiresIn,
     });
+    const headersAuthenticator = await buildHeadersAuthenticator(
+      tokens.accessToken,
+      {
+        dpopKey: tokens.dpopKey,
+      }
+    );
 
     await this.storageUtility.setForUser(
       storedSessionId,
@@ -258,6 +271,7 @@ export class AuthCodeRedirectHandler implements IRedirectHandler {
 
     return Object.assign(sessionInfo, {
       fetch: authFetch,
+      headersAuthenticator,
       expirationDate:
         typeof tokens.expiresIn === "number"
           ? referenceTime + tokens.expiresIn * 1000

--- a/packages/browser/src/login/oidc/redirectHandler/ErrorOidcHandler.spec.ts
+++ b/packages/browser/src/login/oidc/redirectHandler/ErrorOidcHandler.spec.ts
@@ -65,7 +65,7 @@ describe("ErrorOidcHandler", () => {
       window.fetch = jest.fn();
       const redirectHandler = new ErrorOidcHandler();
       const mySession = await redirectHandler.handle("https://my.app");
-      expect(mySession.isLoggedIn).toEqual(false);
+      expect(mySession.isLoggedIn).toBe(false);
       expect(mySession.webId).toBeUndefined();
     });
     it("calls the onError callback if given with both parameters", async () => {
@@ -78,7 +78,7 @@ describe("ErrorOidcHandler", () => {
         "https://coolparty.com/?error=error&error_description=unable_to_fetch",
         mockEmitter
       );
-      expect(mySession.isLoggedIn).toEqual(false);
+      expect(mySession.isLoggedIn).toBe(false);
       expect(mySession.webId).toBeUndefined();
       expect(mockEmit).toHaveBeenCalledWith(
         EVENTS.ERROR,
@@ -97,7 +97,7 @@ describe("ErrorOidcHandler", () => {
         "https://coolparty.com/?error=error",
         mockEmitter
       );
-      expect(mySession.isLoggedIn).toEqual(false);
+      expect(mySession.isLoggedIn).toBe(false);
       expect(mySession.webId).toBeUndefined();
       expect(mockEmit).toHaveBeenCalledWith(EVENTS.ERROR, "error", null);
     });

--- a/packages/browser/src/login/oidc/redirectHandler/ErrorOidcHandler.spec.ts
+++ b/packages/browser/src/login/oidc/redirectHandler/ErrorOidcHandler.spec.ts
@@ -67,6 +67,9 @@ describe("ErrorOidcHandler", () => {
       const mySession = await redirectHandler.handle("https://my.app");
       expect(mySession.isLoggedIn).toBe(false);
       expect(mySession.webId).toBeUndefined();
+      expect(
+        await mySession.headersAuthenticator("A", "GET", new Headers())
+      ).toEqual(new Headers());
     });
     it("calls the onError callback if given with both parameters", async () => {
       window.fetch = jest.fn();

--- a/packages/browser/src/login/oidc/redirectHandler/ErrorOidcHandler.ts
+++ b/packages/browser/src/login/oidc/redirectHandler/ErrorOidcHandler.ts
@@ -28,6 +28,7 @@ import {
   EVENTS,
   IRedirectHandler,
   ISessionInfo,
+  HeadersAuthenticator,
 } from "@inrupt/solid-client-authn-core";
 import type { EventEmitter } from "events";
 
@@ -54,7 +55,12 @@ export class ErrorOidcHandler implements IRedirectHandler {
   async handle(
     redirectUrl: string,
     eventEmitter?: EventEmitter
-  ): Promise<ISessionInfo & { fetch: typeof fetch }> {
+  ): Promise<
+    ISessionInfo & {
+      fetch: typeof fetch;
+      headersAuthenticator: HeadersAuthenticator;
+    }
+  > {
     if (eventEmitter !== undefined) {
       const url = new URL(redirectUrl);
       const errorUrl = url.searchParams.get("error");

--- a/packages/browser/src/login/oidc/redirectHandler/FallbackRedirectHandler.spec.ts
+++ b/packages/browser/src/login/oidc/redirectHandler/FallbackRedirectHandler.spec.ts
@@ -54,7 +54,7 @@ describe("FallbackRedirectHandler", () => {
       window.fetch = jest.fn();
       const redirectHandler = new FallbackRedirectHandler();
       const mySession = await redirectHandler.handle("https://my.app");
-      expect(mySession.isLoggedIn).toEqual(false);
+      expect(mySession.isLoggedIn).toBe(false);
       expect(mySession.webId).toBeUndefined();
     });
   });

--- a/packages/browser/src/login/oidc/redirectHandler/FallbackRedirectHandler.spec.ts
+++ b/packages/browser/src/login/oidc/redirectHandler/FallbackRedirectHandler.spec.ts
@@ -56,6 +56,9 @@ describe("FallbackRedirectHandler", () => {
       const mySession = await redirectHandler.handle("https://my.app");
       expect(mySession.isLoggedIn).toBe(false);
       expect(mySession.webId).toBeUndefined();
+      expect(
+        await mySession.headersAuthenticator("A", "GET", new Headers())
+      ).toEqual(new Headers());
     });
   });
 });

--- a/packages/browser/src/login/oidc/redirectHandler/FallbackRedirectHandler.ts
+++ b/packages/browser/src/login/oidc/redirectHandler/FallbackRedirectHandler.ts
@@ -27,6 +27,7 @@
 import {
   IRedirectHandler,
   ISessionInfo,
+  HeadersAuthenticator,
 } from "@inrupt/solid-client-authn-core";
 
 import { getUnauthenticatedSession } from "../../../sessionInfo/SessionInfoManager";
@@ -54,7 +55,12 @@ export class FallbackRedirectHandler implements IRedirectHandler {
   async handle(
     // The argument is ignored, but must be present to implement the interface
     _redirectUrl: string
-  ): Promise<ISessionInfo & { fetch: typeof fetch }> {
+  ): Promise<
+    ISessionInfo & {
+      fetch: typeof fetch;
+      headersAuthenticator: HeadersAuthenticator;
+    }
+  > {
     return getUnauthenticatedSession();
   }
 }

--- a/packages/browser/src/sessionInfo/SessionInfoManager.ts
+++ b/packages/browser/src/sessionInfo/SessionInfoManager.ts
@@ -31,17 +31,24 @@ import {
   ISessionInfoManagerOptions,
   IStorageUtility,
   isSupportedTokenType,
+  HeadersAuthenticator,
 } from "@inrupt/solid-client-authn-core";
 import { v4 } from "uuid";
 import { clearOidcPersistentStorage } from "@inrupt/oidc-client-ext";
 
 export function getUnauthenticatedSession(): ISessionInfo & {
   fetch: typeof fetch;
+  headersAuthenticator: HeadersAuthenticator;
 } {
   return {
     isLoggedIn: false,
     sessionId: v4(),
     fetch,
+    headersAuthenticator: async (
+      resource: string,
+      method: string,
+      headers: Headers
+    ) => headers,
   };
 }
 

--- a/packages/browser/src/util/urlPath.spec.ts
+++ b/packages/browser/src/util/urlPath.spec.ts
@@ -23,31 +23,31 @@ import { appendToUrlPathname } from "./urlPath";
 
 describe("urlPath", () => {
   it("should remove one slash if empty path", () => {
-    expect(appendToUrlPathname("https://ex.com/", "/test")).toEqual(
+    expect(appendToUrlPathname("https://ex.com/", "/test")).toBe(
       "https://ex.com/test"
     );
 
     expect(
       appendToUrlPathname("https://ex.com/", "////only-remove-one-slash")
-    ).toEqual("https://ex.com////only-remove-one-slash");
+    ).toBe("https://ex.com////only-remove-one-slash");
   });
 
   it("should remove one slash if non-empty path", () => {
-    expect(appendToUrlPathname("https://ex.com/a/", "/test")).toEqual(
+    expect(appendToUrlPathname("https://ex.com/a/", "/test")).toBe(
       "https://ex.com/a/test"
     );
 
     expect(
       appendToUrlPathname("https://ex.com/a/", "////only-remove-one-slash")
-    ).toEqual("https://ex.com/a////only-remove-one-slash");
+    ).toBe("https://ex.com/a////only-remove-one-slash");
   });
 
   it("should add a slash before appending slash", () => {
-    expect(appendToUrlPathname("https://ex.com", "test")).toEqual(
+    expect(appendToUrlPathname("https://ex.com", "test")).toBe(
       "https://ex.com/test"
     );
 
-    expect(appendToUrlPathname("https://ex.com/a", "test")).toEqual(
+    expect(appendToUrlPathname("https://ex.com/a", "test")).toBe(
       "https://ex.com/a/test"
     );
   });

--- a/packages/browser/src/util/worker/WindowToWorkerHandler.spec.ts
+++ b/packages/browser/src/util/worker/WindowToWorkerHandler.spec.ts
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2021 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { jest } from "@jest/globals";
+import { WorkerToWindowHandler } from "./WorkerToWindowHandler";
+import type { Session } from "../../Session";
+import { WindowToWorkerHandler } from "./WindowToWorkerHandler";
+
+describe("WindowToWorkerHandler", () => {
+  let windowSelf: Window;
+  let worker: Worker;
+  let session: Session;
+  let handler: WindowToWorkerHandler;
+  beforeEach(() => {
+    windowSelf = <any>{};
+    worker = <any>{
+      postMessage: jest.fn(),
+    };
+    session = <any>{
+      authenticateHeaders: jest.fn(
+        async (
+          resource: string,
+          method: string,
+          headersUnauthenticated: Headers
+        ) => {
+          const authHeaders = new Headers(headersUnauthenticated);
+          authHeaders.set("Authenticated", "true");
+          return authHeaders;
+        }
+      ),
+    };
+    handler = new WindowToWorkerHandler(windowSelf, worker, session);
+  });
+
+  describe("onmessage", () => {
+    it("should ignore unknown literal messages", () => {
+      expect(
+        handler.onmessage(<any>{
+          data: "dummy",
+        })
+      ).toBe(false);
+
+      expect(session.authenticateHeaders).not.toHaveBeenCalled();
+      expect(worker.postMessage).not.toHaveBeenCalled();
+    });
+
+    it("should ignore unknown object messages", () => {
+      expect(
+        handler.onmessage(<any>{
+          data: { a: "dummy" },
+        })
+      ).toBe(false);
+
+      expect(session.authenticateHeaders).not.toHaveBeenCalled();
+      expect(worker.postMessage).not.toHaveBeenCalled();
+    });
+
+    it("should handle valid auth messages", async () => {
+      expect(
+        handler.onmessage(<any>{
+          data: {
+            [WorkerToWindowHandler.MESSAGE_KEY_POST]: {
+              messageId: 10,
+              resource: "URL",
+              method: "GET",
+              headersUnauthenticatedRaw: [["Accept", "text/turtle"]],
+            },
+          },
+        })
+      ).toBe(true);
+
+      // Wait a tick for the job to resolve
+      await new Promise(setImmediate);
+
+      expect(session.authenticateHeaders).toHaveBeenCalledWith(
+        "URL",
+        "GET",
+        new Headers({
+          Accept: "text/turtle",
+        })
+      );
+      expect(worker.postMessage).toHaveBeenCalledWith({
+        [WorkerToWindowHandler.MESSAGE_KEY_RESPONSE]: {
+          messageId: 10,
+          headersAuthenticatedRaw: [
+            ["accept", "text/turtle"],
+            ["authenticated", "true"],
+          ],
+        },
+      });
+    });
+
+    it("should handle valid auth messages that produce an error", async () => {
+      session.authenticateHeaders = jest.fn(() =>
+        Promise.reject(new Error("Auth headers rejection"))
+      );
+      expect(
+        handler.onmessage(<any>{
+          data: {
+            [WorkerToWindowHandler.MESSAGE_KEY_POST]: {
+              messageId: 10,
+              resource: "URL",
+              method: "GET",
+              headersUnauthenticatedRaw: [["Accept", "text/turtle"]],
+            },
+          },
+        })
+      ).toBe(true);
+
+      // Wait a tick for the job to resolve
+      await new Promise(setImmediate);
+
+      expect(session.authenticateHeaders).toHaveBeenCalledWith(
+        "URL",
+        "GET",
+        new Headers({
+          Accept: "text/turtle",
+        })
+      );
+      expect(worker.postMessage).toHaveBeenCalledWith({
+        [WorkerToWindowHandler.MESSAGE_KEY_RESPONSE]: {
+          messageId: 10,
+          errorMessage: "Auth headers rejection",
+        },
+      });
+    });
+  });
+});

--- a/packages/browser/src/util/worker/WindowToWorkerHandler.ts
+++ b/packages/browser/src/util/worker/WindowToWorkerHandler.ts
@@ -60,7 +60,10 @@ export class WindowToWorkerHandler {
    * @return True if the message was meant for this handler, false otherwise.
    */
   public onmessage(messageEvent: MessageEvent): boolean {
-    if (WorkerToWindowHandler.MESSAGE_KEY_POST in messageEvent.data) {
+    if (
+      typeof messageEvent.data === "object" &&
+      WorkerToWindowHandler.MESSAGE_KEY_POST in messageEvent.data
+    ) {
       // Authenticate headers from incoming message
       const message: IWorkerMessagePost =
         messageEvent.data[WorkerToWindowHandler.MESSAGE_KEY_POST];

--- a/packages/browser/src/util/worker/WindowToWorkerHandler.ts
+++ b/packages/browser/src/util/worker/WindowToWorkerHandler.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2021 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { Session } from "../..";
+import {
+  WorkerToWindowHandler,
+  IWorkerMessagePost,
+  IWorkerMessageResponse,
+} from "./WorkerToWindowHandler";
+
+/**
+ * Handler that is to be instantiated within the main WINDOW for allowing a worker to request authenticated headers.
+ * Must be used together with {@link WorkerToWindowHandler}.
+ *
+ * After instantiation, users MUST invoke @link{onmessage} within the @link{worker.onmessage} callback.
+ *
+ * For example:
+ * ```
+   const session = getDefaultSession();
+   const worker = new Worker(...);
+   const windowToWorkerHandler = new WindowToWorkerHandler(this, worker, session);
+
+   worker.onmessage = async (message) => {
+      if (windowToWorkerHandler.onmessage(message)) {
+        // This means that the message was taken care of by the handler
+      } else {
+        // Optionally, take care of any other custom messages that your worker may send.
+      }
+    };
+   ```
+ */
+export class WindowToWorkerHandler {
+  public constructor(
+    private windowSelf: Window,
+    private worker: Worker,
+    private session: Session
+  ) {}
+
+  /**
+   * Handle messages from the worker to the window.
+   * @param messageEvent A message.
+   * @return True if the message was meant for this handler, false otherwise.
+   */
+  public onmessage(messageEvent: MessageEvent): boolean {
+    if (WorkerToWindowHandler.MESSAGE_KEY_POST in messageEvent.data) {
+      // Authenticate headers from incoming message
+      const message: IWorkerMessagePost =
+        messageEvent.data[WorkerToWindowHandler.MESSAGE_KEY_POST];
+      this.session
+        .authenticateHeaders(
+          message.resource,
+          message.method,
+          new Headers(message.headersUnauthenticatedRaw)
+        )
+        .then((headersAuthenticated) => {
+          // Send response with authenticated headers
+          const messageResponse: IWorkerMessageResponse = {
+            messageId: message.messageId,
+            headersAuthenticatedRaw: [...(<any>headersAuthenticated).entries()],
+          };
+          this.worker.postMessage({
+            [WorkerToWindowHandler.MESSAGE_KEY_RESPONSE]: messageResponse,
+          });
+        })
+        .catch((error) => {
+          // Send response with error reply if something goes wrong
+          const messageResponse: IWorkerMessageResponse = {
+            messageId: message.messageId,
+            errorMessage: error.message,
+          };
+          this.worker.postMessage({
+            [WorkerToWindowHandler.MESSAGE_KEY_RESPONSE]: messageResponse,
+          });
+        });
+
+      return true;
+    }
+    return false;
+  }
+}

--- a/packages/browser/src/util/worker/WindowToWorkerHandler.ts
+++ b/packages/browser/src/util/worker/WindowToWorkerHandler.ts
@@ -74,6 +74,8 @@ export class WindowToWorkerHandler {
           // Send response with authenticated headers
           const messageResponse: IWorkerMessageResponse = {
             messageId: message.messageId,
+            // TODO: this any cast can be removed when updating to TS 4.1
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
             headersAuthenticatedRaw: [...(<any>headersAuthenticated).entries()],
           };
           this.worker.postMessage({

--- a/packages/browser/src/util/worker/WorkerToWindowHandler.spec.ts
+++ b/packages/browser/src/util/worker/WorkerToWindowHandler.spec.ts
@@ -1,0 +1,276 @@
+/*
+ * Copyright 2021 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { jest } from "@jest/globals";
+import { WorkerToWindowHandler } from "./WorkerToWindowHandler";
+
+describe("WorkerToWindowHandler", () => {
+  let workerSelf: Window;
+  let handler: WorkerToWindowHandler;
+  beforeEach(() => {
+    workerSelf = <any>{
+      postMessage: jest.fn(),
+    };
+    handler = new WorkerToWindowHandler(workerSelf);
+    global.fetch = <any>jest.fn(() => "response");
+  });
+
+  describe("buildAuthenticatedFetch", () => {
+    it("should return a function", () => {
+      expect(handler.buildAuthenticatedFetch()).toBeInstanceOf(Function);
+    });
+
+    describe("a built auth fetch", () => {
+      let authFetch: any;
+      beforeEach(() => {
+        authFetch = handler.buildAuthenticatedFetch();
+      });
+
+      it("should communicate to resolve the request without headers", async () => {
+        const fetchPromise = authFetch("URL");
+
+        // Expect message from worker to window
+        expect(workerSelf.postMessage).toHaveBeenCalledWith({
+          [WorkerToWindowHandler.MESSAGE_KEY_POST]: {
+            messageId: 0,
+            resource: "URL",
+            method: "get",
+            headersUnauthenticatedRaw: [],
+          },
+        });
+
+        // Send message from window to worker
+        expect(
+          handler.onmessage(<any>{
+            data: {
+              [WorkerToWindowHandler.MESSAGE_KEY_RESPONSE]: {
+                messageId: 0,
+                headersAuthenticatedRaw: [["authenticated", "true"]],
+              },
+            },
+          })
+        ).toBe(true);
+
+        // The fetch promise should now be able to resolve
+        await expect(fetchPromise).resolves.toBe("response");
+
+        // Expect request to be done using authenticated headers
+        expect(global.fetch).toHaveBeenCalledWith("URL", {
+          headers: new Headers({
+            authenticated: "true",
+          }),
+        });
+      });
+
+      it("should communicate to resolve the request with headers", async () => {
+        const fetchPromise = authFetch("URL", {
+          headers: new Headers({
+            A: "B",
+          }),
+        });
+
+        // Expect message from worker to window
+        expect(workerSelf.postMessage).toHaveBeenCalledWith({
+          [WorkerToWindowHandler.MESSAGE_KEY_POST]: {
+            messageId: 0,
+            resource: "URL",
+            method: "get",
+            headersUnauthenticatedRaw: [["a", "B"]],
+          },
+        });
+
+        // Send message from window to worker
+        expect(
+          handler.onmessage(<any>{
+            data: {
+              [WorkerToWindowHandler.MESSAGE_KEY_RESPONSE]: {
+                messageId: 0,
+                headersAuthenticatedRaw: [
+                  ["a", "B"],
+                  ["authenticated", "true"],
+                ],
+              },
+            },
+          })
+        ).toBe(true);
+
+        // The fetch promise should now be able to resolve
+        await expect(fetchPromise).resolves.toBe("response");
+
+        // Expect request to be done using authenticated headers
+        expect(global.fetch).toHaveBeenCalledWith("URL", {
+          headers: new Headers({
+            a: "B",
+            authenticated: "true",
+          }),
+        });
+      });
+
+      it("should communicate to resolve the request with headers in init object", async () => {
+        const fetchPromise = authFetch({
+          url: "URL",
+          headers: new Headers({
+            A: "B",
+          }),
+        });
+
+        // Expect message from worker to window
+        expect(workerSelf.postMessage).toHaveBeenCalledWith({
+          [WorkerToWindowHandler.MESSAGE_KEY_POST]: {
+            messageId: 0,
+            resource: "URL",
+            method: "get",
+            headersUnauthenticatedRaw: [["a", "B"]],
+          },
+        });
+
+        // Send message from window to worker
+        expect(
+          handler.onmessage(<any>{
+            data: {
+              [WorkerToWindowHandler.MESSAGE_KEY_RESPONSE]: {
+                messageId: 0,
+                headersAuthenticatedRaw: [
+                  ["a", "B"],
+                  ["authenticated", "true"],
+                ],
+              },
+            },
+          })
+        ).toBe(true);
+
+        // The fetch promise should now be able to resolve
+        await expect(fetchPromise).resolves.toBe("response");
+
+        // Expect request to be done using authenticated headers
+        expect(global.fetch).toHaveBeenCalledWith(
+          {
+            url: "URL",
+            headers: new Headers({
+              a: "B",
+              authenticated: "true",
+            }),
+          },
+          {}
+        );
+      });
+
+      it("should communicate to resolve an erroring request", async () => {
+        const fetchPromise = authFetch("URL", {
+          headers: new Headers({
+            A: "B",
+          }),
+        });
+
+        // Expect message from worker to window
+        expect(workerSelf.postMessage).toHaveBeenCalledWith({
+          [WorkerToWindowHandler.MESSAGE_KEY_POST]: {
+            messageId: 0,
+            resource: "URL",
+            method: "get",
+            headersUnauthenticatedRaw: [["a", "B"]],
+          },
+        });
+
+        // Send message from window to worker
+        expect(
+          handler.onmessage(<any>{
+            data: {
+              [WorkerToWindowHandler.MESSAGE_KEY_RESPONSE]: {
+                messageId: 0,
+                errorMessage: "Auth request failed",
+              },
+            },
+          })
+        ).toBe(true);
+
+        // The fetch promise should now be able to resolve
+        await expect(fetchPromise).rejects.toThrow("Auth request failed");
+
+        // Expect request not to be done
+        expect(global.fetch).not.toHaveBeenCalled();
+      });
+
+      it("should increment message id for every request", async () => {
+        authFetch("URL1");
+        authFetch("URL2");
+        authFetch("URL3");
+
+        // Expect message from worker to window
+        expect(workerSelf.postMessage).toHaveBeenCalledTimes(3);
+        expect(workerSelf.postMessage).toHaveBeenCalledWith({
+          [WorkerToWindowHandler.MESSAGE_KEY_POST]: {
+            messageId: 0,
+            resource: "URL1",
+            method: "get",
+            headersUnauthenticatedRaw: [],
+          },
+        });
+        expect(workerSelf.postMessage).toHaveBeenCalledWith({
+          [WorkerToWindowHandler.MESSAGE_KEY_POST]: {
+            messageId: 1,
+            resource: "URL2",
+            method: "get",
+            headersUnauthenticatedRaw: [],
+          },
+        });
+        expect(workerSelf.postMessage).toHaveBeenCalledWith({
+          [WorkerToWindowHandler.MESSAGE_KEY_POST]: {
+            messageId: 2,
+            resource: "URL3",
+            method: "get",
+            headersUnauthenticatedRaw: [],
+          },
+        });
+      });
+    });
+  });
+
+  describe("onmessage", () => {
+    it("should ignore unknown literal messages", () => {
+      expect(
+        handler.onmessage(<any>{
+          data: "dummy",
+        })
+      ).toBe(false);
+    });
+
+    it("should ignore unknown object messages", () => {
+      expect(
+        handler.onmessage(<any>{
+          data: { a: "dummy" },
+        })
+      ).toBe(false);
+    });
+
+    it("should throw when a message id is not expected", () => {
+      expect(() =>
+        handler.onmessage(<any>{
+          data: {
+            [WorkerToWindowHandler.MESSAGE_KEY_RESPONSE]: {
+              messageId: 0,
+            },
+          },
+        })
+      ).toThrow(`Received unexpected authenticated headers response for id 0`);
+    });
+  });
+});

--- a/packages/browser/src/util/worker/WorkerToWindowHandler.ts
+++ b/packages/browser/src/util/worker/WorkerToWindowHandler.ts
@@ -62,7 +62,10 @@ export class WorkerToWindowHandler {
    * @return True if the message was meant for this handler, false otherwise.
    */
   public onmessage(messageEvent: MessageEvent): boolean {
-    if (WorkerToWindowHandler.MESSAGE_KEY_RESPONSE in messageEvent.data) {
+    if (
+      typeof messageEvent.data === "object" &&
+      WorkerToWindowHandler.MESSAGE_KEY_RESPONSE in messageEvent.data
+    ) {
       // Read message
       const message: IWorkerMessageResponse =
         messageEvent.data[WorkerToWindowHandler.MESSAGE_KEY_RESPONSE];
@@ -109,6 +112,12 @@ export class WorkerToWindowHandler {
         (inputRaw ? init?.method : input.method) || "get",
         new Headers(inputRaw || !input.headers ? init?.headers : input.headers)
       );
+      if (typeof input !== "string") {
+        return global.fetch(
+          { ...input, headers: headersAuthenticated },
+          { ...init }
+        );
+      }
       return global.fetch(input, { ...init, headers: headersAuthenticated });
     };
   }

--- a/packages/browser/src/util/worker/WorkerToWindowHandler.ts
+++ b/packages/browser/src/util/worker/WorkerToWindowHandler.ts
@@ -130,6 +130,8 @@ export class WorkerToWindowHandler {
       messageId,
       resource,
       method,
+      // TODO: this any cast can be removed when updating to TS 4.1
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       headersUnauthenticatedRaw: [...(<any>headers).entries()],
     };
     this.workerSelf.postMessage({

--- a/packages/browser/src/util/worker/WorkerToWindowHandler.ts
+++ b/packages/browser/src/util/worker/WorkerToWindowHandler.ts
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2021 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * Handler that is to be instantiated within a WORKER for allowing it to request authenticated headers from the main window.
+ * Must be used together with {@link WindowToWorkerHandler}.
+ *
+ * After instantiation, users MUST invoke @link{onmessage} within the @link{self.onmessage} callback.
+ * Once that is done, the @{link buildAuthenticatedFetch()} method may be used to create new authenticated fetch functions.
+ *
+ * For example:
+ * ```
+   const workerToWindowHandler = new WorkerToWindowHandler(self);
+   self.onmessage = (message => {
+    if (workerToWindowHandler.onmessage(message)) {
+      // This means that the message was taken care of by the handler
+    } else {
+      // Optionally, take care of any other custom messages that your worker may receive.
+    }
+   ```
+ */
+export class WorkerToWindowHandler {
+  public static readonly MESSAGE_KEY_POST =
+    "solid-client-authn-js.requestUnauthenticated";
+
+  public static readonly MESSAGE_KEY_RESPONSE =
+    "solid-client-authn-js.headersAuthenticated";
+
+  private messageCounter = 0;
+
+  private messageReceiveCallbackBuffer: Record<
+    number,
+    {
+      resolve: (headersAuthenticated: Headers) => void;
+      reject: (error: Error) => void;
+    }
+  > = {};
+
+  public constructor(private workerSelf: Window) {}
+
+  /**
+   * Handle messages from the window to the worker.
+   * @param messageEvent A message.
+   * @return True if the message was meant for this handler, false otherwise.
+   */
+  public onmessage(messageEvent: MessageEvent): boolean {
+    if (WorkerToWindowHandler.MESSAGE_KEY_RESPONSE in messageEvent.data) {
+      // Read message
+      const message: IWorkerMessageResponse =
+        messageEvent.data[WorkerToWindowHandler.MESSAGE_KEY_RESPONSE];
+
+      // Check if we were expecting this message
+      const callback = this.messageReceiveCallbackBuffer[message.messageId];
+      if (!callback) {
+        throw new Error(
+          `Received unexpected authenticated headers response for id ${message.messageId}`
+        );
+      }
+
+      // Resolve the callback
+      if (message.errorMessage) {
+        callback.reject(new Error(message.errorMessage));
+      } else {
+        callback.resolve(new Headers(message.headersAuthenticatedRaw));
+      }
+
+      // Cleanup buffer
+      delete this.messageReceiveCallbackBuffer[message.messageId];
+
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Return a new fetch function that can perform authenticated requests.
+   *
+   * All requests will be preceded with a single message round-trip with the main
+   * window to authenticate the headers of this request. But the actual fetch
+   * request will occur from within this worker.
+   */
+  public buildAuthenticatedFetch(): typeof global.fetch {
+    // Wrapper over global.fetch, but authenticate headers
+    return async (
+      input: RequestInfo,
+      init?: RequestInit
+    ): Promise<Response> => {
+      const inputRaw = typeof input === "string";
+      const headersAuthenticated = await this.authenticateHeaders(
+        inputRaw ? input : input.url,
+        (inputRaw ? init?.method : input.method) || "get",
+        new Headers(inputRaw || !input.headers ? init?.headers : input.headers)
+      );
+      return global.fetch(input, { ...init, headers: headersAuthenticated });
+    };
+  }
+
+  protected authenticateHeaders(
+    resource: string,
+    method: string,
+    headers: Headers
+  ): Promise<Headers> {
+    // Prepare new message in the callback buffer, so that it will be handled during onmessage
+    const messageId = this.messageCounter;
+    const promise = new Promise<Headers>((resolve, reject) => {
+      this.messageReceiveCallbackBuffer[messageId] = { resolve, reject };
+    });
+    this.messageCounter += 1;
+
+    // Send a message to the main window
+    const message: IWorkerMessagePost = {
+      messageId,
+      resource,
+      method,
+      headersUnauthenticatedRaw: [...(<any>headers).entries()],
+    };
+    this.workerSelf.postMessage({
+      [WorkerToWindowHandler.MESSAGE_KEY_POST]: message,
+    });
+    return promise;
+  }
+}
+
+/**
+ * A message that will be sent from worker to window.
+ */
+export interface IWorkerMessagePost {
+  messageId: number;
+  resource: string;
+  method: string;
+  headersUnauthenticatedRaw: string[][];
+}
+
+/**
+ * A message that will be sent from window to worker.
+ */
+export interface IWorkerMessageResponse {
+  messageId: number;
+  headersAuthenticatedRaw?: string[][];
+  errorMessage?: string;
+}

--- a/packages/core/src/authenticatedFetch/dpopUtils.spec.ts
+++ b/packages/core/src/authenticatedFetch/dpopUtils.spec.ts
@@ -66,7 +66,7 @@ describe("createDpopHeader", () => {
     );
     const { payload } = await jwtVerify(header, (await mockJwk()).publicKey);
     expect(payload.htm).toBe("GET");
-    expect(payload.jti).not.toBeUndefined();
+    expect(payload.jti).toBeDefined();
     // The IRI is normalized, hence the trailing '/'
     expect(payload.htu).toBe("https://some.resource/");
   });
@@ -92,8 +92,8 @@ describe("createDpopHeader", () => {
 describe("generateDpopKeyPair", () => {
   it("generates a public, private key pair", async () => {
     const keyPair = await generateDpopKeyPair();
-    expect(keyPair.publicKey).not.toBeUndefined();
-    expect(keyPair.privateKey).not.toBeUndefined();
+    expect(keyPair.publicKey).toBeDefined();
+    expect(keyPair.privateKey).toBeDefined();
     expect(keyPair.publicKey.alg).toBe("ES256");
   });
 });

--- a/packages/core/src/authenticatedFetch/fetchFactory.spec.ts
+++ b/packages/core/src/authenticatedFetch/fetchFactory.spec.ts
@@ -130,7 +130,7 @@ describe("buildAuthenticatedFetch", () => {
       },
     });
     await myFetch("https://my.pod/resource");
-    expect(mockedFetch.mock.calls[0][0]).toEqual("https://my.pod/resource");
+    expect(mockedFetch.mock.calls[0][0]).toBe("https://my.pod/resource");
     const headers = new Headers(mockedFetch.mock.calls[0][1].headers);
     const decodedHeader = await jwtVerify(
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -165,8 +165,8 @@ describe("buildAuthenticatedFetch", () => {
         await mockKeyPair()
       ).privateKey
     );
-    expect(payload.htu).toEqual("http://some.url/");
-    expect(payload.htm).toEqual("POST");
+    expect(payload.htu).toBe("http://some.url/");
+    expect(payload.htm).toBe("POST");
   });
 
   it("builds a Bearer fetch if no DPoP key is provided", async () => {
@@ -180,7 +180,7 @@ describe("buildAuthenticatedFetch", () => {
       undefined
     );
     await myFetch("https://my.pod/resource");
-    expect(mockedFetch.mock.calls[0][0]).toEqual("https://my.pod/resource");
+    expect(mockedFetch.mock.calls[0][0]).toBe("https://my.pod/resource");
     const headers = new Headers(mockedFetch.mock.calls[0][1].headers);
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     expect(headers.get("Authorization")!.startsWith("Bearer")).toBe(true);
@@ -204,7 +204,7 @@ describe("buildAuthenticatedFetch", () => {
     });
     await myFetch("https://my.pod/container");
 
-    expect(mockedFetch.mock.calls[1][0]).toEqual("https://my.pod/container/");
+    expect(mockedFetch.mock.calls[1][0]).toBe("https://my.pod/container/");
     const headers = new Headers(mockedFetch.mock.calls[1][1].headers);
     const { payload } = await jwtVerify(
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -213,7 +213,7 @@ describe("buildAuthenticatedFetch", () => {
         await mockKeyPair()
       ).privateKey
     );
-    expect(payload.htu).toEqual("https://my.pod/container/");
+    expect(payload.htu).toBe("https://my.pod/container/");
   });
 
   it("returns a fetch that does not retry fetching with a Bearer token if redirected", async () => {
@@ -243,8 +243,8 @@ describe("buildAuthenticatedFetch", () => {
 
     const headers = new Headers(mockedFetch.mock.calls[0][1].headers);
 
-    expect(headers.get("Authorization")).toEqual("Bearer myToken");
-    expect(headers.get("someHeader")).toEqual("SomeValue");
+    expect(headers.get("Authorization")).toBe("Bearer myToken");
+    expect(headers.get("someHeader")).toBe("SomeValue");
   });
 
   it("returns a fetch preserving optional headers passed as a Header object", async () => {
@@ -263,8 +263,8 @@ describe("buildAuthenticatedFetch", () => {
 
     const headers = new Headers(mockedFetch.mock.calls[0][1].headers);
 
-    expect(headers.get("Authorization")).toEqual("Bearer myToken");
-    expect(headers.get("someHeader")).toEqual("SomeValue");
+    expect(headers.get("Authorization")).toBe("Bearer myToken");
+    expect(headers.get("someHeader")).toBe("SomeValue");
   });
 
   it("returns a fetch overriding any pre-existing Authorization or DPoP headers", async () => {
@@ -283,7 +283,7 @@ describe("buildAuthenticatedFetch", () => {
       },
     });
     const headers = new Headers(mockedFetch.mock.calls[0][1].headers);
-    expect(headers.get("Authorization")).toEqual("DPoP myToken");
+    expect(headers.get("Authorization")).toBe("DPoP myToken");
   });
 
   it("does not retry a **redirected** fetch if the error is not auth-related", async () => {
@@ -299,7 +299,7 @@ describe("buildAuthenticatedFetch", () => {
     const response = await myFetch("https://my.pod/container");
 
     expect(mockedFetch.mock.calls).toHaveLength(1);
-    expect(response.status).toEqual(400);
+    expect(response.status).toBe(400);
   });
 
   it("returns the initial response in case of non-redirected auth error", async () => {
@@ -321,7 +321,7 @@ describe("buildAuthenticatedFetch", () => {
     const response = await myFetch("someUrl");
     // The mocked fetch will 401, which triggers the refresh flow.
     // The test checks that the mocked refreshed token is used silently.
-    expect(response.status).toEqual(401);
+    expect(response.status).toBe(401);
   });
 
   // For some reasons Jest doesn't play nice with timers, so right now the tests
@@ -556,7 +556,7 @@ describe("buildAuthenticatedFetch", () => {
       expiresIn: 0,
     });
     await sleep(200);
-    expect(refreshCall.mock.calls[1][1]).toEqual("some rotated refresh token");
+    expect(refreshCall.mock.calls[1][1]).toBe("some rotated refresh token");
   });
 
   it("emits the appropriate events when refreshing the token fails", async () => {

--- a/packages/core/src/authenticatedFetch/fetchFactory.ts
+++ b/packages/core/src/authenticatedFetch/fetchFactory.ts
@@ -320,9 +320,11 @@ export async function buildHeadersAuthenticator(
         )
       ).headers
     );
-    headersUnauthenticated.forEach((value, key) =>
-      headersAuthenticated.set(key, value)
-    );
+    headersUnauthenticated.forEach((value, key) => {
+      if (!headersAuthenticated.has(key)) {
+        headersAuthenticated.set(key, value);
+      }
+    });
 
     return headersAuthenticated;
   };

--- a/packages/core/src/errors/InruptError.test.ts
+++ b/packages/core/src/errors/InruptError.test.ts
@@ -42,7 +42,7 @@ describe("InruptError", () => {
       const message = "Normal error string...";
       const error = new InruptError(message);
 
-      expect(error.name).toEqual("Error");
+      expect(error.name).toBe("Error");
       expect(error.toString()).toContain(message);
     });
 
@@ -52,7 +52,7 @@ describe("InruptError", () => {
         ["one", "two"]
       );
 
-      expect(error.name).toEqual("Error");
+      expect(error.name).toBe("Error");
       expect(error.toString()).toContain(
         "Error: Normal [two] error string with [one]..."
       );
@@ -82,10 +82,10 @@ describe("InruptError", () => {
         false
       );
 
-      expect(error.name).toEqual("Error");
-      expect(error.hasHttpResponse()).toEqual(true);
-      expect(error.getHttpStatusCode()).toEqual(404);
-      expect(error.getHttpStatusText()).toEqual("Not Found");
+      expect(error.name).toBe("Error");
+      expect(error.hasHttpResponse()).toBe(true);
+      expect(error.getHttpStatusCode()).toBe(404);
+      expect(error.getHttpStatusText()).toBe("Not Found");
       expect(error.toString()).toContain(message);
       expect(error.toString()).not.toContain("404");
     });
@@ -98,10 +98,10 @@ describe("InruptError", () => {
       const message = "Normal error string...";
       const error = new InruptError(message).httpResponse(failedResponse);
 
-      expect(error.name).toEqual("Error");
-      expect(error.hasHttpResponse()).toEqual(true);
-      expect(error.getHttpStatusCode()).toEqual(404);
-      expect(error.getHttpStatusText()).toEqual("Not Found");
+      expect(error.name).toBe("Error");
+      expect(error.hasHttpResponse()).toBe(true);
+      expect(error.getHttpStatusCode()).toBe(404);
+      expect(error.getHttpStatusText()).toBe("Not Found");
       expect(error.toString()).toContain(message);
       expect(error.toString()).toContain("404");
     });
@@ -144,7 +144,7 @@ describe("InruptError", () => {
         const errorIri = new NamedNode("https://example.com/vocab#errTest1");
         const error = new InruptError(errorIri);
 
-        expect(error.name).toEqual("Error");
+        expect(error.name).toBe("Error");
         expect(error.toString()).toContain(errorIri.value);
 
         // TODO: PMcB55: Replace this when (if?) we do actually lookup vocabs
@@ -157,7 +157,7 @@ describe("InruptError", () => {
         const params = ["one", "two"];
         const error = new InruptError(errorIri, params);
 
-        expect(error.name).toEqual("Error");
+        expect(error.name).toBe("Error");
         expect(error.toString()).toContain(params[0]);
         expect(error.toString()).toContain(params[1]);
         expect(error.toString()).toContain(errorIri.value);
@@ -172,7 +172,7 @@ describe("InruptError", () => {
         const errorIri = INRUPT_TEST.somePredicate;
         const error = new InruptError(errorIri);
 
-        expect(error.name).toEqual("Error");
+        expect(error.name).toBe("Error");
         expect(error.toString()).toContain(errorIri.value);
         expect(error.toString()).toContain("found no message value");
       });
@@ -182,7 +182,7 @@ describe("InruptError", () => {
         const params = ["one", "two", "three"];
         const error = new InruptError(vocabError, params);
 
-        expect(error.name).toEqual("Error");
+        expect(error.name).toBe("Error");
         expect(error.hasHttpResponse()).toBeFalsy();
         expect(error.toString()).toContain(params[0]);
         expect(error.toString()).toContain(params[1]);
@@ -203,7 +203,7 @@ describe("InruptError", () => {
 
           const error = new InruptError(errorIri, params);
 
-          expect(error.name).toEqual("Error");
+          expect(error.name).toBe("Error");
           expect(error.hasHttpResponse()).toBeFalsy();
           expect(error.toString()).toContain(params[0]);
           expect(error.toString()).toContain(params[1]);
@@ -234,10 +234,10 @@ describe("InruptError", () => {
             true
           );
 
-          expect(error.name).toEqual("Error");
-          expect(error.hasHttpResponse()).toEqual(true);
-          expect(error.getHttpStatusCode()).toEqual(404);
-          expect(error.getHttpStatusText()).toEqual("Not Found");
+          expect(error.name).toBe("Error");
+          expect(error.hasHttpResponse()).toBe(true);
+          expect(error.getHttpStatusCode()).toBe(404);
+          expect(error.getHttpStatusText()).toBe("Not Found");
           expect(error.toString()).toContain(params[0]);
           expect(error.toString()).toContain(params[1]);
           expect(error.toString()).toContain(params[2]);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -47,6 +47,7 @@ export {
   ISessionInfo,
   ISessionInternalInfo,
   isSupportedTokenType,
+  HeadersAuthenticator,
 } from "./sessionInfo/ISessionInfo";
 export {
   ISessionInfoManager,
@@ -92,6 +93,7 @@ export {
 
 export {
   buildAuthenticatedFetch,
+  buildHeadersAuthenticator,
   DpopHeaderPayload,
   RefreshOptions,
 } from "./authenticatedFetch/fetchFactory";

--- a/packages/core/src/login/oidc/redirectHandler/IRedirectHandler.ts
+++ b/packages/core/src/login/oidc/redirectHandler/IRedirectHandler.ts
@@ -34,9 +34,15 @@ import {
 } from "@inrupt/jose-legacy-modules";
 import { EventEmitter } from "events";
 import IHandleable from "../../../util/handlerPattern/IHandleable";
-import { ISessionInfo } from "../../../sessionInfo/ISessionInfo";
+import {
+  HeadersAuthenticator,
+  ISessionInfo,
+} from "../../../sessionInfo/ISessionInfo";
 
-export type RedirectResult = ISessionInfo & { fetch: typeof fetch };
+export type RedirectResult = ISessionInfo & {
+  fetch: typeof fetch;
+  headersAuthenticator: HeadersAuthenticator;
+};
 export type RedirectInput = [string, EventEmitter | undefined];
 
 /**

--- a/packages/core/src/sessionInfo/ISessionInfo.ts
+++ b/packages/core/src/sessionInfo/ISessionInfo.ts
@@ -92,6 +92,16 @@ export interface ISessionInternalInfo {
   tokenType?: "DPoP" | "Bearer";
 }
 
+/**
+ * An async callback that adds an appropriate Authorization header to the given
+ * headers with the provided token, and adds a DPoP header if applicable.
+ */
+export type HeadersAuthenticator = (
+  resource: string,
+  method: string,
+  headersUnauthenticated: Headers
+) => Promise<Headers>;
+
 export function isSupportedTokenType(
   token: string | "DPoP" | "Bearer"
 ): token is "DPoP" | "Bearer" {

--- a/packages/core/src/storage/InMemoryStorage.spec.ts
+++ b/packages/core/src/storage/InMemoryStorage.spec.ts
@@ -27,7 +27,7 @@ describe("InMemoryStorage", () => {
     await expect(nodeStorage.set("a", "A")).resolves.not.toBeNull();
   });
   it("can get an item", async () => {
-    expect(await nodeStorage.get("a")).toEqual("A");
+    expect(await nodeStorage.get("a")).toBe("A");
   });
   it("returns undefined if the key does not exist", async () => {
     expect(await nodeStorage.get("doesNotExist")).toBeUndefined();

--- a/packages/core/src/storage/StorageUtility.spec.ts
+++ b/packages/core/src/storage/StorageUtility.spec.ts
@@ -272,9 +272,9 @@ describe("StorageUtility", () => {
       await expect(
         storageUtility.getForUser(userId, "jackie")
       ).resolves.toBeUndefined();
-      await expect(
-        storageUtility.getForUser(userId, "sledge")
-      ).resolves.toEqual("The Dog");
+      await expect(storageUtility.getForUser(userId, "sledge")).resolves.toBe(
+        "The Dog"
+      );
     });
 
     it("deletes a value for a user from secure storage", async () => {
@@ -296,7 +296,7 @@ describe("StorageUtility", () => {
       ).resolves.toBeUndefined();
       await expect(
         storageUtility.getForUser("someUser", "sledge", { secure: true })
-      ).resolves.toEqual("The Dog");
+      ).resolves.toBe("The Dog");
     });
   });
 
@@ -312,9 +312,9 @@ describe("StorageUtility", () => {
 
       // Write some user data, and make sure it's there.
       await storageUtility.setForUser(userId, userData);
-      await expect(
-        storageUtility.getForUser(userId, "jackie")
-      ).resolves.toEqual("The Cat");
+      await expect(storageUtility.getForUser(userId, "jackie")).resolves.toBe(
+        "The Cat"
+      );
 
       // Delete that user data, and make sure it's gone.
       await storageUtility.deleteAllUserData(userId);
@@ -336,7 +336,7 @@ describe("StorageUtility", () => {
       await storageUtility.setForUser(userId, userData, { secure: true });
       await expect(
         storageUtility.getForUser(userId, "jackie", { secure: true })
-      ).resolves.toEqual("The Cat");
+      ).resolves.toBe("The Cat");
 
       // Delete that user data, and make sure it's gone.
       await storageUtility.deleteAllUserData(userId, { secure: true });
@@ -619,7 +619,7 @@ describe("saveSessionInfoToStorage", () => {
 
     await expect(
       mockedStorage.getForUser("some session", "refreshToken", { secure: true })
-    ).resolves.toEqual("a refresh token");
+    ).resolves.toBe("a refresh token");
   });
 
   it("saves ID token if provided in the given storage", async () => {
@@ -636,7 +636,7 @@ describe("saveSessionInfoToStorage", () => {
 
     await expect(
       mockedStorage.getForUser("some session", "idToken", { secure: true })
-    ).resolves.toEqual("an ID token");
+    ).resolves.toBe("an ID token");
   });
 
   it("saves the webid if provided in the given storage", async () => {
@@ -653,7 +653,7 @@ describe("saveSessionInfoToStorage", () => {
 
     await expect(
       mockedStorage.getForUser("some session", "webId", { secure: true })
-    ).resolves.toEqual("https://my.webid");
+    ).resolves.toBe("https://my.webid");
   });
 
   it("saves the logged in status if provided in the given storage", async () => {
@@ -670,7 +670,7 @@ describe("saveSessionInfoToStorage", () => {
 
     await expect(
       mockedStorage.getForUser("some session", "isLoggedIn", { secure: true })
-    ).resolves.toEqual("true");
+    ).resolves.toBe("true");
   });
 
   let publicKey: KeyLike | undefined;

--- a/packages/node/src/ClientAuthentication.spec.ts
+++ b/packages/node/src/ClientAuthentication.spec.ts
@@ -130,8 +130,8 @@ describe("ClientAuthentication", () => {
         },
         mockEmitter
       );
-      expect(loginResult).not.toBeUndefined();
-      expect(loginResult?.webId).toEqual("https://my.webid/");
+      expect(loginResult).toBeDefined();
+      expect(loginResult?.webId).toBe("https://my.webid/");
       expect(clientAuthn.fetch).toBe(mockedAuthFetch);
     });
 

--- a/packages/node/src/Session.spec.ts
+++ b/packages/node/src/Session.spec.ts
@@ -47,19 +47,19 @@ describe("Session", () => {
   describe("constructor", () => {
     it("accepts an empty config", async () => {
       const mySession = new Session({});
-      expect(mySession.info.isLoggedIn).toEqual(false);
+      expect(mySession.info.isLoggedIn).toBe(false);
       expect(mySession.info.sessionId).toBeDefined();
     });
 
     it("accepts no config", async () => {
       const mySession = new Session();
-      expect(mySession.info.isLoggedIn).toEqual(false);
+      expect(mySession.info.isLoggedIn).toBe(false);
       expect(mySession.info.sessionId).toBeDefined();
     });
 
     it("does not generate a session ID if one is provided", () => {
       const mySession = new Session({}, "mySession");
-      expect(mySession.info.sessionId).toEqual("mySession");
+      expect(mySession.info.sessionId).toBe("mySession");
     });
 
     it("accepts legacy input storage", async () => {
@@ -74,7 +74,7 @@ describe("Session", () => {
         insecureStorage,
         secureStorage,
       });
-      expect(mySession).not.toBeUndefined();
+      expect(mySession).toBeDefined();
       expect(
         dependencies.getClientAuthenticationWithDependencies
       ).toHaveBeenCalledWith({
@@ -92,7 +92,7 @@ describe("Session", () => {
       const mySession = new Session({
         storage,
       });
-      expect(mySession).not.toBeUndefined();
+      expect(mySession).toBeDefined();
       expect(
         dependencies.getClientAuthenticationWithDependencies
       ).toHaveBeenCalledWith({
@@ -114,7 +114,7 @@ describe("Session", () => {
         secureStorage,
         storage,
       });
-      expect(mySession).not.toBeUndefined();
+      expect(mySession).toBeDefined();
       expect(
         dependencies.getClientAuthenticationWithDependencies
       ).toHaveBeenCalledWith({
@@ -131,9 +131,9 @@ describe("Session", () => {
           webId: "https://some.webid",
         },
       });
-      expect(mySession.info.isLoggedIn).toEqual(false);
-      expect(mySession.info.sessionId).toEqual("mySession");
-      expect(mySession.info.webId).toEqual("https://some.webid");
+      expect(mySession.info.isLoggedIn).toBe(false);
+      expect(mySession.info.sessionId).toBe("mySession");
+      expect(mySession.info.webId).toBe("https://some.webid");
     });
 
     it("accepts legacy token rotation callback", () => {
@@ -180,9 +180,9 @@ describe("Session", () => {
         });
       const mySession = new Session({ clientAuthentication });
       await mySession.login({});
-      expect(mySession.info.isLoggedIn).toEqual(true);
-      expect(mySession.info.sessionId).toEqual("mySession");
-      expect(mySession.info.webId).toEqual("https://my.webid/");
+      expect(mySession.info.isLoggedIn).toBe(true);
+      expect(mySession.info.sessionId).toBe("mySession");
+      expect(mySession.info.webId).toBe("https://my.webid/");
     });
   });
 
@@ -265,11 +265,11 @@ describe("Session", () => {
         }
       );
       const mySession = new Session({ clientAuthentication });
-      expect(mySession.info.isLoggedIn).toEqual(false);
+      expect(mySession.info.isLoggedIn).toBe(false);
       await mySession.handleIncomingRedirect("https://some.url");
-      expect(mySession.info.isLoggedIn).toEqual(true);
-      expect(mySession.info.sessionId).toEqual("a session ID");
-      expect(mySession.info.webId).toEqual("https://some.webid#them");
+      expect(mySession.info.isLoggedIn).toBe(true);
+      expect(mySession.info.sessionId).toBe("a session ID");
+      expect(mySession.info.webId).toBe("https://some.webid#them");
     });
 
     it("directly returns the session's info if already logged in", async () => {
@@ -285,7 +285,7 @@ describe("Session", () => {
       );
       const mySession = new Session({ clientAuthentication });
       await mySession.handleIncomingRedirect("https://some.url");
-      expect(mySession.info.isLoggedIn).toEqual(true);
+      expect(mySession.info.isLoggedIn).toBe(true);
       await mySession.handleIncomingRedirect("https://some.url");
       // The second request should not hit the wrapped function
       expect(clientAuthentication.handleIncomingRedirect).toHaveBeenCalledTimes(
@@ -300,8 +300,8 @@ describe("Session", () => {
       );
       const mySession = new Session({ clientAuthentication }, "mySession");
       await mySession.handleIncomingRedirect("https://some.url");
-      expect(mySession.info.isLoggedIn).toEqual(false);
-      expect(mySession.info.sessionId).toEqual("mySession");
+      expect(mySession.info.isLoggedIn).toBe(false);
+      expect(mySession.info.sessionId).toBe("mySession");
     });
 
     function sleep(ms: number): Promise<void> {

--- a/packages/node/src/Session.spec.ts
+++ b/packages/node/src/Session.spec.ts
@@ -20,6 +20,8 @@
  */
 
 import { jest, it, describe, expect } from "@jest/globals";
+// eslint-disable-next-line no-shadow
+import { Headers } from "cross-fetch";
 import {
   InMemoryStorage,
   ISessionInfo,
@@ -342,6 +344,22 @@ describe("Session", () => {
       // One of the two token requests should not have reached the token endpoint
       // because the other was pending.
       expect(tokenRequests).toContain(undefined);
+    });
+  });
+
+  describe("authenticateHeaders", () => {
+    it("wraps up ClientAuthentication fetch if logged in", async () => {
+      const clientAuthentication = mockClientAuthentication();
+      const clientAuthnHeadersAuthenticator = jest.spyOn(
+        clientAuthentication,
+        "headersAuthenticator"
+      );
+      const mySession = new Session({ clientAuthentication });
+      mySession.info.isLoggedIn = true;
+      await expect(
+        mySession.authenticateHeaders("https://some.url", "GET", new Headers())
+      ).rejects.toThrow("headersAuthenticator is not initialized yet");
+      expect(clientAuthnHeadersAuthenticator).toHaveBeenCalled();
     });
   });
 

--- a/packages/node/src/Session.ts
+++ b/packages/node/src/Session.ts
@@ -200,6 +200,25 @@ export class Session extends EventEmitter {
   };
 
   /**
+   * Provides the necessary headers to perform the given request using this
+   * session's authentication.
+   * @param resource The resource URL to request.
+   * @param method The request method.
+   * @param headersUnauthenticated The headers for the request.
+   */
+  authenticateHeaders = (
+    resource: string,
+    method: string,
+    headersUnauthenticated: Headers
+  ): Promise<Headers> => {
+    return this.clientAuthentication.headersAuthenticator(
+      resource,
+      method,
+      headersUnauthenticated
+    );
+  };
+
+  /**
    * Logs the user out of the application. This does not log the user out of the identity provider, and should not redirect the user away.
    */
   logout = async (): Promise<void> => {

--- a/packages/node/src/e2e/e2e-test.spec.ts
+++ b/packages/node/src/e2e/e2e-test.spec.ts
@@ -73,17 +73,17 @@ const serversUnderTest: AuthDetails[] = [
 describe.each(serversUnderTest)(
   "End-to-end authentication tests against Pod [%s] authenticated to [%s]",
   (rootContainerDisplayName, oidcIssuerDisplayName, clientId, clientSecret) => {
-    const rootContainer = "https://" + rootContainerDisplayName;
-    const oidcIssuer = "https://" + oidcIssuerDisplayName;
+    const rootContainer = `https://${rootContainerDisplayName}`;
+    const oidcIssuer = `https://${oidcIssuerDisplayName}`;
 
     // This first test just saves the trouble of looking for a library failure when
     // the environment wasn't properly set.
     describe("Environment", () => {
       it("contains the expected environment variables", () => {
-        expect(rootContainer).not.toBeUndefined();
-        expect(clientId).not.toBeUndefined();
-        expect(clientSecret).not.toBeUndefined();
-        expect(oidcIssuer).not.toBeUndefined();
+        expect(rootContainer).toBeDefined();
+        expect(clientId).toBeDefined();
+        expect(clientSecret).toBeDefined();
+        expect(oidcIssuer).toBeDefined();
       });
     });
 
@@ -95,9 +95,9 @@ describe.each(serversUnderTest)(
           clientSecret,
           oidcIssuer,
         });
-        expect(session.info.isLoggedIn).toEqual(true);
-        expect(session.info.sessionId).not.toBeUndefined();
-        expect(session.info.webId).not.toBeUndefined();
+        expect(session.info.isLoggedIn).toBe(true);
+        expect(session.info.sessionId).toBeDefined();
+        expect(session.info.webId).toBeDefined();
         await session.logout();
       });
 
@@ -111,7 +111,7 @@ describe.each(serversUnderTest)(
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const publicResourceUrl = session.info.webId!;
         const response = await session.fetch(publicResourceUrl);
-        expect(response.status).toEqual(200);
+        expect(response.status).toBe(200);
         await expect(response.text()).resolves.toContain(
           ":PersonalProfileDocument"
         );
@@ -127,7 +127,7 @@ describe.each(serversUnderTest)(
         });
         const privateResourceUrl = rootContainer;
         const response = await session.fetch(privateResourceUrl);
-        expect(response.status).toEqual(200);
+        expect(response.status).toBe(200);
         await expect(response.text()).resolves.toContain("ldp:BasicContainer");
         await session.logout();
       });
@@ -136,7 +136,7 @@ describe.each(serversUnderTest)(
         const session = new Session();
         const privateResourceUrl = rootContainer;
         let response = await session.fetch(privateResourceUrl);
-        expect(response.status).toEqual(401);
+        expect(response.status).toBe(401);
 
         await session.login({
           clientId,
@@ -145,11 +145,11 @@ describe.each(serversUnderTest)(
         });
 
         response = await session.fetch(privateResourceUrl);
-        expect(response.status).toEqual(200);
+        expect(response.status).toBe(200);
 
         await session.logout();
         response = await session.fetch(privateResourceUrl);
-        expect(response.status).toEqual(401);
+        expect(response.status).toBe(401);
         await session.logout();
       });
 
@@ -164,11 +164,11 @@ describe.each(serversUnderTest)(
         });
 
         let response = await authenticatedSession.fetch(privateResourceUrl);
-        expect(response.status).toEqual(200);
+        expect(response.status).toBe(200);
 
         const nonAuthenticatedSession = new Session();
         response = await nonAuthenticatedSession.fetch(privateResourceUrl);
-        expect(response.status).toEqual(401);
+        expect(response.status).toBe(401);
         await authenticatedSession.logout();
       });
     });
@@ -186,7 +186,7 @@ describe.each(serversUnderTest)(
 
         const unauthenticatedSession = new Session();
         const response = await unauthenticatedSession.fetch(publicResourceUrl);
-        expect(response.status).toEqual(200);
+        expect(response.status).toBe(200);
         await expect(response.text()).resolves.toContain(
           ":PersonalProfileDocument"
         );
@@ -197,7 +197,7 @@ describe.each(serversUnderTest)(
         const session = new Session();
         const privateResourceUrl = rootContainer;
         const response = await session.fetch(privateResourceUrl);
-        expect(response.status).toEqual(401);
+        expect(response.status).toBe(401);
       });
     });
 
@@ -213,7 +213,7 @@ describe.each(serversUnderTest)(
         const publicResourceUrl = session.info.webId!;
         await session.logout();
         const response = await session.fetch(publicResourceUrl);
-        expect(response.status).toEqual(200);
+        expect(response.status).toBe(200);
         await expect(response.text()).resolves.toContain(
           ":PersonalProfileDocument"
         );
@@ -229,7 +229,7 @@ describe.each(serversUnderTest)(
         });
         await session.logout();
         const response = await session.fetch(privateResourceUrl);
-        expect(response.status).toEqual(401);
+        expect(response.status).toBe(401);
       });
     });
   }

--- a/packages/node/src/login/oidc/ClientRegistrar.spec.ts
+++ b/packages/node/src/login/oidc/ClientRegistrar.spec.ts
@@ -99,10 +99,10 @@ describe("ClientRegistrar", () => {
           ...IssuerConfigFetcherFetchConfigResponse,
         }
       );
-      expect(client.clientId).toEqual("an id");
-      expect(client.clientSecret).toEqual("a secret");
-      expect(client.clientName).toEqual("my client name");
-      expect(client.idTokenSignedResponseAlg).toEqual("ES256");
+      expect(client.clientId).toBe("an id");
+      expect(client.clientSecret).toBe("a secret");
+      expect(client.clientName).toBe("my client name");
+      expect(client.idTokenSignedResponseAlg).toBe("ES256");
     });
 
     it("properly performs dynamic registration and saves client information", async () => {

--- a/packages/node/src/login/oidc/OidcLoginHandler.spec.ts
+++ b/packages/node/src/login/oidc/OidcLoginHandler.spec.ts
@@ -66,7 +66,7 @@ describe("OidcLoginHandler", () => {
           tokenType: "DPoP",
           redirectUrl: "https://my.app/redirect",
         })
-      ).resolves.toEqual(false);
+      ).resolves.toBe(false);
     });
 
     // TODO: Move this to appropriate handlers (auth code, implicit)
@@ -91,7 +91,7 @@ describe("OidcLoginHandler", () => {
           oidcIssuer: "https://my.idp/",
           redirectUrl: "https://my.app/redirect",
         })
-      ).resolves.toEqual(true);
+      ).resolves.toBe(true);
     });
   });
 
@@ -160,13 +160,13 @@ describe("OidcLoginHandler", () => {
       expect(clientRegistrar.getClient).not.toHaveBeenCalled();
       await expect(
         mockedStorage.getForUser("mySession", "clientId")
-      ).resolves.toEqual("some pre-registered client id");
+      ).resolves.toBe("some pre-registered client id");
       await expect(
         mockedStorage.getForUser("mySession", "clientSecret")
-      ).resolves.toEqual("some pre-registered client secret");
+      ).resolves.toBe("some pre-registered client secret");
       await expect(
         mockedStorage.getForUser("mySession", "clientName")
-      ).resolves.toEqual("My App");
+      ).resolves.toBe("My App");
     });
 
     it("should save client WebID if one is provided, and the target IdP supports Solid-OIDC", async () => {
@@ -203,7 +203,7 @@ describe("OidcLoginHandler", () => {
         "mySession",
         "clientId"
       );
-      expect(storedClientId).toEqual("https://my.app/registration#app");
+      expect(storedClientId).toBe("https://my.app/registration#app");
     });
 
     it("should perform DCR if a client WebID is provided, but the target IdP does not support Solid-OIDC", async () => {
@@ -240,7 +240,7 @@ describe("OidcLoginHandler", () => {
       });
 
       const calledWith = oidcHandler.handle.mock.calls[0][0];
-      expect(calledWith.client.clientId).toEqual(
+      expect(calledWith.client.clientId).toBe(
         "a dynamically registered client id"
       );
     });
@@ -267,7 +267,7 @@ describe("OidcLoginHandler", () => {
       expect(clientRegistrar.getClient).not.toHaveBeenCalled();
       await expect(
         mockedStorage.getForUser("mySession", "clientId")
-      ).resolves.toEqual("some pre-registered client id");
+      ).resolves.toBe("some pre-registered client id");
     });
 
     it("uses the refresh token from storage if available", async () => {

--- a/packages/node/src/login/oidc/oidcHandlers/AuthorizationCodeWithPkceOidcHandler.spec.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/AuthorizationCodeWithPkceOidcHandler.spec.ts
@@ -104,7 +104,7 @@ describe("AuthorizationCodeWithPkceOidcHandler", () => {
       expect(builtUrl.searchParams.get("client_id")).toEqual(
         oidcOptions.client.clientId
       );
-      expect(builtUrl.searchParams.get("response_type")).toEqual("code");
+      expect(builtUrl.searchParams.get("response_type")).toBe("code");
       expect(builtUrl.searchParams.get("redirect_uri")).toEqual(
         oidcOptions.redirectUrl
       );
@@ -133,7 +133,7 @@ describe("AuthorizationCodeWithPkceOidcHandler", () => {
       ).resolves.toEqual(oidcOptions.redirectUrl);
       await expect(
         mockedStorage.getForUser(oidcOptions.sessionId, "dpop")
-      ).resolves.toEqual("true");
+      ).resolves.toBe("true");
     });
 
     it("serializes the token type boolean appropriately", async () => {
@@ -150,7 +150,7 @@ describe("AuthorizationCodeWithPkceOidcHandler", () => {
 
       await expect(
         mockedStorage.getForUser(oidcOptions.sessionId, "dpop")
-      ).resolves.toEqual("false");
+      ).resolves.toBe("false");
     });
   });
 });

--- a/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.spec.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.spec.ts
@@ -175,7 +175,7 @@ describe("ClientCredentialsOidcHandler", () => {
             clientType: "static",
           },
         })
-      ).resolves.toEqual(false);
+      ).resolves.toBe(false);
     });
 
     it("cannot handle if the client is not statically registered", async () => {
@@ -192,7 +192,7 @@ describe("ClientCredentialsOidcHandler", () => {
             clientType: "dynamic",
           },
         })
-      ).resolves.toEqual(false);
+      ).resolves.toBe(false);
     });
 
     it("can handle if both client ID and secret are present for a confidential client", async () => {
@@ -209,7 +209,7 @@ describe("ClientCredentialsOidcHandler", () => {
             clientType: "static",
           },
         })
-      ).resolves.toEqual(true);
+      ).resolves.toBe(true);
     });
   });
 });

--- a/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.ts
@@ -39,6 +39,7 @@ import {
   getWebidFromTokenPayload,
   buildAuthenticatedFetch,
   ITokenRefresher,
+  buildHeadersAuthenticator,
 } from "@inrupt/solid-client-authn-core";
 import { KeyObject } from "crypto";
 import { Issuer } from "openid-client";
@@ -123,6 +124,12 @@ export default class ClientCredentialsOidcHandler implements IOidcHandler {
         eventEmitter: oidcLoginOptions.eventEmitter,
       }
     );
+    const headersAuthenticator = await buildHeadersAuthenticator(
+      tokens.access_token,
+      {
+        dpopKey,
+      }
+    );
 
     const sessionInfo: ISessionInfo = {
       isLoggedIn: true,
@@ -137,6 +144,7 @@ export default class ClientCredentialsOidcHandler implements IOidcHandler {
 
     return Object.assign(sessionInfo, {
       fetch: authFetch,
+      headersAuthenticator,
     });
   }
 }

--- a/packages/node/src/login/oidc/oidcHandlers/RefreshTokenOidcHandler.spec.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/RefreshTokenOidcHandler.spec.ts
@@ -83,7 +83,7 @@ describe("RefreshTokenOidcHandler", () => {
             },
           })
         )
-      ).resolves.toEqual(false);
+      ).resolves.toBe(false);
     });
 
     it("doesn't handle options missing a client ID", async () => {
@@ -105,7 +105,7 @@ describe("RefreshTokenOidcHandler", () => {
             },
           })
         )
-      ).resolves.toEqual(false);
+      ).resolves.toBe(false);
     });
   });
 
@@ -148,7 +148,7 @@ describe("RefreshTokenOidcHandler", () => {
           },
         })
       );
-      expect(result?.webId).toEqual("https://my.webid/");
+      expect(result?.webId).toBe("https://my.webid/");
 
       const mockedFetch = jest.requireMock("cross-fetch") as jest.Mock;
       mockedFetch.mockResolvedValue({
@@ -178,8 +178,8 @@ describe("RefreshTokenOidcHandler", () => {
           },
         })
       );
-      expect(result).not.toBeUndefined();
-      expect(result?.webId).toEqual("https://my.webid/");
+      expect(result).toBeDefined();
+      expect(result?.webId).toBe("https://my.webid/");
 
       const mockedFetch = jest.requireMock("cross-fetch") as jest.Mock;
       mockedFetch.mockResolvedValue({
@@ -253,7 +253,7 @@ describe("RefreshTokenOidcHandler", () => {
           dpop: false,
         })
       );
-      expect(result).not.toBeUndefined();
+      expect(result).toBeDefined();
 
       const mockedFetch = jest.requireMock("cross-fetch") as jest.Mock;
       mockedFetch.mockResolvedValue({
@@ -287,19 +287,19 @@ describe("RefreshTokenOidcHandler", () => {
       );
       await expect(
         mockedStorage.getForUser(mockDefaultOidcOptions().sessionId, "clientId")
-      ).resolves.toEqual("some client id");
+      ).resolves.toBe("some client id");
       await expect(
         mockedStorage.getForUser(
           mockDefaultOidcOptions().sessionId,
           "clientSecret"
         )
-      ).resolves.toEqual("some client secret");
+      ).resolves.toBe("some client secret");
       await expect(
         mockedStorage.getForUser(
           mockDefaultOidcOptions().sessionId,
           "clientName"
         )
-      ).resolves.toEqual("some client name");
+      ).resolves.toBe("some client name");
       await expect(
         mockedStorage.getForUser(mockDefaultOidcOptions().sessionId, "issuer")
       ).resolves.toEqual(mockDefaultOidcOptions().issuer);
@@ -323,7 +323,7 @@ describe("RefreshTokenOidcHandler", () => {
         },
       })
     );
-    expect(result).not.toBeUndefined();
+    expect(result).toBeDefined();
   });
 
   it("throws if the IdP does not return an ID token", async () => {
@@ -376,7 +376,7 @@ describe("RefreshTokenOidcHandler", () => {
         },
       })
     );
-    expect(result?.webId).toEqual("https://my.webid/");
+    expect(result?.webId).toBe("https://my.webid/");
 
     expect(mockAuthenticatedFetchBuild).toHaveBeenCalledWith(
       expect.anything(),

--- a/packages/node/src/login/oidc/redirectHandler/AggregateRedirectHandler.ts
+++ b/packages/node/src/login/oidc/redirectHandler/AggregateRedirectHandler.ts
@@ -31,6 +31,7 @@ import {
   IRedirectHandler,
   ISessionInfo,
   AggregateHandler,
+  HeadersAuthenticator,
 } from "@inrupt/solid-client-authn-core";
 import { EventEmitter } from "events";
 
@@ -40,7 +41,10 @@ import { EventEmitter } from "events";
 export default class AggregateRedirectHandler
   extends AggregateHandler<
     [string, EventEmitter],
-    ISessionInfo & { fetch: typeof fetch }
+    ISessionInfo & {
+      fetch: typeof fetch;
+      headersAuthenticator: HeadersAuthenticator;
+    }
   >
   implements IRedirectHandler
 {

--- a/packages/node/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
+++ b/packages/node/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
@@ -274,8 +274,8 @@ describe("AuthCodeRedirectHandler", () => {
       );
 
       // Check that the returned session is the one we expected
-      expect(result.sessionId).toEqual("mySession");
-      expect(result.isLoggedIn).toEqual(true);
+      expect(result.sessionId).toBe("mySession");
+      expect(result.isLoggedIn).toBe(true);
       expect(result.webId).toEqual(mockWebId());
 
       // Check that the session information is stored in the provided storage
@@ -284,7 +284,7 @@ describe("AuthCodeRedirectHandler", () => {
       ).resolves.toEqual(mockWebId());
       await expect(
         mockedStorage.getForUser("mySession", "isLoggedIn")
-      ).resolves.toEqual("true");
+      ).resolves.toBe("true");
 
       // Check that the returned fetch function is authenticated
       const mockedFetch = jest.requireMock("cross-fetch") as jest.Mock;
@@ -364,7 +364,7 @@ describe("AuthCodeRedirectHandler", () => {
       // Check that the session information is stored in the provided storage
       await expect(
         mockedStorage.getForUser("mySession", "refreshToken")
-      ).resolves.toEqual("some refresh token");
+      ).resolves.toBe("some refresh token");
     });
 
     it("stores the DPoP key pair if the refresh token is DPoP-bound", async () => {
@@ -386,10 +386,10 @@ describe("AuthCodeRedirectHandler", () => {
       // Check that the session information is stored in the provided storage
       await expect(
         mockedStorage.getForUser("mySession", "privateKey")
-      ).resolves.not.toBeUndefined();
+      ).resolves.toBeDefined();
       await expect(
         mockedStorage.getForUser("mySession", "publicKey")
-      ).resolves.not.toBeUndefined();
+      ).resolves.toBeDefined();
     });
 
     it("calls the refresh token handler if one is provided", async () => {

--- a/packages/node/src/login/oidc/redirectHandler/FallbackRedirectHandler.spec.ts
+++ b/packages/node/src/login/oidc/redirectHandler/FallbackRedirectHandler.spec.ts
@@ -20,6 +20,8 @@
  */
 
 import { jest, it, describe, expect } from "@jest/globals";
+// eslint-disable-next-line no-shadow
+import { Headers } from "cross-fetch";
 import { FallbackRedirectHandler } from "./FallbackRedirectHandler";
 
 jest.mock("cross-fetch");
@@ -57,6 +59,9 @@ describe("FallbackRedirectHandler", () => {
       const mySession = await redirectHandler.handle("https://my.app");
       expect(mySession.isLoggedIn).toBe(false);
       expect(mySession.webId).toBeUndefined();
+      expect(
+        await mySession.headersAuthenticator("A", "GET", new Headers())
+      ).toEqual(new Headers());
     });
   });
 });

--- a/packages/node/src/login/oidc/redirectHandler/FallbackRedirectHandler.spec.ts
+++ b/packages/node/src/login/oidc/redirectHandler/FallbackRedirectHandler.spec.ts
@@ -55,7 +55,7 @@ describe("FallbackRedirectHandler", () => {
     it("returns an unauthenticated session", async () => {
       const redirectHandler = new FallbackRedirectHandler();
       const mySession = await redirectHandler.handle("https://my.app");
-      expect(mySession.isLoggedIn).toEqual(false);
+      expect(mySession.isLoggedIn).toBe(false);
       expect(mySession.webId).toBeUndefined();
     });
   });

--- a/packages/node/src/login/oidc/redirectHandler/FallbackRedirectHandler.ts
+++ b/packages/node/src/login/oidc/redirectHandler/FallbackRedirectHandler.ts
@@ -25,6 +25,7 @@
  */
 
 import {
+  HeadersAuthenticator,
   IRedirectHandler,
   ISessionInfo,
 } from "@inrupt/solid-client-authn-core";
@@ -56,7 +57,12 @@ export class FallbackRedirectHandler implements IRedirectHandler {
   async handle(
     // The argument is ignored, but must be present to implement the interface
     _redirectUrl: string
-  ): Promise<ISessionInfo & { fetch: typeof fetch }> {
+  ): Promise<
+    ISessionInfo & {
+      fetch: typeof fetch;
+      headersAuthenticator: HeadersAuthenticator;
+    }
+  > {
     return getUnauthenticatedSession();
   }
 }

--- a/packages/node/src/login/oidc/refresh/TokenRefresher.spec.ts
+++ b/packages/node/src/login/oidc/refresh/TokenRefresher.spec.ts
@@ -311,12 +311,12 @@ describe("TokenRefresher", () => {
       "some old refresh token",
       await mockKeyPair()
     );
-    expect(refreshedTokens.refreshToken).toEqual("some new refresh token");
+    expect(refreshedTokens.refreshToken).toBe("some new refresh token");
 
     // Check that the session information is stored in the provided storage
     await expect(
       mockedStorage.getForUser("mySession", "refreshToken")
-    ).resolves.toEqual("some new refresh token");
+    ).resolves.toBe("some new refresh token");
   });
 
   it("calls the refresh token rotation handler if one is provided", async () => {
@@ -338,7 +338,7 @@ describe("TokenRefresher", () => {
       mockEmitter
     );
 
-    expect(refreshedTokens.refreshToken).toEqual("some new refresh token");
+    expect(refreshedTokens.refreshToken).toBe("some new refresh token");
     expect(mockEmit).toHaveBeenCalledWith(
       EVENTS.NEW_REFRESH_TOKEN,
       "some new refresh token"

--- a/packages/node/src/sessionInfo/SessionInfoManager.ts
+++ b/packages/node/src/sessionInfo/SessionInfoManager.ts
@@ -30,6 +30,7 @@ import {
   ISessionInfoManager,
   ISessionInfoManagerOptions,
   IStorageUtility,
+  HeadersAuthenticator,
 } from "@inrupt/solid-client-authn-core";
 import { v4 } from "uuid";
 // eslint-disable-next-line no-shadow
@@ -38,11 +39,17 @@ import { KEY_REGISTERED_SESSIONS } from "../constant";
 
 export function getUnauthenticatedSession(): ISessionInfo & {
   fetch: typeof fetch;
+  headersAuthenticator: HeadersAuthenticator;
 } {
   return {
     isLoggedIn: false,
     sessionId: v4(),
     fetch,
+    headersAuthenticator: async (
+      resource: string,
+      method: string,
+      headers: Headers
+    ) => headers,
   };
 }
 

--- a/packages/node/src/util/urlPath.spec.ts
+++ b/packages/node/src/util/urlPath.spec.ts
@@ -23,31 +23,31 @@ import { appendToUrlPathname } from "./urlPath";
 
 describe("urlPath", () => {
   it("should remove one slash if empty path", () => {
-    expect(appendToUrlPathname("https://ex.com/", "/test")).toEqual(
+    expect(appendToUrlPathname("https://ex.com/", "/test")).toBe(
       "https://ex.com/test"
     );
 
     expect(
       appendToUrlPathname("https://ex.com/", "////only-remove-one-slash")
-    ).toEqual("https://ex.com////only-remove-one-slash");
+    ).toBe("https://ex.com////only-remove-one-slash");
   });
 
   it("should remove one slash if non-empty path", () => {
-    expect(appendToUrlPathname("https://ex.com/a/", "/test")).toEqual(
+    expect(appendToUrlPathname("https://ex.com/a/", "/test")).toBe(
       "https://ex.com/a/test"
     );
 
     expect(
       appendToUrlPathname("https://ex.com/a/", "////only-remove-one-slash")
-    ).toEqual("https://ex.com/a////only-remove-one-slash");
+    ).toBe("https://ex.com/a////only-remove-one-slash");
   });
 
   it("should add a slash before appending slash", () => {
-    expect(appendToUrlPathname("https://ex.com", "test")).toEqual(
+    expect(appendToUrlPathname("https://ex.com", "test")).toBe(
       "https://ex.com/test"
     );
 
-    expect(appendToUrlPathname("https://ex.com/a", "test")).toEqual(
+    expect(appendToUrlPathname("https://ex.com/a", "test")).toBe(
       "https://ex.com/a/test"
     );
   });

--- a/packages/oidc/src/cleanup/cleanup.spec.ts
+++ b/packages/oidc/src/cleanup/cleanup.spec.ts
@@ -37,27 +37,25 @@ jest.mock("@inrupt/oidc-client", () => {
 
 describe("removeOidcQueryParam", () => {
   it("removes the 'code' query string if present", () => {
-    expect(removeOidcQueryParam("https://some.url/?code=aCode")).toEqual(
+    expect(removeOidcQueryParam("https://some.url/?code=aCode")).toBe(
       "https://some.url/"
     );
   });
 
   it("removes the 'state' query string if present", () => {
-    expect(removeOidcQueryParam("https://some.url/?state=arkansas")).toEqual(
+    expect(removeOidcQueryParam("https://some.url/?state=arkansas")).toBe(
       "https://some.url/"
     );
   });
 
   it("removes the hash part of the IRI", () => {
-    expect(removeOidcQueryParam("https://some.url/#some-anchor")).toEqual(
+    expect(removeOidcQueryParam("https://some.url/#some-anchor")).toBe(
       "https://some.url/"
     );
   });
 
   it("returns an URL without query strings as is", () => {
-    expect(removeOidcQueryParam("https://some.url/")).toEqual(
-      "https://some.url/"
-    );
+    expect(removeOidcQueryParam("https://some.url/")).toBe("https://some.url/");
   });
 
   it("preserves other query strings", () => {
@@ -65,7 +63,7 @@ describe("removeOidcQueryParam", () => {
       removeOidcQueryParam(
         "https://some.url/?code=someCode&state=someState&otherQuery=aValue"
       )
-    ).toEqual("https://some.url/?otherQuery=aValue");
+    ).toBe("https://some.url/?otherQuery=aValue");
   });
 });
 

--- a/packages/oidc/src/dcr/clientRegistrar.spec.ts
+++ b/packages/oidc/src/dcr/clientRegistrar.spec.ts
@@ -98,7 +98,7 @@ describe("registerClient", () => {
     await registerClient(options, getMockIssuer());
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
-    expect(myFetch.mock.calls[0][1]?.headers.Authorization).toEqual(
+    expect(myFetch.mock.calls[0][1]?.headers.Authorization).toBe(
       "Bearer some token"
     );
   });
@@ -107,9 +107,9 @@ describe("registerClient", () => {
     const myFetch = getSuccessfulFetch();
     global.fetch = myFetch;
     const client = await registerClient(getMockOptions(), getMockIssuer());
-    expect(client.clientId).toEqual("some id");
-    expect(client.clientSecret).toEqual("some secret");
-    expect(client.idTokenSignedResponseAlg).toEqual("RS256");
+    expect(client.clientId).toBe("some id");
+    expect(client.clientSecret).toBe("some secret");
+    expect(client.idTokenSignedResponseAlg).toBe("RS256");
   });
 
   // TODO: this only tests the minimal registration request.

--- a/packages/oidc/src/dpop/tokenExchange.spec.ts
+++ b/packages/oidc/src/dpop/tokenExchange.spec.ts
@@ -208,7 +208,7 @@ describe("getTokens", () => {
     );
     const headers = myFetch.mock.calls[0][1]?.headers as Record<string, string>;
     // c29tZSBjbGllbnQ6c29tZSBzZWNyZXQ= is 'some client:some secret' encoded in base 64
-    expect(headers.Authorization).toEqual(
+    expect(headers.Authorization).toBe(
       "Basic c29tZSBjbGllbnQ6c29tZSBzZWNyZXQ="
     );
   });
@@ -264,11 +264,9 @@ describe("getTokens", () => {
     const myFetch = mockFetch(JSON.stringify(mockDpopTokens()), 200);
     await getTokens(mockIssuer(), mockClient(), mockEndpointInput(), true);
     const headers = myFetch.mock.calls[0][1]?.headers as Record<string, string>;
-    expect(headers["content-type"]).toEqual(
-      "application/x-www-form-urlencoded"
-    );
+    expect(headers["content-type"]).toBe("application/x-www-form-urlencoded");
     const body = myFetch.mock.calls[0][1]?.body as string;
-    expect(body).toEqual(
+    expect(body).toBe(
       "grant_type=authorization_code&redirect_uri=https%3A%2F%2Fmy.app%2Fredirect&code=some+code&code_verifier=some+pkce+token&client_id=some+client"
     );
   });
@@ -312,7 +310,7 @@ describe("getTokens", () => {
       mockEndpointInput(),
       true
     );
-    expect(result?.refreshToken).toEqual("some token");
+    expect(result?.refreshToken).toBe("some token");
   });
 
   it("throws if the access token is missing", async () => {

--- a/packages/oidc/src/refresh/refreshGrant.spec.ts
+++ b/packages/oidc/src/refresh/refreshGrant.spec.ts
@@ -58,7 +58,7 @@ describe("refreshGrant", () => {
     );
     const headers = myFetch.mock.calls[0][1]?.headers as Record<string, string>;
     // c29tZSBjbGllbnQ6c29tZSBzZWNyZXQ= is 'some client:some secret' encoded in base 64
-    expect(headers.Authorization).toEqual(
+    expect(headers.Authorization).toBe(
       "Basic c29tZSBjbGllbnQ6c29tZSBzZWNyZXQ="
     );
   });
@@ -84,7 +84,7 @@ describe("refreshGrant", () => {
       mockIssuer().tokenEndpoint.toString()
     );
     const headers = myFetch.mock.calls[0][1]?.headers as Record<string, string>;
-    expect(headers.DPoP).not.toBeUndefined();
+    expect(headers.DPoP).toBeDefined();
     const dpopHeader = headers.DPoP;
     const dpopProof = await jwtVerify(
       dpopHeader,


### PR DESCRIPTION
<!-- When adding a new feature: -->

# Checklist

- [X] All acceptance criteria are met.
- [X] Relevant documentation, if any, has been written/updated.
- [X] The changelog has been updated, if applicable.
- [X] New functions/types have been exported in `index.ts`, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

-----

As discussed in #1657, this PR adds two main features, which are fully tested and documented (as JSDoc).
(If there's another place that requires documentation writing around this, please let me know)

### 1. `Session#authenticateHeaders`

This is a new method that exists in both Node.js and browsers, and allows an authenticated headers object to be created based on a given request input.

This method enables authenticated request execution to be delegated to other services, such as Web workers.

This approach does not leak any of the internal secrets of the session object, as it just signs the request, within sharing the internal keys.

Example usage:
```javascript
const authHeaders = session.authenticateHeaders(
  'https://example.org',
  'GET',
  new Headers({ accept: 'text/turtle' }),
);
```

### 2. Web worker helpers

To simplify the usage of this library within Web workers, I've added some helper classes that can be used to handle the communication channel between the main window and a worker.

This communication channel exposes a fetch-like method to the worker, and follows the following flow:

* Worker wants to do an authenticated request.
* Worker sends request information to the main Window.
* Window constructs authenticated headers for the request information.
* Window sends back authenticated headers to the Worker.
* Worker performs request using the authenticated headers.

I've also adapted the [single bundle example](https://github.com/rubensworks/solid-client-authn-js/tree/feature/web-workers/packages/browser/examples/single/bundle) so that authenticated fetch requests can also be done via workers, as an example.

Furthermore, I've tested this approach within the (request-heavy) Comunica query engine, and everything seems to be working (with good performance) there as well: https://data.rubensworks.net/tmp/comunica-solid/

Example usage (Window):
```javascript
   const session = getDefaultSession();
   const worker = new Worker(...);
   const windowToWorkerHandler = new WindowToWorkerHandler(this, worker, session);

   worker.onmessage = async (message) => {
      if (windowToWorkerHandler.onmessage(message)) {
        // This means that the message was taken care of by the handler
      } else {
        // Optionally, take care of any other custom messages that your worker may send.
      }
    };
```

Example usage (Worker):
```javascript
   const workerToWindowHandler = new WorkerToWindowHandler(self);
   self.onmessage = (message => {
    if (workerToWindowHandler.onmessage(message)) {
      // This means that the message was taken care of by the handler
    } else {
      // Optionally, take care of any other custom messages that your worker may receive.
    }


   // Use the authenticated fetch function
  const authFetch = workerToWindowHandler.buildAuthenticatedFetch();
  await authFetch('https://example.org/');
```