### PR TITLE
Support missing ID token in client credential flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,8 @@ will happen normally, and the session will remain active.
 
 #### node
 
-- The client credential flow as implemented by the CSS Identity Provider is now
-supported.
+- The client credential flow as implemented by the Community Solid Server Identity
+Provider is now supported. See [the documentation](https://github.com/CommunitySolidServer/CommunitySolidServer/blob/main/documentation/client-credentials.md) for more details.
 
 ## 1.11.7 - 2022-03-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ storage.
 leading to short session lifetime. Now that this is fixed, the background refresh
 will happen normally, and the session will remain active.
 
+#### node
+
+- The client credential flow as implemented by the CSS Identity Provider is now
+supported.
+
 ## 1.11.7 - 2022-03-16
 
 ### Bugfixes

--- a/packages/core/src/util/token.spec.ts
+++ b/packages/core/src/util/token.spec.ts
@@ -142,7 +142,7 @@ describe("getWebidFromTokenPayload", () => {
         "https://some.clientId"
       )
     ).rejects.toThrow(
-      "ID token verification failed: JWSSignatureVerificationFailed: signature verification failed"
+      "Token verification failed: JWSSignatureVerificationFailed: signature verification failed"
     );
   });
 
@@ -161,7 +161,7 @@ describe("getWebidFromTokenPayload", () => {
         "https://some.clientId"
       )
     ).rejects.toThrow(
-      'ID token verification failed: JWTClaimValidationFailed: unexpected "iss" claim value'
+      'Token verification failed: JWTClaimValidationFailed: unexpected "iss" claim value'
     );
   });
 
@@ -180,7 +180,7 @@ describe("getWebidFromTokenPayload", () => {
         "https://some.clientId"
       )
     ).rejects.toThrow(
-      'ID token verification failed: JWTClaimValidationFailed: unexpected "aud" claim value'
+      'Token verification failed: JWTClaimValidationFailed: unexpected "aud" claim value'
     );
   });
 
@@ -216,7 +216,7 @@ describe("getWebidFromTokenPayload", () => {
         "https://some.clientId"
       )
     ).rejects.toThrow(
-      "The ID token has no 'webid' claim, and its 'sub' claim of [some user ID] is invalid as a URL - error [TypeError: Invalid URL: some user ID]."
+      "The token has no 'webid' claim, and its 'sub' claim of [some user ID] is invalid as a URL - error [TypeError: Invalid URL: some user ID]."
     );
   });
 

--- a/packages/core/src/util/token.ts
+++ b/packages/core/src/util/token.ts
@@ -82,7 +82,7 @@ export async function getWebidFromTokenPayload(
     );
     payload = verifiedPayload;
   } catch (e) {
-    throw new Error(`ID token verification failed: ${(e as WithStack).stack}`);
+    throw new Error(`Token verification failed: ${(e as WithStack).stack}`);
   }
 
   if (typeof payload.webid === "string") {
@@ -90,7 +90,7 @@ export async function getWebidFromTokenPayload(
   }
   if (typeof payload.sub !== "string") {
     throw new Error(
-      `The ID token ${JSON.stringify(
+      `The token ${JSON.stringify(
         payload
       )} is invalid: it has no 'webid' claim and no 'sub' claim.`
     );
@@ -104,7 +104,7 @@ export async function getWebidFromTokenPayload(
     return payload.sub;
   } catch (e) {
     throw new Error(
-      `The ID token has no 'webid' claim, and its 'sub' claim of [${payload.sub}] is invalid as a URL - error [${e}].`
+      `The token has no 'webid' claim, and its 'sub' claim of [${payload.sub}] is invalid as a URL - error [${e}].`
     );
   }
 }

--- a/packages/node/src/ClientAuthentication.spec.ts
+++ b/packages/node/src/ClientAuthentication.spec.ts
@@ -20,7 +20,7 @@
  */
 
 import { jest, it, describe, expect } from "@jest/globals";
-import { Session } from "inspector";
+import { Session } from "./Session";
 import { EventEmitter } from "events";
 
 import { ILoginHandler, ILoginOptions } from "@inrupt/solid-client-authn-core";

--- a/packages/node/src/ClientAuthentication.spec.ts
+++ b/packages/node/src/ClientAuthentication.spec.ts
@@ -20,10 +20,10 @@
  */
 
 import { jest, it, describe, expect } from "@jest/globals";
-import { Session } from "./Session";
 import { EventEmitter } from "events";
 
 import { ILoginHandler, ILoginOptions } from "@inrupt/solid-client-authn-core";
+import { Session } from "./Session";
 // FIXME: For some reason jest crashes on trying to handle a subpath import
 // this should import from @inrupt/solid-client-authn-core/mocks
 import {

--- a/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.spec.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.spec.ts
@@ -275,10 +275,11 @@ describe("handle", () => {
         clientType: "static",
       },
     });
-    expect(sessionInfo).toBeDefined();
     // The session's WebID should have been picked up from the access token in
     // the absence of an ID token.
-    expect(sessionInfo.webId).toBe("https://my.webid/");
+    expect((sessionInfo as SolidClientAuthnCore.ISessionInfo).webId).toBe(
+      "https://my.webid/"
+    );
   });
 
   // Note that this is a temporary fix, and it will eventually be removed from the

--- a/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.spec.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.spec.ts
@@ -154,12 +154,11 @@ const setupOidcClientMock = (tokenSet: TokenSet) => {
 };
 
 const setupGetWebidMock = (webid: string) => {
-  const { getWebidFromTokenPayload } = jest.requireMock("@inrupt/solid-client-authn-core") as jest.Mocked<
-  typeof SolidClientAuthnCore
->;
+  const { getWebidFromTokenPayload } = jest.requireMock(
+    "@inrupt/solid-client-authn-core"
+  ) as jest.Mocked<typeof SolidClientAuthnCore>;
   getWebidFromTokenPayload.mockResolvedValueOnce(webid);
-}
-
+};
 
 describe("ClientCredentialsOidcHandler", () => {
   describe("canHandle", () => {
@@ -278,9 +277,9 @@ describe("handle", () => {
     });
     // The session's WebID should have been picked up from the access token in
     // the absence of an ID token.
-    expect(
-      (sessionInfo as SolidClientAuthnCore.ISessionInfo).webId
-    ).toStrictEqual("https://my.webid/");
+    expect((sessionInfo as SolidClientAuthnCore.ISessionInfo).webId).toBe(
+      "https://my.webid/"
+    );
   });
 
   // Note that this is a temporary fix, and it will eventually be removed from the
@@ -291,9 +290,9 @@ describe("handle", () => {
     const tokens = mockDpopTokens();
     tokens.id_token = undefined;
     setupOidcClientMock(tokens);
-    const { getWebidFromTokenPayload } = jest.requireMock("@inrupt/solid-client-authn-core") as jest.Mocked<
-      typeof SolidClientAuthnCore
-    >;
+    const { getWebidFromTokenPayload } = jest.requireMock(
+      "@inrupt/solid-client-authn-core"
+    ) as jest.Mocked<typeof SolidClientAuthnCore>;
     // Pretend the token validation function throws
     getWebidFromTokenPayload.mockRejectedValueOnce(new Error("Bad audience"));
     const clientCredentialsOidcHandler = new ClientCredentialsOidcHandler(
@@ -301,14 +300,16 @@ describe("handle", () => {
       mockStorageUtility({})
     );
 
-    await expect(clientCredentialsOidcHandler.handle({
-      ...standardOidcOptions,
-      client: {
-        clientId: "some client ID",
-        clientSecret: "some client secret",
-        clientType: "static",
-      },
-    })).rejects.toThrow();
+    await expect(
+      clientCredentialsOidcHandler.handle({
+        ...standardOidcOptions,
+        client: {
+          clientId: "some client ID",
+          clientSecret: "some client secret",
+          clientType: "static",
+        },
+      })
+    ).rejects.toThrow();
   });
 
   it("builds a fetch authenticated with a DPoP token if appropriate", async () => {

--- a/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.spec.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.spec.ts
@@ -78,7 +78,7 @@ const mockIdToken = (): string =>
   "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJodHRwczovL215LndlYmlkIiwiaXNzIjoiaHR0cHM6Ly9teS5pZHAvIiwiYXVkIjoiaHR0cHM6Ly9yZXNvdXJjZS5leGFtcGxlLm9yZyIsImV4cCI6MTY2MjI2NjIxNiwiaWF0IjoxNDYyMjY2MjE2fQ.IwumuwJtQw5kUBMMHAaDPJBppfBpRHbiXZw_HlKe6GNVUWUlyQRYV7W7r9OQtHmMsi6GVwOckelA3ErmhrTGVw";
 
 type AccessJwt = {
-  sub: string;
+  webid: string;
   iss: string;
   aud: string;
   nbf: number;
@@ -92,7 +92,7 @@ const mockWebId = (): string => "https://my.webid/";
 
 const mockKeyBoundToken = (): AccessJwt => {
   return {
-    sub: mockWebId(),
+    webid: mockWebId(),
     iss: mockDefaultIssuerConfig().issuer.toString(),
     aud: "https://resource.example.org",
     nbf: 1562262611,
@@ -246,7 +246,10 @@ describe("handle", () => {
     );
   });
 
-  it("throws if the issuer does not return an ID token", async () => {
+  // Note that this is a temporary fix, and it will eventually be removed from the
+  // codebase once the client credential use case is properly covered by the authentication
+  // panel.
+  it("gets the WebID from the access token if the issuer does not return an ID token", async () => {
     const tokens = mockDpopTokens();
     tokens.id_token = undefined;
     setupOidcClientMock(tokens);
@@ -254,18 +257,20 @@ describe("handle", () => {
       mockDefaultTokenRefresher(),
       mockStorageUtility({})
     );
-    await expect(
-      clientCredentialsOidcHandler.handle({
-        ...standardOidcOptions,
-        client: {
-          clientId: "some client ID",
-          clientSecret: "some client secret",
-          clientType: "static",
-        },
-      })
-    ).rejects.toThrow(
-      /Invalid response from Solid Identity Provider \[.+\]: \{.+\} is missing 'id_token'/
-    );
+
+    const sessionInfo = await clientCredentialsOidcHandler.handle({
+      ...standardOidcOptions,
+      client: {
+        clientId: "some client ID",
+        clientSecret: "some client secret",
+        clientType: "static",
+      },
+    });
+    // The session's WebID should have been picked up from the access token in
+    // the absence of an ID token.
+    expect(
+      (sessionInfo as SolidClientAuthnCore.ISessionInfo).webId
+    ).toStrictEqual(mockKeyBoundToken().webid);
   });
 
   it("builds a fetch authenticated with a DPoP token if appropriate", async () => {

--- a/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.spec.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.spec.ts
@@ -309,7 +309,7 @@ describe("handle", () => {
           clientType: "static",
         },
       })
-    ).rejects.toThrow();
+    ).rejects.toThrow("Bad audience");
   });
 
   it("builds a fetch authenticated with a DPoP token if appropriate", async () => {

--- a/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.spec.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.spec.ts
@@ -275,9 +275,10 @@ describe("handle", () => {
         clientType: "static",
       },
     });
+    expect(sessionInfo).toBeDefined();
     // The session's WebID should have been picked up from the access token in
     // the absence of an ID token.
-    expect((sessionInfo as SolidClientAuthnCore.ISessionInfo).webId).toBe(
+    expect(sessionInfo.webId).toBe(
       "https://my.webid/"
     );
   });

--- a/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.spec.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.spec.ts
@@ -278,9 +278,7 @@ describe("handle", () => {
     expect(sessionInfo).toBeDefined();
     // The session's WebID should have been picked up from the access token in
     // the absence of an ID token.
-    expect(sessionInfo.webId).toBe(
-      "https://my.webid/"
-    );
+    expect(sessionInfo.webId).toBe("https://my.webid/");
   });
 
   // Note that this is a temporary fix, and it will eventually be removed from the


### PR DESCRIPTION
By definition, the client credential flow happens without the resource owner: the client acts on its own behalf. In some Solid-OIDC providers implementations, this is slightly worked around by binding the client to a resource owner account so that it still gets a WebID. However, these workaround are somewhat implementation-specific, and not all result in striclty similar behaviours. In particular, the ESS Solid-OIDC broker produces an ID token in response to a client credential grant token exchange, but that isn't the case of the CSS Solid-OIDC provider.

This commit clears our assumption that an ID token must always be present: instead, it is acknowledged that in the absence of an ID token, the access token should contain a `webid` claim, which is sufficient for our purpose. Note that this is a temporary fix: the authentication panel is moving away from an access token being present at all in the Solid-OIDC provider response. Dedicated work will be required to address the use case currently covered by the client credential flow. When the Solid-OIDC specification provides normative behavior there, this library should be updated accordingly.

- [X] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).