### PR TITLE
Improve handlers & ensure oauth params are always stripped from redirect URLs in browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ storage.
 - The refresh flow was broken for browser-based applications using a client identifier, 
 leading to short session lifetime. Now that this is fixed, the background refresh
 will happen normally, and the session will remain active.
+- The incoming redirect sometimes left OAuth parameters on the URL, despite
+already having consumed them, this only happened in certain error scenarios,
+but now the parameters will always be removed, such that the user doesn't get
+stuck at an error.
 
 #### node
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "eslint-plugin-jest": "^26.0.0",
         "eslint-plugin-prettier": "^4.0.0",
         "jest": "^27.5.1",
+        "jest-mock-console": "^1.2.3",
         "lerna-audit": "^1.3.3",
         "license-checker": "^25.0.1",
         "prettier": "2.6.2",
@@ -9194,6 +9195,15 @@
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-mock-console": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/jest-mock-console/-/jest-mock-console-1.2.3.tgz",
+      "integrity": "sha512-q4jfuHW3V3tYzwtKTF6nxjRNriUC2/D2SVfxW88lNeG1qO1mVarBUqgOAvZjTEmxuTsjzGlHQsDIgvlOZaLccg==",
+      "dev": true,
+      "peerDependencies": {
+        "jest": ">= 22.4.2"
       }
     },
     "node_modules/jest-pnp-resolver": {
@@ -22013,6 +22023,13 @@
         "@jest/types": "^27.5.1",
         "@types/node": "*"
       }
+    },
+    "jest-mock-console": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/jest-mock-console/-/jest-mock-console-1.2.3.tgz",
+      "integrity": "sha512-q4jfuHW3V3tYzwtKTF6nxjRNriUC2/D2SVfxW88lNeG1qO1mVarBUqgOAvZjTEmxuTsjzGlHQsDIgvlOZaLccg==",
+      "dev": true,
+      "requires": {}
     },
     "jest-pnp-resolver": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "eslint-plugin-header": "^3.1.1",
     "eslint-plugin-prettier": "^4.0.0",
     "jest": "^27.5.1",
+    "jest-mock-console": "^1.2.3",
     "lerna-audit": "^1.3.3",
     "license-checker": "^25.0.1",
     "prettier": "2.6.2",

--- a/packages/browser/jest.config.js
+++ b/packages/browser/jest.config.js
@@ -2,4 +2,7 @@ module.exports = {
   ...require("../../jest.config"),
   // Allows running tests from packages/browser/
   testEnvironment: "<rootDir>/../../tests/environment/customEnvironment.js",
+  // Enable injectGlobals here to support jest-mock-console
+  // https://github.com/bpedersen/jest-mock-console/issues/32
+  injectGlobals: true,
 };

--- a/packages/browser/src/login/oidc/__mocks__/Redirector.ts
+++ b/packages/browser/src/login/oidc/__mocks__/Redirector.ts
@@ -25,12 +25,12 @@ import {
 } from "@inrupt/solid-client-authn-core";
 import { jest } from "@jest/globals";
 
-export const RedirectorMock: jest.Mocked<IRedirector> = {
-  redirect: jest.fn(
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    (redirectUrl: string, redirectOptions: IRedirectorOptions) => {
-      /* void */
-    }
-  ),
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-} as any;
+export const mockedRedirector = jest.fn<
+  void,
+  [redirectUrl: string, redirectOptions: IRedirectorOptions]
+>();
+export const mockRedirector = (): IRedirector => {
+  return {
+    redirect: mockedRedirector,
+  };
+};

--- a/packages/browser/src/login/oidc/oidcHandlers/AuthorizationCodeWithPkceOidcHandler.spec.ts
+++ b/packages/browser/src/login/oidc/oidcHandlers/AuthorizationCodeWithPkceOidcHandler.spec.ts
@@ -20,6 +20,7 @@
  */
 
 import { jest, it, describe, expect, beforeEach } from "@jest/globals";
+import mockConsole from "jest-mock-console";
 
 /**
  * Test for AuthorizationCodeWithPkceOidcHandler
@@ -96,6 +97,8 @@ describe("AuthorizationCodeWithPkceOidcHandler", () => {
   describe("handle", () => {
     it("swallows any redirector exceptions", async () => {
       mockOidcModule();
+      mockConsole("error");
+
       mockedRedirector.mockImplementationOnce(
         (redirectUrl: string, redirectOptions: IRedirectorOptions) => {
           throw new Error(
@@ -122,6 +125,16 @@ describe("AuthorizationCodeWithPkceOidcHandler", () => {
       ).resolves.toBeUndefined();
 
       expect(mockedRedirector).toHaveBeenCalledTimes(1);
+
+      // Test the error was even printed to the console Note: this matcher is
+      // pretty nasty due to an Error instance being logged without being
+      // converted to a string:
+
+      // eslint-disable-next-line no-console
+      expect(console.error).toHaveBeenCalledTimes(1);
+      expect(
+        (console as jest.Mocked<Console>).error.mock.calls[0][0].toString()
+      ).toMatch(/Error: Redirecting to \[[^\]]+\] with options/);
     });
 
     it("handles login properly with PKCE", async () => {

--- a/packages/core/src/storage/__mocks__/StorageUtility.ts
+++ b/packages/core/src/storage/__mocks__/StorageUtility.ts
@@ -20,8 +20,8 @@
  */
 
 import StorageUtility from "../StorageUtility";
-import IStorage from "../IStorage";
-import IStorageUtility from "../IStorageUtility";
+import type IStorage from "../IStorage";
+import type IStorageUtility from "../IStorageUtility";
 
 export const StorageUtilityGetResponse = "getResponse";
 

--- a/packages/node/src/login/oidc/__mocks__/Redirector.ts
+++ b/packages/node/src/login/oidc/__mocks__/Redirector.ts
@@ -25,17 +25,12 @@ import {
 } from "@inrupt/solid-client-authn-core";
 import { jest } from "@jest/globals";
 
-export const RedirectorMock = {
-  redirect: jest.fn(
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    (redirectUrl: string, redirectOptions: IRedirectorOptions) => {
-      /* void */
-    }
-  ),
-} as unknown as jest.Mocked<IRedirector>;
-
+export const mockedRedirector = jest.fn<
+  void,
+  [redirectUrl: string, redirectOptions: IRedirectorOptions]
+>();
 export const mockRedirector = (): IRedirector => {
   return {
-    redirect: jest.fn(),
+    redirect: mockedRedirector,
   };
 };

--- a/packages/node/src/login/oidc/oidcHandlers/AuthorizationCodeWithPkceOidcHandler.spec.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/AuthorizationCodeWithPkceOidcHandler.spec.ts
@@ -22,7 +22,7 @@
 /**
  * Test for AuthorizationCodeWithPkceOidcHandler
  */
-import { jest, it, describe, expect } from "@jest/globals";
+import { it, describe, expect } from "@jest/globals";
 import {
   mockStorageUtility,
   StorageUtilityMock,
@@ -36,7 +36,7 @@ import {
   mockDefaultOidcOptions,
   mockOidcOptions,
 } from "../__mocks__/IOidcOptions";
-import { mockRedirector } from "../__mocks__/Redirector";
+import { mockRedirector, mockedRedirector } from "../__mocks__/Redirector";
 
 describe("AuthorizationCodeWithPkceOidcHandler", () => {
   const defaultMocks = {
@@ -72,35 +72,27 @@ describe("AuthorizationCodeWithPkceOidcHandler", () => {
 
   describe("handle", () => {
     it("redirects the user to the specified IdP", async () => {
-      const mockedRedirector = mockRedirector();
       const authorizationCodeWithPkceOidcHandler =
-        getAuthorizationCodeWithPkceOidcHandler({
-          redirector: mockedRedirector,
-        });
+        getAuthorizationCodeWithPkceOidcHandler();
 
       await authorizationCodeWithPkceOidcHandler.handle(
         mockDefaultOidcOptions()
       );
-      const mockRedirect = mockedRedirector.redirect as jest.Mock;
 
-      const builtUrl = new URL(mockRedirect.mock.calls[0][0]);
+      const builtUrl = new URL(mockedRedirector.mock.calls[0][0]);
       expect(builtUrl.hostname).toEqual(
         new URL(mockDefaultOidcOptions().issuer).hostname
       );
     });
 
     it("sets the specified options in the query params", async () => {
-      const mockedRedirector = mockRedirector();
       const authorizationCodeWithPkceOidcHandler =
-        getAuthorizationCodeWithPkceOidcHandler({
-          redirector: mockedRedirector,
-        });
+        getAuthorizationCodeWithPkceOidcHandler();
       const oidcOptions = mockDefaultOidcOptions();
 
       await authorizationCodeWithPkceOidcHandler.handle(oidcOptions);
-      const mockRedirect = mockedRedirector.redirect as jest.Mock;
 
-      const builtUrl = new URL(mockRedirect.mock.calls[0][0]);
+      const builtUrl = new URL(mockedRedirector.mock.calls[0][0]);
       expect(builtUrl.searchParams.get("client_id")).toEqual(
         oidcOptions.client.clientId
       );


### PR DESCRIPTION
# Description

This improves our tests where we were using the MockRedirector (now mockRedirector) to be like our other tests, adds test coverage to the `console.error` in `AuthorizationCodeWithPkceOidcHandler` for browsers, fixes a minor imports issue in the StorageUtility mock, and ensures that OAuth Parameters are always stripped from redirect URLs.

Previously in error conditions, it was possible that the user would be left with bad OAuth redirect parameters to be left in the URL, which usually resulted in the user getting stuck at an error if they reloaded the page.

# Checklist

- [x] All acceptance criteria are met.
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
