### PR TITLE
Clear pkce verifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,12 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 The following changes have been implemented but not released yet:
 
-### New features
+### Bugfixes
 
 - @inrupt/oidc-client-ext: remove ts-jest from package dependencies.
+- The PKCE verifier is now cleared from storage as soon as it has been used in the
+token exchange, regardless of the token type (it used to not be cleared from part
+of the storage when getting a DPoP-bound token).
 
 ## 1.11.6 - 2022-03-04
 

--- a/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
+++ b/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
@@ -359,7 +359,6 @@ describe("AuthCodeRedirectHandler", () => {
 
     it("returns an authenticated bearer fetch if requested", async () => {
       mockOidcClient();
-      mockLocalStorage({});
 
       const mockedFetch = mockFetch(
         new Response("", {
@@ -398,7 +397,6 @@ describe("AuthCodeRedirectHandler", () => {
 
     it("returns an authenticated DPoP fetch if requested", async () => {
       mockOidcClient();
-      mockLocalStorage({});
       const mockedFetch = jest.fn(global.fetch).mockReturnValue(
         new Promise((resolve) => {
           resolve(
@@ -436,7 +434,6 @@ describe("AuthCodeRedirectHandler", () => {
 
     it("saves session information in storage on successful login", async () => {
       mockOidcClient();
-      mockLocalStorage({});
       window.fetch = jest.fn(global.fetch).mockReturnValue(
         new Promise((resolve) => {
           resolve(
@@ -479,7 +476,6 @@ describe("AuthCodeRedirectHandler", () => {
 
     it("preserves any query strings from the redirect URI", async () => {
       mockOidcClient();
-      mockLocalStorage({});
 
       window.fetch = (jest.fn() as any).mockReturnValue(
         new Promise((resolve) => {
@@ -626,7 +622,6 @@ describe("AuthCodeRedirectHandler", () => {
 
   it("stores information about the resource server cookie in local storage on successful authentication", async () => {
     mockOidcClient();
-    mockLocalStorage({});
 
     // This mocks the fetch to the Resource Server session endpoint
     // Note: Currently, the endpoint only returns the webid in plain/text, it could
@@ -818,7 +813,9 @@ describe("AuthCodeRedirectHandler", () => {
   });
 
   it("returns a fetch that supports the refresh flow", async () => {
-    window.localStorage.setItem("tmp-resource-server-session-enabled", "false");
+    mockLocalStorage({
+      "tmp-resource-server-session-enabled": "false",
+    });
     mockOidcClient();
     const mockedStorage = mockDefaultStorageUtility();
     const coreModule = jest.requireActual(

--- a/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
+++ b/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
@@ -579,7 +579,7 @@ describe("AuthCodeRedirectHandler", () => {
       expect(sessionInfo.expirationDate).toBeNull();
     });
 
-    it("clears the PKCE verifier from session information", async () => {
+    it("clears the oidc-client specific session information", async () => {
       mockOidcClient();
       mockLocalStorage({
         // This mocks how oidc-client stores session information
@@ -614,9 +614,6 @@ describe("AuthCodeRedirectHandler", () => {
       await authCodeRedirectHandler.handle(
         "https://coolsite.com/?code=someCode&state=oauth2StateValue"
       );
-      await expect(
-        storage.getForUser("mySession", "codeVerifier")
-      ).resolves.toBeUndefined();
       expect(window.localStorage.getItem("oidc.oauth2StateValue")).toBeNull();
     });
   });

--- a/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
+++ b/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
@@ -655,7 +655,6 @@ describe("AuthCodeRedirectHandler", () => {
       .mockReturnValueOnce(MOCK_TIMESTAMP)
       .mockReturnValueOnce(MOCK_TIMESTAMP) as typeof Date.now;
 
-    const testIssuer = "some test Issuer";
     const mockedStorage = mockDefaultStorageUtility();
 
     const authCodeRedirectHandler = getAuthCodeRedirectHandler({

--- a/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
+++ b/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.spec.ts
@@ -572,16 +572,7 @@ describe("AuthCodeRedirectHandler", () => {
         // This mocks how oidc-client stores session information
         "oidc.oauth2StateValue": "some arbitrary value",
       });
-      const mockedFetch = jest.fn(global.fetch).mockReturnValue(
-        new Promise((resolve) => {
-          resolve(
-            new Response("", {
-              status: 200,
-            })
-          );
-        })
-      );
-      window.fetch = mockedFetch;
+      mockFetch(new Response());
 
       const authCodeRedirectHandler = getAuthCodeRedirectHandler({
         storageUtility: mockDefaultStorageUtility(),

--- a/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
+++ b/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
@@ -186,9 +186,17 @@ export class AuthCodeRedirectHandler implements IRedirectHandler {
         codeVerifier,
         redirectUrl: storedRedirectIri,
       });
+
+      // Delete oidc-client-specific session information from storage. This is
+      // done automatically when retrieving a bearer token, but since the DPoP
+      // binding uses our custom code, this needs to be done manually.
+      window.localStorage.removeItem(`oidc.${oauthState}`);
     } else {
       tokens = await getBearerToken(url.toString());
     }
+
+    // Clear storage from information which was only required to make the backchannel exchange.
+    await this.storageUtility.deleteForUser(storedSessionId, "codeVerifier");
 
     let refreshOptions: RefreshOptions | undefined;
     if (tokens.refreshToken !== undefined) {

--- a/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
+++ b/packages/browser/src/login/oidc/redirectHandler/AuthCodeRedirectHandler.ts
@@ -176,7 +176,7 @@ export class AuthCodeRedirectHandler implements IRedirectHandler {
     );
 
     let tokens: CodeExchangeResult;
-    const referenceTime = Date.now();
+    const tokenCreatedAt = Date.now();
 
     if (isDpop) {
       tokens = await getDpopToken(issuerConfig, client, {
@@ -255,7 +255,7 @@ export class AuthCodeRedirectHandler implements IRedirectHandler {
       fetch: authFetch,
       expirationDate:
         typeof tokens.expiresIn === "number"
-          ? referenceTime + tokens.expiresIn * 1000
+          ? tokenCreatedAt + tokens.expiresIn * 1000
           : null,
     });
   }

--- a/packages/core/src/storage/StorageUtility.spec.ts
+++ b/packages/core/src/storage/StorageUtility.spec.ts
@@ -598,6 +598,26 @@ describe("loadOidcContextFromStorage", () => {
       dpop: true,
     });
   });
+
+  it("Clears the code verifier", async () => {
+    const mockedStorage = mockStorageUtility({
+      "solidClientAuthenticationUser:mySession": {
+        issuer: "https://my.idp/",
+        codeVerifier: "some code verifier",
+        redirectUrl: "https://my.app/redirect",
+        dpop: "true",
+      },
+    });
+
+    await loadOidcContextFromStorage(
+      "mySession",
+      mockedStorage,
+      mockIssuerConfigFetcher(mockIssuerConfig())
+    );
+    await expect(
+      mockedStorage.getForUser("mySession", "codeVerifier")
+    ).resolves.toBeUndefined();
+  });
 });
 
 describe("saveSessionInfoToStorage", () => {

--- a/packages/core/src/storage/StorageUtility.ts
+++ b/packages/core/src/storage/StorageUtility.ts
@@ -72,6 +72,8 @@ export async function loadOidcContextFromStorage(
         storageUtility.getForUser(sessionId, "redirectUrl"),
         storageUtility.getForUser(sessionId, "dpop", { errorIfNull: true }),
       ]);
+    // Clear the code verifier, which is one-time use.
+    await storageUtility.deleteForUser(sessionId, "codeVerifier");
 
     // Unlike openid-client, this looks up the configuration from storage
     const issuerConfig = await configFetcher.fetchConfig(issuerIri as string);


### PR DESCRIPTION
This clears the PKCE verifier from storage after it has been retrieved to perform the token exchange. 

 Note that the PKCE verifier was stored in two distinct instances:
- As part of the `oidc-client` storage, which was not cleared when binding the exchanged token to a DPoP key because this exchange relies on our custom extension `oidc-client-ext`, rather than on the main library.
-   As part of the session  storage from our library.

A lot of the PR is just test refactoring.

-  [X] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).