### PR TITLE
chore: remove unnecessary form-urlencoded dependency

### DIFF
--- a/packages/oidc/package-lock.json
+++ b/packages/oidc/package-lock.json
@@ -13,7 +13,6 @@
         "@inrupt/solid-client-authn-core": "^1.11.7",
         "@types/jest": "^27.0.3",
         "@types/uuid": "^8.3.0",
-        "form-urlencoded": "~6.0.3",
         "jose": "^4.3.7",
         "uuid": "^8.3.1"
       },
@@ -2480,11 +2479,6 @@
       "engines": {
         "node": ">= 6"
       }
-    },
-    "node_modules/form-urlencoded": {
-      "version": "6.0.6",
-      "resolved": "https://registry.npmjs.org/form-urlencoded/-/form-urlencoded-6.0.6.tgz",
-      "integrity": "sha512-5n3L86l3uVJLFk8w+HTcuaV8WrEeH9pPqJcICxAbs3oW/gsKg9kJ8XVPZ3I1PJR50ld2fQjstT94p4G90JDMAg=="
     },
     "node_modules/fs-extra": {
       "version": "10.0.1",
@@ -7138,11 +7132,6 @@
         "combined-stream": "^1.0.8",
         "mime-types": "^2.1.12"
       }
-    },
-    "form-urlencoded": {
-      "version": "6.0.6",
-      "resolved": "https://registry.npmjs.org/form-urlencoded/-/form-urlencoded-6.0.6.tgz",
-      "integrity": "sha512-5n3L86l3uVJLFk8w+HTcuaV8WrEeH9pPqJcICxAbs3oW/gsKg9kJ8XVPZ3I1PJR50ld2fQjstT94p4G90JDMAg=="
     },
     "fs-extra": {
       "version": "10.0.1",

--- a/packages/oidc/package.json
+++ b/packages/oidc/package.json
@@ -38,7 +38,6 @@
     "@inrupt/solid-client-authn-core": "^1.11.7",
     "@types/jest": "^27.0.3",
     "@types/uuid": "^8.3.0",
-    "form-urlencoded": "~6.0.3",
     "jose": "^4.3.7",
     "uuid": "^8.3.1"
   },

--- a/packages/oidc/src/dpop/tokenExchange.ts
+++ b/packages/oidc/src/dpop/tokenExchange.ts
@@ -19,7 +19,6 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import formurlencoded from "form-urlencoded";
 import { OidcClient } from "@inrupt/oidc-client";
 import {
   IClient,
@@ -222,20 +221,22 @@ export async function getTokens(
     )}`;
   }
 
+  const requestBody = {
+    /* eslint-disable camelcase */
+    grant_type: data.grantType,
+    redirect_uri: data.redirectUrl,
+    code: data.code,
+    code_verifier: data.codeVerifier,
+    client_id: client.clientId,
+    /* eslint-enable camelcase */
+  };
+
   const tokenRequestInit: RequestInit & {
     headers: Record<string, string>;
   } = {
     method: "POST",
     headers,
-    body: formurlencoded({
-      /* eslint-disable camelcase */
-      grant_type: data.grantType,
-      redirect_uri: data.redirectUrl,
-      code: data.code,
-      code_verifier: data.codeVerifier,
-      client_id: client.clientId,
-      /* eslint-enable camelcase */
-    }),
+    body: new URLSearchParams(requestBody).toString(),
   };
 
   const rawTokenResponse = await await fetch(

--- a/packages/oidc/src/refresh/refreshGrant.ts
+++ b/packages/oidc/src/refresh/refreshGrant.ts
@@ -28,19 +28,19 @@ import {
   TokenEndpointResponse,
   DEFAULT_SCOPES,
 } from "@inrupt/solid-client-authn-core";
+
 // NB: once this is rebased on #1560, change dependency to core package.
-import formUrlEncoded from "form-urlencoded";
 import { validateTokenEndpointResponse } from "../dpop/tokenExchange";
 
 // Camelcase identifiers are required in the OIDC specification.
 /* eslint-disable camelcase */
 
-interface IRefreshRequestBody {
+type IRefreshRequestBody = {
   grant_type: "refresh_token";
   refresh_token: string;
   scope: typeof DEFAULT_SCOPES;
   client_id?: string;
-}
+};
 
 const isValidUrl = (url: string): boolean => {
   try {
@@ -100,7 +100,7 @@ export async function refresh(
 
   const rawResponse = await fetch(issuer.tokenEndpoint, {
     method: "POST",
-    body: formUrlEncoded(requestBody),
+    body: new URLSearchParams(requestBody).toString(),
     headers: {
       ...dpopHeader,
       ...authHeader,


### PR DESCRIPTION
# New feature description

Since node.js v10 `URLSearchParams` is a [global](https://nodejs.org/dist/latest-v16.x/docs/api/url.html#class-urlsearchparams), and it is also a global in all [browser environments](https://caniuse.com/urlsearchparams) that we support, therefore, we don't need to depend on an external package for this.

# Checklist

- [x] All acceptance criteria are met.
- [ ] Relevant documentation, if any, has been written/updated.
- [ ] The changelog has been updated, if applicable.
- [ ] New functions/types have been exported in `index.ts`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

# Questions

- Is this changelog worthy?