### PR TITLE
security: rotate npm credentials

### DIFF
--- a/.github/workflows/cd-preview.yml
+++ b/.github/workflows/cd-preview.yml
@@ -53,7 +53,7 @@ jobs:
       - run: npm run build
       - run: npm run publish-preview -- --dist-tag "$TAG_SLUG" --yes
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.INRUPT_NPM_TOKEN }}
       - run: |
           echo "Package published. To install, run:"
           echo ""

--- a/.github/workflows/cd-release.yml
+++ b/.github/workflows/cd-release.yml
@@ -69,7 +69,7 @@ jobs:
           echo ""
           echo "    npm install @inrupt/solid-client-authn-XXXX"
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.INRUPT_NPM_TOKEN }}
       - name: Mark GitHub Deployment as successful
         uses: octokit/request-action@v2.x
         with:

--- a/.github/workflows/cd-teardown.yml
+++ b/.github/workflows/cd-teardown.yml
@@ -25,7 +25,7 @@ jobs:
       run: |
         export EXISTING_TAGS=$(npm dist-tag ls @inrupt/solid-client-authn-core | grep --count $TAG_SLUG)
         # Unfortunately GitHub Actions does not currently let us do something like
-        #     if: secrets.NPM_TOKEN != ''
+        #     if: secrets.INRUPT_NPM_TOKEN != ''
         # so simply skip the command if the env var is not set:
         if [ -n $NODE_AUTH_TOKEN ] && [ $EXISTING_TAGS -eq 1 ]; then
         npm dist-tag rm @inrupt/solid-client-authn-browser $TAG_SLUG;
@@ -33,5 +33,5 @@ jobs:
         npm dist-tag rm @inrupt/oidc-client-ext $TAG_SLUG;
         fi
       env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        NODE_AUTH_TOKEN: ${{ secrets.INRUPT_NPM_TOKEN }}
     - run: echo "Package tag \`$TAG_SLUG\` unpublished."


### PR DESCRIPTION
This migrates us to a new secret managed by the GitHub Organisation for publishing to the inrupt npm organisation.