### PR TITLE
v1.11.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased
 
+The following changes have been implemented but not released yet:
+
+- 
+
+## 1.11.3 - 2021-08-24
+
 ### Bugfixes
 
 #### node
@@ -27,8 +33,6 @@ scope is now added to token requests.
 OIDC package now depends on a fork, `@inrupt/oidc-client`, so that we can ensure
 the dependencies are kept up-to-date. This should be transparent for users of
 `@inrupt/solid-client-authn-browser`.
-
-The following sections document changes that have been released already:
 
 ## 1.11.2 - 2021-08-24
 

--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
   "packages": ["packages/*"],
-  "version": "1.11.2"
+  "version": "1.11.3"
 }

--- a/packages/browser/package-lock.json
+++ b/packages/browser/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/solid-client-authn-browser",
-  "version": "1.11.2",
+  "version": "1.11.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/solid-client-authn-browser",
-  "version": "1.11.2",
+  "version": "1.11.3",
   "license": "MIT",
   "types": "dist/index",
   "browser": "dist/index.js",
@@ -43,8 +43,8 @@
     "webpack-merge": "^5.7.2"
   },
   "dependencies": {
-    "@inrupt/oidc-client-ext": "^1.11.2",
-    "@inrupt/solid-client-authn-core": "^1.11.2",
+    "@inrupt/oidc-client-ext": "^1.11.3",
+    "@inrupt/solid-client-authn-core": "^1.11.3",
     "@types/lodash.clonedeep": "^4.5.6",
     "@types/node": "^16.11.12",
     "@types/uuid": "^8.3.0",

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/solid-client-authn-core",
-  "version": "1.11.2",
+  "version": "1.11.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/solid-client-authn-core",
-  "version": "1.11.2",
+  "version": "1.11.3",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index",

--- a/packages/node/package-lock.json
+++ b/packages/node/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/solid-client-authn-node",
-  "version": "1.11.2",
+  "version": "1.11.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/solid-client-authn-node",
-  "version": "1.11.2",
+  "version": "1.11.3",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index",
@@ -30,7 +30,7 @@
     "typescript": "^4.0.5"
   },
   "dependencies": {
-    "@inrupt/solid-client-authn-core": "^1.11.2",
+    "@inrupt/solid-client-authn-core": "^1.11.3",
     "@types/node": "^16.11.12",
     "@types/uuid": "^8.3.0",
     "cross-fetch": "^3.0.6",

--- a/packages/oidc/package-lock.json
+++ b/packages/oidc/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/oidc-client-ext",
-  "version": "1.11.2",
+  "version": "1.11.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/packages/oidc/package.json
+++ b/packages/oidc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/oidc-client-ext",
-  "version": "1.11.2",
+  "version": "1.11.3",
   "description": "A module extending oidc-client-js with new features, such as dynamic client registration and DPoP support.",
   "homepage": "https://github.com/inrupt/solid-client-authn-js/tree/main/packages/oidc/",
   "bugs": "https://github.com/inrupt/solid-client-authn-js/issues",
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@inrupt/oidc-client": "^1.11.6",
-    "@inrupt/solid-client-authn-core": "^1.11.2",
+    "@inrupt/solid-client-authn-core": "^1.11.3",
     "@types/jest": "^27.0.3",
     "@types/uuid": "^8.3.0",
     "form-urlencoded": "~6.0.3",


### PR DESCRIPTION
This PR bumps the version to 1.11.3.

# Checklist

- [X] I used `npm run lerna-version -- <major|minor|patch> --no-push` to update the version number, first inspecting the CHANGELOG to determine if the release was major, minor or patch.
- [X] The CHANGELOG has been updated to show version and release date - https://keepachangelog.com/en/1.0.0/.
- [X] The **only** commits in this PR are:
  - the CHANGELOG update.
  - the version update.
- [X] I will make sure **not** to squash these commits, but **rebase** instead.
- [ ] Once this PR is merged, I will push the tag created by `lerna version ...` (e.g. `git push origin vX.X.X`).
