### PR TITLE
1.11.7 release

### DIFF
--- a/.github/workflows/e2e-browser.yml
+++ b/.github/workflows/e2e-browser.yml
@@ -32,9 +32,7 @@ jobs:
       - run: npm run bootstrap -- --ci
       - run: npm run build
       - name: Install e2e tests dependencies
-        run: |
-          npm ci
-          npx playwright install --with-deps
+        run: npx playwright install --with-deps
         working-directory: e2e/browser/
       - name: Prepare browser-based end-to-end tests
         run: npm install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 The following changes have been implemented but not released yet:
 
+### New features
+
+- 
+
+## 1.11.7 - 2022-03-16
+
 ### Bugfixes
 
 - @inrupt/oidc-client-ext: remove ts-jest from package dependencies.

--- a/e2e/browser/package-lock.json
+++ b/e2e/browser/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "e2e-browser",
-  "version": "1.0.0",
+  "version": "1.11.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/e2e/browser/package.json
+++ b/e2e/browser/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "e2e-browser",
-  "version": "1.0.0",
+  "version": "1.11.7",
   "description": "Playwright end-2-end test runner for solid-client-authn-browser",
   "scripts": {
     "start": "cd ../../packages/browser/examples/demoClientApp && npm run start",
@@ -16,7 +16,7 @@
   "license": "MIT",
   "devDependencies": {
     "@inrupt/solid-client": "^1.20.1",
-    "@inrupt/solid-client-authn-node": "^1.11.6",
+    "@inrupt/solid-client-authn-node": "^1.11.7",
     "@inrupt/vocab-common-rdf": "^1.0.3",
     "@playwright/test": "^1.18.0",
     "dotenv-flow": "^3.2.0",

--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
   "packages": ["packages/*", "e2e/browser"],
-  "version": "1.11.6"
+  "version": "1.11.7"
 }

--- a/packages/browser/package-lock.json
+++ b/packages/browser/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/solid-client-authn-browser",
-  "version": "1.11.6",
+  "version": "1.11.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/solid-client-authn-browser",
-  "version": "1.11.6",
+  "version": "1.11.7",
   "license": "MIT",
   "types": "dist/index",
   "browser": "dist/index.js",
@@ -43,8 +43,8 @@
     "webpack-merge": "^5.7.2"
   },
   "dependencies": {
-    "@inrupt/oidc-client-ext": "^1.11.6",
-    "@inrupt/solid-client-authn-core": "^1.11.6",
+    "@inrupt/oidc-client-ext": "^1.11.7",
+    "@inrupt/solid-client-authn-core": "^1.11.7",
     "@types/lodash.clonedeep": "^4.5.6",
     "@types/node": "^17.0.2",
     "@types/uuid": "^8.3.0",

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/solid-client-authn-core",
-  "version": "1.11.6",
+  "version": "1.11.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/solid-client-authn-core",
-  "version": "1.11.6",
+  "version": "1.11.7",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index",

--- a/packages/node/package-lock.json
+++ b/packages/node/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/solid-client-authn-node",
-  "version": "1.11.6",
+  "version": "1.11.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/solid-client-authn-node",
-  "version": "1.11.6",
+  "version": "1.11.7",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index",
@@ -32,7 +32,7 @@
     "typescript": "^4.0.5"
   },
   "dependencies": {
-    "@inrupt/solid-client-authn-core": "^1.11.6",
+    "@inrupt/solid-client-authn-core": "^1.11.7",
     "@types/node": "^17.0.2",
     "@types/uuid": "^8.3.0",
     "cross-fetch": "^3.0.6",

--- a/packages/oidc/package-lock.json
+++ b/packages/oidc/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/oidc-client-ext",
-  "version": "1.11.6",
+  "version": "1.11.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/packages/oidc/package.json
+++ b/packages/oidc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/oidc-client-ext",
-  "version": "1.11.6",
+  "version": "1.11.7",
   "description": "A module extending oidc-client-js with new features, such as dynamic client registration and DPoP support.",
   "homepage": "https://github.com/inrupt/solid-client-authn-js/tree/main/packages/oidc/",
   "bugs": "https://github.com/inrupt/solid-client-authn-js/issues",
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@inrupt/oidc-client": "^1.11.6",
-    "@inrupt/solid-client-authn-core": "^1.11.6",
+    "@inrupt/solid-client-authn-core": "^1.11.7",
     "@types/jest": "^27.0.3",
     "@types/uuid": "^8.3.0",
     "form-urlencoded": "~6.0.3",


### PR DESCRIPTION
This PR bumps the version to 1.11.7.

# Checklist

- [X] I used `npm run lerna-version -- <major|minor|patch> --no-push` to update the version number, first inspecting the CHANGELOG to determine if the release was major, minor or patch.
- [X] The CHANGELOG has been updated to show version and release date - https://keepachangelog.com/en/1.0.0/.
- [X] The **only** commits in this PR are:
  - the CHANGELOG update.
  - the version update.
- [ ] Once this PR is merged, I will push the tag created by `lerna version ...` (e.g. `git push origin vX.X.X`).
