### PR TITLE
Clean local storage from deprecated data

### DIFF
--- a/packages/browser/src/Session.ts
+++ b/packages/browser/src/Session.ts
@@ -235,6 +235,11 @@ export class Session extends EventEmitter {
     this.on(EVENTS.SESSION_EXPIRED, () => this.internalLogout(false));
 
     this.on(EVENTS.ERROR, () => this.internalLogout(false));
+
+    // @deprecated: Remove this when removing all support for the useEssSession parameter.
+    // This intends at cleaning up local storage of applications from data related
+    // to the resource server session workaround.
+    window.localStorage.removeItem("tmp-resource-server-session-enabled");
   }
 
   /**


### PR DESCRIPTION
Even if the resource server session workaround was disabled, an entry was present in local storage. This clears that entry so that any client running this code will have no traces left of this workaround.
