### PR TITLE
Prevent silent auth cycle on authentication error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ The following changes have been implemented but not released yet:
 
 ### Bugfixes
 
-- 
+#### browser
+
+- Silent authentication is only attempted once, and no longer retries indefinitely on failure.  
 
 ## 1.11.5 - 2022-02-14
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "prepublishOnly": "npm run build",
     "publish": "lerna publish",
     "publish-preview": "lerna publish from-package",
-    "test": "jest --coverage --verbose",
+    "test": "lerna run test",
     "test:e2e": "jest --config jest.e2e.config.js",
     "lerna-version": "lerna version",
     "install-sandbox": "npm ci && npm ci --prefix .codesandbox/sandbox",

--- a/packages/browser/src/ClientAuthentication.spec.ts
+++ b/packages/browser/src/ClientAuthentication.spec.ts
@@ -37,7 +37,6 @@ import { LogoutHandlerMock } from "./logout/__mocks__/LogoutHandler";
 import { mockSessionInfoManager } from "./sessionInfo/__mocks__/SessionInfoManager";
 import ClientAuthentication from "./ClientAuthentication";
 import { mockDefaultIssuerConfigFetcher } from "./login/oidc/__mocks__/IssuerConfigFetcher";
-import { LocalStorageMock } from "./storage/__mocks__/LocalStorage";
 
 jest.mock("@inrupt/solid-client-authn-core", () => {
   const actualCoreModule = jest.requireActual(

--- a/packages/browser/src/ClientAuthentication.ts
+++ b/packages/browser/src/ClientAuthentication.ts
@@ -36,7 +36,6 @@ import {
 } from "@inrupt/solid-client-authn-core";
 import { removeOidcQueryParam } from "@inrupt/oidc-client-ext";
 import { EventEmitter } from "events";
-import { KEY_CURRENT_SESSION } from "./constant";
 
 // By only referring to `window` at runtime, apps that do server-side rendering
 // won't run into errors when rendering code that instantiates a
@@ -112,13 +111,9 @@ export default class ClientAuthentication {
   // if the expected information cannot be found.
   // Note that the ID token is not stored, which means the session information
   // cannot be validated at this point.
-  validateCurrentSession = async (): Promise<
-    (ISessionInfo & ISessionInternalInfo) | null
-  > => {
-    const currentSessionId = window.localStorage.getItem(KEY_CURRENT_SESSION);
-    if (currentSessionId === null) {
-      return null;
-    }
+  validateCurrentSession = async (
+    currentSessionId: string
+  ): Promise<(ISessionInfo & ISessionInternalInfo) | null> => {
     const sessionInfo = await this.sessionInfoManager.get(currentSessionId);
     if (
       sessionInfo === undefined ||

--- a/packages/browser/src/Session.spec.ts
+++ b/packages/browser/src/Session.spec.ts
@@ -270,6 +270,24 @@ describe("Session", () => {
       expect(mySession.info.webId).toBe("https://some.webid#them");
     });
 
+    it("updates the localStorage if the login is completed", async () => {
+      const clientAuthentication = mockClientAuthentication();
+      clientAuthentication.handleIncomingRedirect = jest.fn(
+        async (_url: string) => {
+          return {
+            isLoggedIn: true,
+            sessionId: "a session ID",
+            webId: "https://some.webid#them",
+          };
+        }
+      );
+      const mySession = new Session({ clientAuthentication });
+      await mySession.handleIncomingRedirect("https://some.url");
+      expect(window.localStorage.getItem(KEY_CURRENT_SESSION)).toBe(
+        mySession.info.sessionId
+      );
+    });
+
     it("directly returns the session's info if already logged in", async () => {
       const clientAuthentication = mockClientAuthentication();
       clientAuthentication.handleIncomingRedirect = jest.fn(

--- a/packages/browser/src/Session.ts
+++ b/packages/browser/src/Session.ts
@@ -227,21 +227,16 @@ export class Session extends EventEmitter {
     );
 
     // When a session is logged in, we want to track its ID in local storage to
-    // enable silent refresh.
-    this.on(EVENTS.LOGIN, () => {
-      // Store the current session ID specifically in 'localStorage' (i.e., not using
-      // any other storage mechanism), as we don't deem this information to be
-      // sensitive, and we want to ensure it survives a browser tab refresh.
-      window.localStorage.setItem(KEY_CURRENT_SESSION, this.info.sessionId);
-    });
+    // enable silent refresh. The current session ID specifically stored in 'localStorage'
+    // (as opposed to using our storage abstraction layer) because it is only
+    // used in a browser-specific mechanism.
+    this.on(EVENTS.LOGIN, () =>
+      window.localStorage.setItem(KEY_CURRENT_SESSION, this.info.sessionId)
+    );
 
-    this.on(EVENTS.SESSION_EXPIRED, async () => {
-      await this.internalLogout(false);
-    });
+    this.on(EVENTS.SESSION_EXPIRED, () => this.internalLogout(false));
 
-    this.on(EVENTS.ERROR, async () => {
-      await this.internalLogout(false);
-    });
+    this.on(EVENTS.ERROR, () => this.internalLogout(false));
   }
 
   /**

--- a/packages/browser/src/Session.ts
+++ b/packages/browser/src/Session.ts
@@ -227,6 +227,27 @@ export class Session extends EventEmitter {
         this
       )
     );
+
+    // When a session is logged in, we want to track its ID in local storage to
+    // enable silent refresh.
+    this.on("login", () => {
+      // Store the current session ID specifically in 'localStorage' (i.e., not using
+      // any other storage mechanism), as we don't deem this information to be
+      // sensitive, and we want to ensure it survives a browser tab refresh.
+      window.localStorage.setItem(KEY_CURRENT_SESSION, this.info.sessionId);
+    });
+
+    // On logout, silent refresh should no longer be considered a viable option.
+    this.on("logout", () => {
+      window.localStorage.removeItem(KEY_CURRENT_SESSION);
+    });
+
+    // If an error happens, silent refresh should no longer be considered a viable option
+    // to prevent endless redirection, and session information should be cleared.
+    this.on(EVENTS.ERROR, async () => {
+      window.localStorage.removeItem(KEY_CURRENT_SESSION);
+      await this.logout();
+    });
   }
 
   /**

--- a/packages/browser/src/Session.ts
+++ b/packages/browser/src/Session.ts
@@ -104,9 +104,7 @@ export async function silentlyAuthenticate(
   },
   session: Session
 ): Promise<boolean> {
-  // Check if we have session information in storage - if we do then we may be
-  // currently logged in, and the user has refreshed their browser page.
-  const storedSessionInfo = await clientAuthn.validateCurrentSession();
+  const storedSessionInfo = await clientAuthn.validateCurrentSession(sessionId);
   if (storedSessionInfo !== null) {
     // It can be really useful to save the user's current browser location,
     // so that we can restore it after completing the silent authentication

--- a/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
+++ b/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
@@ -41,7 +41,6 @@ import {
 } from "./AuthCodeRedirectHandler";
 import { RedirectorMock } from "../__mocks__/Redirector";
 import { SessionInfoManagerMock } from "../../../sessionInfo/__mocks__/SessionInfoManager";
-import { KEY_CURRENT_SESSION } from "../../../constant";
 import { LocalStorageMock } from "../../../storage/__mocks__/LocalStorage";
 import {
   mockDefaultTokenRefresher,
@@ -455,11 +454,6 @@ describe("AuthCodeRedirectHandler", () => {
       });
       await authCodeRedirectHandler.handle(
         "https://coolsite.com/redirect?code=someCode&state=oauth2StateValue"
-      );
-      // Check that the current session is stored correctly __specifically__ in
-      // 'localStorage'.
-      expect(window.localStorage.getItem(KEY_CURRENT_SESSION)).toBe(
-        "mySession"
       );
       await expect(
         mockedStorage.getForUser("mySession", "redirectUrl", {

--- a/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
+++ b/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
@@ -42,7 +42,6 @@ import {
   CodeExchangeResult,
 } from "@inrupt/oidc-client-ext";
 import { EventEmitter } from "events";
-import { KEY_CURRENT_SESSION } from "../../../constant";
 
 // A lifespan of 30 minutes is ESS's default. This could be removed if we
 // configure the server to return the remaining lifespan of the cookie.
@@ -156,11 +155,6 @@ export class AuthCodeRedirectHandler implements IRedirectHandler {
       "issuer",
       { errorIfNull: true }
     )) as string;
-
-    // Store the current session ID specifically in 'localStorage' (i.e., not using
-    // any other storage mechanism), as we don't deem this information to be
-    // sensitive, and we want to ensure it survives a browser tab refresh.
-    window.localStorage.setItem(KEY_CURRENT_SESSION, storedSessionId);
 
     const issuerConfig = await this.issuerConfigFetcher.fetchConfig(issuer);
     const client: IClient = await this.clientRegistrar.getClient(

--- a/packages/browser/src/login/oidc/redirectHandler/ErrorOidcHandler.spec.ts
+++ b/packages/browser/src/login/oidc/redirectHandler/ErrorOidcHandler.spec.ts
@@ -71,6 +71,8 @@ describe("ErrorOidcHandler", () => {
     it("calls the onError callback if given with both parameters", async () => {
       window.fetch = jest.fn();
       const mockEmitter = new EventEmitter();
+      // error events must be handled: https://nodejs.org/dist/latest-v16.x/docs/api/events.html#error-events
+      mockEmitter.on(EVENTS.ERROR, jest.fn());
       const mockEmit = jest.spyOn(mockEmitter, "emit");
 
       const redirectHandler = new ErrorOidcHandler();
@@ -91,6 +93,8 @@ describe("ErrorOidcHandler", () => {
       window.fetch = jest.fn();
       const mockEmitter = new EventEmitter();
       const mockEmit = jest.spyOn(mockEmitter, "emit");
+      // error events must be handled: https://nodejs.org/dist/latest-v16.x/docs/api/events.html#error-events
+      mockEmitter.on(EVENTS.ERROR, jest.fn());
 
       const redirectHandler = new ErrorOidcHandler();
       const mySession = await redirectHandler.handle(

--- a/packages/core/src/authenticatedFetch/fetchFactory.spec.ts
+++ b/packages/core/src/authenticatedFetch/fetchFactory.spec.ts
@@ -575,6 +575,8 @@ describe("buildAuthenticatedFetch", () => {
         )
       ) as any;
     const mockEmitter = new EventEmitter();
+    // 'error' events must be listened to.
+    mockEmitter.on(EVENTS.ERROR, jest.fn());
     const spiedEmit = jest.spyOn(mockEmitter, "emit");
 
     await buildAuthenticatedFetch(mockedFetch, "myToken", {

--- a/packages/core/src/constant.ts
+++ b/packages/core/src/constant.ts
@@ -32,7 +32,8 @@ export const SOLID_CLIENT_AUTHN_KEY_PREFIX = "solidClientAuthn:";
 export const PREFERRED_SIGNING_ALG = ["ES256", "RS256"];
 
 export const EVENTS = {
-  ERROR: "error",
+  // `error` is not a valid event name, hence the `onError`.
+  ERROR: "onError",
   LOGIN: "login",
   LOGOUT: "logout",
   NEW_REFRESH_TOKEN: "newRefreshToken",

--- a/packages/core/src/constant.ts
+++ b/packages/core/src/constant.ts
@@ -32,7 +32,7 @@ export const SOLID_CLIENT_AUTHN_KEY_PREFIX = "solidClientAuthn:";
 export const PREFERRED_SIGNING_ALG = ["ES256", "RS256"];
 
 export const EVENTS = {
-  ERROR: "onError",
+  ERROR: "error",
   LOGIN: "login",
   LOGOUT: "logout",
   NEW_REFRESH_TOKEN: "newRefreshToken",

--- a/packages/core/src/constant.ts
+++ b/packages/core/src/constant.ts
@@ -32,10 +32,13 @@ export const SOLID_CLIENT_AUTHN_KEY_PREFIX = "solidClientAuthn:";
 export const PREFERRED_SIGNING_ALG = ["ES256", "RS256"];
 
 export const EVENTS = {
-  NEW_REFRESH_TOKEN: "newRefreshToken",
   ERROR: "onError",
+  LOGIN: "login",
+  LOGOUT: "logout",
+  NEW_REFRESH_TOKEN: "newRefreshToken",
   SESSION_EXPIRED: "sessionExpired",
   SESSION_EXTENDED: "sessionExtended",
+  SESSION_RESTORED: "sessionRestore",
   TIMEOUT_SET: "timeoutSet",
 };
 /**

--- a/packages/core/src/constant.ts
+++ b/packages/core/src/constant.ts
@@ -32,8 +32,8 @@ export const SOLID_CLIENT_AUTHN_KEY_PREFIX = "solidClientAuthn:";
 export const PREFERRED_SIGNING_ALG = ["ES256", "RS256"];
 
 export const EVENTS = {
-  // `error` is not a valid event name, hence the `onError`.
-  ERROR: "onError",
+  // Note that an `error` events MUST be listened to: https://nodejs.org/dist/latest-v16.x/docs/api/events.html#error-events.
+  ERROR: "error",
   LOGIN: "login",
   LOGOUT: "logout",
   NEW_REFRESH_TOKEN: "newRefreshToken",

--- a/packages/node/src/Session.spec.ts
+++ b/packages/node/src/Session.spec.ts
@@ -155,6 +155,42 @@ describe("Session", () => {
           .lastTimeoutHandle
       ).toBe(0);
     });
+
+    it("logs the session out on error", async () => {
+      const mySession = new Session({
+        clientAuthentication: mockClientAuthentication(),
+      });
+      // Spy on the private session logout
+      const spiedLogout = jest.spyOn(
+        mySession as unknown as { internalLogout: () => Promise<void> },
+        "internalLogout"
+      );
+      const logoutEventcallback = jest.fn();
+      mySession.onLogout(logoutEventcallback);
+      mySession.emit(EVENTS.ERROR);
+      // The internal logout should have been called...
+      expect(spiedLogout).toHaveBeenCalled();
+      // ... but the user-initiated logout signal should not have been sent
+      expect(logoutEventcallback).not.toHaveBeenCalled();
+    });
+
+    it("logs the session out on expiration", async () => {
+      const mySession = new Session({
+        clientAuthentication: mockClientAuthentication(),
+      });
+      // Spy on the private session logout
+      const spiedLogout = jest.spyOn(
+        mySession as unknown as { internalLogout: () => Promise<void> },
+        "internalLogout"
+      );
+      const logoutEventcallback = jest.fn();
+      mySession.onLogout(logoutEventcallback);
+      mySession.emit(EVENTS.SESSION_EXPIRED);
+      // The internal logout should have been called...
+      expect(spiedLogout).toHaveBeenCalled();
+      // ... but the user-initiated logout signal should not have been sent
+      expect(logoutEventcallback).not.toHaveBeenCalled();
+    });
   });
 
   describe("login", () => {

--- a/packages/node/src/Session.ts
+++ b/packages/node/src/Session.ts
@@ -207,7 +207,7 @@ export class Session extends EventEmitter {
     // Clears the timeouts on logout so that Node does not hang.
     clearTimeout(this.lastTimeoutHandle);
     this.info.isLoggedIn = false;
-    this.emit("logout");
+    this.emit(EVENTS.LOGOUT);
   };
 
   /**
@@ -242,7 +242,7 @@ export class Session extends EventEmitter {
           if (sessionInfo.isLoggedIn) {
             // The login event can only be triggered **after** the user has been
             // redirected from the IdP with access and ID tokens.
-            this.emit("login");
+            this.emit(EVENTS.LOGIN);
           }
         }
       } finally {
@@ -260,7 +260,7 @@ export class Session extends EventEmitter {
    * @param callback The function called when a user completes login.
    */
   onLogin(callback: () => unknown): void {
-    this.on("login", callback);
+    this.on(EVENTS.LOGIN, callback);
   }
 
   /**
@@ -269,7 +269,7 @@ export class Session extends EventEmitter {
    * @param callback The function called when a user completes logout.
    */
   onLogout(callback: () => unknown): void {
-    this.on("logout", callback);
+    this.on(EVENTS.LOGOUT, callback);
   }
 
   onNewRefreshToken(callback: (newToken: string) => unknown): void {

--- a/packages/node/src/Session.ts
+++ b/packages/node/src/Session.ts
@@ -158,6 +158,9 @@ export class Session extends EventEmitter {
     this.on(EVENTS.TIMEOUT_SET, (timeoutHandle: number) => {
       this.lastTimeoutHandle = timeoutHandle;
     });
+
+    this.on(EVENTS.ERROR, () => this.internalLogout(false));
+    this.on(EVENTS.SESSION_EXPIRED, () => this.internalLogout(false));
   }
 
   /**
@@ -202,12 +205,16 @@ export class Session extends EventEmitter {
   /**
    * Logs the user out of the application. This does not log the user out of the identity provider, and should not redirect the user away.
    */
-  logout = async (): Promise<void> => {
+  logout = async (): Promise<void> => this.internalLogout(true);
+
+  private internalLogout = async (emitEvent: boolean): Promise<void> => {
     await this.clientAuthentication.logout(this.info.sessionId);
     // Clears the timeouts on logout so that Node does not hang.
     clearTimeout(this.lastTimeoutHandle);
     this.info.isLoggedIn = false;
-    this.emit(EVENTS.LOGOUT);
+    if (emitEvent) {
+      this.emit(EVENTS.LOGOUT);
+    }
   };
 
   /**


### PR DESCRIPTION
When an authentication error happens, local storage is now cleared in order to prevent further silent login attempts. This should fix the issue where failed login cycle endlessly.

In order to implement this, the Session object listens on authentication events bubbled up by the handlers. In particular, on login, the current session ID is stored in local storage to enable silent auth in the future, and it is cleared on logout/auth error.

- [X] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).