### PR TITLE
Add default value for OP-supported scopes (browser)

### DIFF
--- a/packages/browser/src/login/oidc/IssuerConfigFetcher.spec.ts
+++ b/packages/browser/src/login/oidc/IssuerConfigFetcher.spec.ts
@@ -100,4 +100,24 @@ describe("IssuerConfigFetcher", () => {
     expect(fetchedConfig.scopesSupported).toContain("openid");
     expect(fetchedConfig.scopesSupported).toContain("offline_access");
   });
+
+  it("should return a default value for the supported scopes if not advertized by the OpenID provider", async () => {
+    const fetchResponse = new NodeResponse(
+      JSON.stringify({
+        issuer: "https://example.com",
+        // eslint-disable-next-line camelcase
+        claim_types_supported: "oidc",
+        scopes_supported: undefined,
+      })
+    ) as unknown as Response;
+    const configFetcher = getIssuerConfigFetcher({
+      storageUtility: mockStorageUtility({}),
+    });
+    const mockFetch = (jest.fn() as any).mockResolvedValueOnce(fetchResponse);
+    window.fetch = mockFetch as typeof window.fetch;
+    const fetchedConfig = await configFetcher.fetchConfig(
+      "https://arbitrary.url"
+    );
+    expect(fetchedConfig.scopesSupported).toContain("openid");
+  });
 });

--- a/packages/browser/src/login/oidc/IssuerConfigFetcher.spec.ts
+++ b/packages/browser/src/login/oidc/IssuerConfigFetcher.spec.ts
@@ -107,7 +107,6 @@ describe("IssuerConfigFetcher", () => {
         issuer: "https://example.com",
         // eslint-disable-next-line camelcase
         claim_types_supported: "oidc",
-        scopes_supported: undefined,
       })
     ) as unknown as Response;
     const configFetcher = getIssuerConfigFetcher({

--- a/packages/browser/src/login/oidc/IssuerConfigFetcher.ts
+++ b/packages/browser/src/login/oidc/IssuerConfigFetcher.ts
@@ -139,7 +139,9 @@ function processConfig(
       parsedConfig[issuerConfigKeyMap[key].toKey] = config[key];
     }
   });
-
+  if (parsedConfig.scopesSupported === undefined) {
+    parsedConfig.scopesSupported = ["openid"];
+  }
   return parsedConfig as unknown as IIssuerConfig;
 }
 

--- a/packages/browser/src/login/oidc/IssuerConfigFetcher.ts
+++ b/packages/browser/src/login/oidc/IssuerConfigFetcher.ts
@@ -139,7 +139,7 @@ function processConfig(
       parsedConfig[issuerConfigKeyMap[key].toKey] = config[key];
     }
   });
-  if (parsedConfig.scopesSupported === undefined) {
+  if (!Array.isArray(parsedConfig.scopesSupported)) {
     parsedConfig.scopesSupported = ["openid"];
   }
   return parsedConfig as unknown as IIssuerConfig;


### PR DESCRIPTION
This sould fix #1991.

@inrupt/solid-client-authn-browser didn't provide a default value for the `scopes_supported` property of the OpenID issuer discovery document. Said config is recommanded, but not mandatory, so a default is now provided in order to be able to rely on its presence.

- [X] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).