### PR TITLE
chore: fix code coverage reports to use text reporter

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -11,6 +11,8 @@ module.exports = {
     // By default we only run unit tests:
     "e2e/*",
   ],
+  collectCoverage: true,
+  coverageReporters: ["text"],
   coverageThreshold: {
     global: {
       branches: 100,


### PR DESCRIPTION
We've been using the text reporters for jest code coverage output for a while in other repos, as this integrates with Github Actions and means we're not uploading data that we never look at.

# Checklist

- [ ] All acceptance criteria are met.
- [ ] Relevant documentation, if any, has been written/updated.
- [ ] The changelog has been updated, if applicable.
- [ ] New functions/types have been exported in `index.ts`, if applicable.
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
