### PR TITLE
Refresh client identifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,13 @@ feature in an ESS instance you were running yourself, this change should not
 affect you. If you were using this in a demo app, you may want to clear its local
 storage.
 
-### New features
+### Bugfix
 
-- 
+#### browser
+
+- The refresh flow was broken for browser-based applications using a client identifier, 
+leading to short session lifetime. Now that this is fixed, the background refresh
+will happen normally, and the session will remain active.
 
 ## 1.11.7 - 2022-03-16
 

--- a/packages/browser/examples/single/bundle/package.json
+++ b/packages/browser/examples/single/bundle/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "regenerator-runtime": "^0.13.9"
+    "regenerator-runtime": "^0.13.9",
+    "@inrupt/solid-client-authn-browser": "file:../../../"
   }
 }

--- a/packages/browser/examples/single/bundle/src/App.js
+++ b/packages/browser/examples/single/bundle/src/App.js
@@ -31,6 +31,9 @@ import {
 } from "@inrupt/solid-client-authn-browser";
 
 const REDIRECT_URL = "http://localhost:3113/";
+// This is the IRI where the Client identifier document (i.e. client-app-profile.jsonld)
+// is available to the OIDC issuer. See https://solid.github.io/solid-oidc/#clientids-document
+// for more information.
 const CLIENT_IDENTIFIER =
   "https://raw.githubusercontent.com/inrupt/solid-client-authn-js/main/packages/browser/examples/single/bundle/client-app-profile.jsonld";
 

--- a/packages/browser/examples/single/bundle/src/App.js
+++ b/packages/browser/examples/single/bundle/src/App.js
@@ -31,7 +31,8 @@ import {
 } from "@inrupt/solid-client-authn-browser";
 
 const REDIRECT_URL = "http://localhost:3113/";
-const CLIENT_IDENTIFIER = "https://zwifi.eu/client-id.json";
+const CLIENT_IDENTIFIER =
+  "https://raw.githubusercontent.com/inrupt/solid-client-authn-js/main/packages/browser/examples/single/bundle/client-app-profile.jsonld";
 
 export default function App() {
   const [webId, setWebId] = useState(getDefaultSession().info.webId);

--- a/packages/browser/examples/single/bundle/src/App.js
+++ b/packages/browser/examples/single/bundle/src/App.js
@@ -28,11 +28,10 @@ import {
   handleIncomingRedirect,
   fetch,
   getDefaultSession,
-} from "../../../../dist/index";
+} from "@inrupt/solid-client-authn-browser";
 
 const REDIRECT_URL = "http://localhost:3113/";
-const CLIENT_IDENTIFIER =
-  "https://raw.githubusercontent.com/inrupt/solid-client-authn-js/main/packages/browser/examples/single/bundle/client-app-profile.jsonld";
+const CLIENT_IDENTIFIER = "https://zwifi.eu/client-id.json";
 
 export default function App() {
   const [webId, setWebId] = useState(getDefaultSession().info.webId);

--- a/packages/browser/src/login/oidc/oidcHandlers/AuthorizationCodeWithPkceOidcHandler.ts
+++ b/packages/browser/src/login/oidc/oidcHandlers/AuthorizationCodeWithPkceOidcHandler.ts
@@ -33,6 +33,7 @@ import {
   IRedirector,
   IStorageUtility,
   LoginResult,
+  DEFAULT_SCOPES,
 } from "@inrupt/solid-client-authn-core";
 import { OidcClient } from "@inrupt/oidc-client-ext";
 
@@ -67,9 +68,7 @@ export default class AuthorizationCodeWithPkceOidcHandler
       redirect_uri: oidcLoginOptions.redirectUrl.toString(),
       post_logout_redirect_uri: oidcLoginOptions.redirectUrl.toString(),
       response_type: "code",
-      // The offline_access scope requests that a refresh token be returned.
-      // The webid scope is required as per https://solid.github.io/solid-oidc/#webid-scope
-      scope: "openid offline_access webid",
+      scope: DEFAULT_SCOPES,
       filterProtocolClaims: true,
       // The userinfo endpoint on NSS fails, so disable this for now
       // Note that in Solid, information should be retrieved from the

--- a/packages/core/src/constant.ts
+++ b/packages/core/src/constant.ts
@@ -46,3 +46,14 @@ export const EVENTS = {
  * We want to refresh a token 5 seconds before it expires.
  */
 export const REFRESH_BEFORE_EXPIRATION_SECONDS = 5;
+
+// The openid scope requests an OIDC ID token token to be returned.
+const SCOPE_OPENID = "openid";
+// The offline_access scope requests a refresh token to be returned.
+const SCOPE_OFFLINE = "offline_access";
+// The webid scope is required as per https://solid.github.io/solid-oidc/#webid-scope
+const SCOPE_WEBID = "webid";
+// The scopes are expected as a space-separated list.
+export const DEFAULT_SCOPES = [SCOPE_OPENID, SCOPE_OFFLINE, SCOPE_WEBID].join(
+  " "
+);

--- a/packages/node/src/login/oidc/oidcHandlers/AuthorizationCodeWithPkceOidcHandler.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/AuthorizationCodeWithPkceOidcHandler.ts
@@ -33,6 +33,7 @@ import {
   IRedirector,
   IStorageUtility,
   LoginResult,
+  DEFAULT_SCOPES,
 } from "@inrupt/solid-client-authn-core";
 import { Issuer, generators } from "openid-client";
 import { configToIssuerMetadata } from "../IssuerConfigFetcher";
@@ -78,9 +79,7 @@ export default class AuthorizationCodeWithPkceOidcHandler
       redirect_uri: oidcLoginOptions.redirectUrl,
       code_challenge_method: "S256",
       prompt: "consent",
-      // The offline_access scope asks the provider to issue a refresh token.
-      // The webid scope is required as per https://solid.github.io/solid-oidc/#webid-scope
-      scope: "openid offline_access webid",
+      scope: DEFAULT_SCOPES,
     });
 
     // Stores information to be reused after reload

--- a/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.ts
@@ -39,6 +39,7 @@ import {
   getWebidFromTokenPayload,
   buildAuthenticatedFetch,
   ITokenRefresher,
+  DEFAULT_SCOPES,
 } from "@inrupt/solid-client-authn-core";
 import { KeyObject } from "crypto";
 import { Issuer } from "openid-client";
@@ -83,7 +84,7 @@ export default class ClientCredentialsOidcHandler implements IOidcHandler {
       {
         grant_type: "client_credentials",
         token_endpoint_auth_method: "client_secret_basic",
-        scope: "openid offline_access webid",
+        scope: DEFAULT_SCOPES,
       },
       {
         DPoP:

--- a/packages/oidc/src/__mocks__/issuer.mocks.ts
+++ b/packages/oidc/src/__mocks__/issuer.mocks.ts
@@ -151,7 +151,7 @@ export const mockDpopTokens = (): TokenEndpointRawResponse => {
   };
 };
 
-export const mockClient = (clientId: string = "some client"): IClient => {
+export const mockClient = (clientId = "some client"): IClient => {
   return {
     clientId,
     clientType: "dynamic",

--- a/packages/oidc/src/__mocks__/issuer.mocks.ts
+++ b/packages/oidc/src/__mocks__/issuer.mocks.ts
@@ -151,9 +151,9 @@ export const mockDpopTokens = (): TokenEndpointRawResponse => {
   };
 };
 
-export const mockClient = (): IClient => {
+export const mockClient = (clientId: string = "some client"): IClient => {
   return {
-    clientId: "some client",
+    clientId,
     clientType: "dynamic",
   };
 };

--- a/packages/oidc/src/refresh/refreshGrant.spec.ts
+++ b/packages/oidc/src/refresh/refreshGrant.spec.ts
@@ -19,6 +19,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+import { IClient } from "@inrupt/solid-client-authn-core";
 import { jest, it, describe, expect } from "@jest/globals";
 import { jwtVerify, importJWK } from "jose";
 import {
@@ -112,6 +113,17 @@ describe("refreshGrant", () => {
       await importJWK(keyPair.publicKey)
     );
     expect(dpopProof.payload.htu).toBe(mockIssuer().tokenEndpoint.toString());
+  });
+
+  it("throws if the client identifier is undefined", async () => {
+    const client = mockClient();
+    await expect(
+      refresh("some refresh token", mockIssuer(), {
+        clientId: undefined,
+      } as unknown as IClient)
+    ).rejects.toThrow(
+      "No client ID available when trying to refresh the access token"
+    );
   });
 
   it("throws if the token endpoint returns an unexpected data format (i.e. not JSON)", async () => {

--- a/packages/oidc/src/refresh/refreshGrant.spec.ts
+++ b/packages/oidc/src/refresh/refreshGrant.spec.ts
@@ -63,7 +63,7 @@ describe("refreshGrant", () => {
     );
   });
 
-  it("does not use basic auth if no client secret is available", async () => {
+  it("include the client id in the body if no client secret is available", async () => {
     const myFetch = mockFetch(JSON.stringify(mockBearerTokens()), 200);
     const client = mockClient();
 
@@ -71,8 +71,12 @@ describe("refreshGrant", () => {
     expect(myFetch.mock.calls[0][0]).toBe(
       mockIssuer().tokenEndpoint.toString()
     );
+    // The basic auth scheme should not have been used
     const headers = myFetch.mock.calls[0][1]?.headers as Record<string, string>;
     expect(headers.Authorization).toBeUndefined();
+
+    const body = myFetch.mock.calls[0][1]?.body as BodyInit;
+    expect(body.toString()).toContain("client_id=some+client");
   });
 
   it("includes a DPoP proof if a DPoP key is provided", async () => {

--- a/packages/oidc/src/refresh/refreshGrant.spec.ts
+++ b/packages/oidc/src/refresh/refreshGrant.spec.ts
@@ -63,9 +63,9 @@ describe("refreshGrant", () => {
     );
   });
 
-  it("include the client id in the body if no client secret is available", async () => {
+  it("include the client id in the body if it is an IRI and no client secret is available", async () => {
     const myFetch = mockFetch(JSON.stringify(mockBearerTokens()), 200);
-    const client = mockClient();
+    const client = mockClient("https://client.identifier");
 
     await refresh("some refresh token", mockIssuer(), client);
     expect(myFetch.mock.calls[0][0]).toBe(
@@ -76,7 +76,24 @@ describe("refreshGrant", () => {
     expect(headers.Authorization).toBeUndefined();
 
     const body = myFetch.mock.calls[0][1]?.body as BodyInit;
-    expect(body.toString()).toContain("client_id=some+client");
+    expect(body.toString()).toContain(
+      "client_id=https%3A%2F%2Fclient.identifier"
+    );
+  });
+
+  it("does not include a non-IRI client ID in the body", async () => {
+    const myFetch = mockFetch(JSON.stringify(mockBearerTokens()), 200);
+    const client = mockClient("some non-IRI client id");
+
+    await refresh("some refresh token", mockIssuer(), client);
+    const mockedFetchCall = myFetch.mock.calls[0];
+    expect(mockedFetchCall[0]).toBe(mockIssuer().tokenEndpoint.toString());
+    // The basic auth scheme should not have been used
+    const headers = mockedFetchCall[1]?.headers as Record<string, string>;
+    expect(headers.Authorization).toBeUndefined();
+
+    const body = mockedFetchCall[1]?.body as BodyInit;
+    expect(body.toString()).not.toContain("client_id=some+non-IRI+client+id");
   });
 
   it("includes a DPoP proof if a DPoP key is provided", async () => {

--- a/packages/oidc/src/refresh/refreshGrant.spec.ts
+++ b/packages/oidc/src/refresh/refreshGrant.spec.ts
@@ -116,7 +116,6 @@ describe("refreshGrant", () => {
   });
 
   it("throws if the client identifier is undefined", async () => {
-    const client = mockClient();
     await expect(
       refresh("some refresh token", mockIssuer(), {
         clientId: undefined,

--- a/packages/oidc/src/refresh/refreshGrant.ts
+++ b/packages/oidc/src/refresh/refreshGrant.ts
@@ -76,6 +76,12 @@ export async function refresh(
     };
   }
 
+  if (client.clientId === undefined) {
+    throw new Error(
+      "No client ID available when trying to refresh the access token."
+    );
+  }
+
   let authHeader = {};
   if (client.clientSecret !== undefined) {
     authHeader = {

--- a/packages/oidc/src/refresh/refreshGrant.ts
+++ b/packages/oidc/src/refresh/refreshGrant.ts
@@ -63,6 +63,12 @@ export async function refresh(
   client: IClient,
   dpopKey?: KeyPair
 ): Promise<TokenEndpointResponse> {
+  if (client.clientId === undefined) {
+    throw new Error(
+      "No client ID available when trying to refresh the access token."
+    );
+  }
+
   const requestBody: IRefreshRequestBody = {
     grant_type: "refresh_token",
     refresh_token: refreshToken,
@@ -74,12 +80,6 @@ export async function refresh(
     dpopHeader = {
       DPoP: await createDpopHeader(issuer.tokenEndpoint, "POST", dpopKey),
     };
-  }
-
-  if (client.clientId === undefined) {
-    throw new Error(
-      "No client ID available when trying to refresh the access token."
-    );
   }
 
   let authHeader = {};

--- a/packages/oidc/src/refresh/refreshGrant.ts
+++ b/packages/oidc/src/refresh/refreshGrant.ts
@@ -32,7 +32,10 @@ import {
 import formUrlEncoded from "form-urlencoded";
 import { validateTokenEndpointResponse } from "../dpop/tokenExchange";
 
-interface RefreshRequestBody {
+// Camelcase identifiers are required in the OIDC specification.
+/* eslint-disable camelcase */
+
+interface IRefreshRequestBody {
   grant_type: "refresh_token";
   refresh_token: string;
   scope: typeof DEFAULT_SCOPES;
@@ -48,7 +51,7 @@ export async function refresh(
   client: IClient,
   dpopKey?: KeyPair
 ): Promise<TokenEndpointResponse> {
-  const requestBody: RefreshRequestBody = {
+  const requestBody: IRefreshRequestBody = {
     grant_type: "refresh_token",
     refresh_token: refreshToken,
     scope: DEFAULT_SCOPES,

--- a/packages/oidc/src/refresh/refreshGrant.ts
+++ b/packages/oidc/src/refresh/refreshGrant.ts
@@ -42,6 +42,18 @@ interface IRefreshRequestBody {
   client_id?: string;
 }
 
+const isValidUrl = (url: string): boolean => {
+  try {
+    // Here, the URL constructor is just called to parse the given string and
+    // verify if it is a well-formed IRI.
+    // eslint-disable-next-line no-new
+    new URL(url);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
 // Identifiers in snake_case are mandated by the OAuth spec.
 /* eslint-disable camelcase */
 
@@ -73,8 +85,8 @@ export async function refresh(
         `${client.clientId}:${client.clientSecret}`
       )}`,
     };
-  } else {
-    // If the client ID is present, and there is no client secret, the client
+  } else if (client.clientId !== undefined && isValidUrl(client.clientId)) {
+    // If the client ID is an URL, and there is no client secret, the client
     // has a Solid-OIDC Client Identifier, and it should be present in the
     // request body.
     requestBody.client_id = client.clientId;

--- a/packages/oidc/src/refresh/refreshGrant.ts
+++ b/packages/oidc/src/refresh/refreshGrant.ts
@@ -91,7 +91,7 @@ export async function refresh(
         `${client.clientId}:${client.clientSecret}`
       )}`,
     };
-  } else if (client.clientId !== undefined && isValidUrl(client.clientId)) {
+  } else if (isValidUrl(client.clientId)) {
     // If the client ID is an URL, and there is no client secret, the client
     // has a Solid-OIDC Client Identifier, and it should be present in the
     // request body.

--- a/packages/oidc/src/refresh/refreshGrant.ts
+++ b/packages/oidc/src/refresh/refreshGrant.ts
@@ -26,6 +26,7 @@ import {
   IIssuerConfig,
   KeyPair,
   TokenEndpointResponse,
+  DEFAULT_SCOPES,
 } from "@inrupt/solid-client-authn-core";
 // NB: once this is rebased on #1560, change dependency to core package.
 import formUrlEncoded from "form-urlencoded";
@@ -34,7 +35,7 @@ import { validateTokenEndpointResponse } from "../dpop/tokenExchange";
 interface RefreshRequestBody {
   grant_type: "refresh_token";
   refresh_token: string;
-  scope: "openid offline_access webid";
+  scope: typeof DEFAULT_SCOPES;
   client_id?: string;
 }
 
@@ -50,7 +51,7 @@ export async function refresh(
   const requestBody: RefreshRequestBody = {
     grant_type: "refresh_token",
     refresh_token: refreshToken,
-    scope: "openid offline_access webid",
+    scope: DEFAULT_SCOPES,
   };
 
   let dpopHeader = {};

--- a/packages/oidc/src/refresh/refreshGrant.ts
+++ b/packages/oidc/src/refresh/refreshGrant.ts
@@ -31,6 +31,13 @@ import {
 import formUrlEncoded from "form-urlencoded";
 import { validateTokenEndpointResponse } from "../dpop/tokenExchange";
 
+interface RefreshRequestBody {
+  grant_type: "refresh_token";
+  refresh_token: string;
+  scope: "openid offline_access webid";
+  client_id?: string;
+}
+
 // Identifiers in snake_case are mandated by the OAuth spec.
 /* eslint-disable camelcase */
 
@@ -40,10 +47,10 @@ export async function refresh(
   client: IClient,
   dpopKey?: KeyPair
 ): Promise<TokenEndpointResponse> {
-  const requestBody = {
+  const requestBody: RefreshRequestBody = {
     grant_type: "refresh_token",
     refresh_token: refreshToken,
-    scope: "openid offline_access",
+    scope: "openid offline_access webid",
   };
 
   let dpopHeader = {};
@@ -62,6 +69,11 @@ export async function refresh(
         `${client.clientId}:${client.clientSecret}`
       )}`,
     };
+  } else {
+    // If the client ID is present, and there is no client secret, the client
+    // has a Solid-OIDC Client Identifier, and it should be present in the
+    // request body.
+    requestBody.client_id = client.clientId;
   }
 
   const rawResponse = await fetch(issuer.tokenEndpoint, {


### PR DESCRIPTION
This fixes a bug affecting client-side apps using a Solid-OIDC client identifier: the client identifier not being included in the refresh request, the session expired at the end of the lifetime of the initial access token, so somewhere around 10 minutes. Fixing this will allow the background refresh to happen, and the session to be maintained alive.

- [X] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).