### PR TITLE
Chore/release v1.11.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 The following changes have been implemented but not released yet:
 
+## 1.11.9 - 2022-05-25
+
 ### Bugfixes
 
 - Removed immediate use of `window` in Session constructor of the browser package

--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
     "packages/*",
     "e2e/browser"
   ],
-  "version": "1.11.8"
+  "version": "1.11.9"
 }

--- a/packages/browser/package-lock.json
+++ b/packages/browser/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/solid-client-authn-browser",
-  "version": "1.11.8",
+  "version": "1.11.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/solid-client-authn-browser",
-  "version": "1.11.8",
+  "version": "1.11.9",
   "license": "MIT",
   "types": "dist/index",
   "browser": "dist/index.js",


### PR DESCRIPTION
This PR bumps the version to 1.11.9.

# Checklist

- [x] I used `npm run lerna-version -- <major|minor|patch> --no-push` to update the version number, first inspecting the CHANGELOG to determine if the release was major, minor or patch.
- [x] The CHANGELOG has been updated to show version and release date - https://keepachangelog.com/en/1.0.0/.
- [x] The **only** commits in this PR are:
  - the CHANGELOG update.
  - the version update.
- [x] I will make sure **not** to squash these commits, but **rebase** instead.
- [ ] Once this PR is merged, I will push the tag created by `lerna version ...` (e.g. `git push origin vX.X.X`).
