### PR TITLE
Temporarily remove MacOS from CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         # Available OS's: https://help.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners
-        os: [ubuntu-20.04, windows-2019, macos-10.15]
+        os: [ubuntu-20.04, windows-2019]
         node-version: [16.x, 14.x, 12.x]
     steps:
       - uses: actions/checkout@v2.4.0


### PR DESCRIPTION
The MacOS runners seem to be overrun at the moment, and the CI jobs aren't getting through. It is possible the large amount of Dependabot PRs in parallel are causing that (because they were just enabled on demo packages, and there was some catching up to do). I will try to re-enable them once the PR backlog is back to normal.