### PR TITLE
Remove reference to window.localstorage from Session constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The following changes have been implemented but not released yet:
 
 ### Bugfixes
 
--
+- Removed immediate use of `window` in Session constructor of the browser package
 
 ## 1.11.8 - 2022-05-17
 

--- a/packages/browser/src/Session.spec.ts
+++ b/packages/browser/src/Session.spec.ts
@@ -112,6 +112,19 @@ describe("Session", () => {
       expect(mySession.info.sessionId).toBe("mySession");
       expect(mySession.info.webId).toBe("https://some.webid");
     });
+
+    it("does not reference window immediately", () => {
+      // Let's make TypeScript and eslint angry! We'll set our window mock to
+      // undefined so that any references to its properties or methods explode.
+      // @ts-ignore-start
+      // eslint-disable-next-line no-global-assign
+      window = undefined;
+      // @ts-ignore-end
+      expect(() => {
+        // eslint-disable-next-line no-new
+        new Session({});
+      }).not.toThrow();
+    });
   });
 
   describe("login", () => {

--- a/packages/browser/src/Session.ts
+++ b/packages/browser/src/Session.ts
@@ -235,11 +235,6 @@ export class Session extends EventEmitter {
     this.on(EVENTS.SESSION_EXPIRED, () => this.internalLogout(false));
 
     this.on(EVENTS.ERROR, () => this.internalLogout(false));
-
-    // @deprecated: Remove this when removing all support for the useEssSession parameter.
-    // This intends at cleaning up local storage of applications from data related
-    // to the resource server session workaround.
-    window.localStorage.removeItem("tmp-resource-server-session-enabled");
   }
 
   /**


### PR DESCRIPTION
A temporary fix was put into place in 3fd7bb44de656bf044e9b09bb3f29fcada5e8de4 which cleared a localstorage value set by a temporary ESS session restoration workflow. This caused window to be accessed in the session constructor, which caused issues with server-side rendering.

The localstorage value no longer needs to be cleared as it is unused, so this line has been removed.

<!-- When fixing a bug: -->

This PR fixes bug #.

- [x] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).