### PR TITLE
Ensure we check that scopesSupported actually exists

### DIFF
--- a/packages/core/src/login/oidc/IClientRegistrar.ts
+++ b/packages/core/src/login/oidc/IClientRegistrar.ts
@@ -77,6 +77,7 @@ function determineClientType(
     return "static";
   }
   if (
+    issuerConfig.scopesSupported &&
     issuerConfig.scopesSupported.includes("webid") &&
     options.clientId !== undefined &&
     isValidUrl(options.clientId)

--- a/packages/core/src/login/oidc/IIssuerConfig.ts
+++ b/packages/core/src/login/oidc/IIssuerConfig.ts
@@ -38,7 +38,7 @@ export interface IIssuerConfig {
   userinfoEndpoint?: string;
   jwksUri: string;
   registrationEndpoint?: string;
-  scopesSupported: string[];
+  scopesSupported?: string[];
   responseTypesSupported?: string[];
   responseModesSupported?: string[];
   grantTypesSupported?: string[];


### PR DESCRIPTION
<!-- When fixing a bug: -->

This PR fixes bug #1991 where by `t.scopesSupport` is undefined — basically the code in https://github.com/inrupt/solid-client-authn-js/pull/1968 incorrectly assumed that `scopesSupported` was always present, but the marshalling code in https://github.com/inrupt/solid-client-authn-js/blob/57849d2ff0a37892650d19fdc6e6fa2924ee599b/packages/browser/src/login/oidc/IssuerConfigFetcher.ts doesn't actually ensure the shape of the IssuerConfig, and the [use of `as unknown as IIssuerConfig`](https://github.com/inrupt/solid-client-authn-js/blob/57849d2ff0a37892650d19fdc6e6fa2924ee599b/packages/browser/src/login/oidc/IssuerConfigFetcher.ts#L143) results in us accessing a key that doesn't actually exist.
 
A further fix would be to actually explicitly build the IssuerConfig structure from the values, without using `as`, such that we build an structure with defaults set (like we do in node.js). The issue we saw was that `scopesSupported` in node is always present due to how it builds IssuerConfig, but in browser, that's not true.

We could optionally make this PR actually implement a proper parsing of IssuerConfig with default values, and ensure that both browser and node truly do conform to the structures we expect, though I think that may be out of scope for a fix on `1.11.x`

- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
