### PR TITLE
Fix: package publishing

### DIFF
--- a/.github/workflows/cd-preview.yml
+++ b/.github/workflows/cd-preview.yml
@@ -1,10 +1,10 @@
 name: CD-preview
 
-on: 
+on:
   push:
     branches:
-        - "**"
-    tags-ignore: 
+      - "**"
+    tags-ignore:
       # Only create preview releases for branches
       # (the `release` workflow creates actual releases for version tags):
       - v[0-9]+.[0-9]+.[0-9]+
@@ -96,50 +96,49 @@ jobs:
           cd .github/workflows/cd-packaging-tests/node
           node --unhandled-rejections=strict esmodule.mjs
 
-
   verify-imports-parcel:
     runs-on: ubuntu-20.04
     needs: [dev-release-npm]
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
-      with:
-        node-version: '16.x'
-        registry-url: 'https://registry.npmjs.org'
-    - name: Verify that the package can be imported in a Parcel project
-      run: |
-        cd .github/workflows/cd-packaging-tests/bundler-parcel
-        npm install @inrupt/solid-client-authn-browser@$VERSION_NR
-        npx parcel@1.12.3 build index.ts
-      env:
-        VERSION_NR: ${{ needs.dev-release-npm.outputs.version-nr }}
-    - name: Archive Parcel build artifacts
-      uses: actions/upload-artifact@v3
-      continue-on-error: true
-      with:
-        name: parcel-dist
-        path: .github/workflows/cd-packaging-tests/bundler-parcel/dist
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "16.x"
+          registry-url: "https://registry.npmjs.org"
+      - name: Verify that the package can be imported in a Parcel project
+        run: |
+          cd .github/workflows/cd-packaging-tests/bundler-parcel
+          npm install @inrupt/solid-client-authn-browser@$VERSION_NR
+          npx parcel@1.12.3 build index.ts
+        env:
+          VERSION_NR: ${{ needs.dev-release-npm.outputs.version-nr }}
+      - name: Archive Parcel build artifacts
+        uses: actions/upload-artifact@v3
+        continue-on-error: true
+        with:
+          name: parcel-dist
+          path: .github/workflows/cd-packaging-tests/bundler-parcel/dist
 
   verify-imports-webpack:
     runs-on: ubuntu-20.04
     needs: [dev-release-npm]
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
-      with:
-        node-version: '16.x'
-        registry-url: 'https://registry.npmjs.org'
-    - name: Verify that the package can be imported in a Webpack project
-      run: |
-        cd .github/workflows/cd-packaging-tests/bundler-webpack
-        npm install @inrupt/solid-client-authn-browser@$VERSION_NR
-        npm install webpack@5 webpack-cli buffer crypto-browserify stream-browserify util
-        npx webpack --devtool source-map
-      env:
-        VERSION_NR: ${{ needs.dev-release-npm.outputs.version-nr }}
-    - name: Archive Webpack build artifacts
-      uses: actions/upload-artifact@v3
-      continue-on-error: true
-      with:
-        name: webpack-dist
-        path: .github/workflows/cd-packaging-tests/bundler-webpack/dist
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "16.x"
+          registry-url: "https://registry.npmjs.org"
+      - name: Verify that the package can be imported in a Webpack project
+        run: |
+          cd .github/workflows/cd-packaging-tests/bundler-webpack
+          npm install @inrupt/solid-client-authn-browser@$VERSION_NR
+          npm install webpack@5 webpack-cli buffer crypto-browserify stream-browserify util
+          npx webpack --devtool source-map
+        env:
+          VERSION_NR: ${{ needs.dev-release-npm.outputs.version-nr }}
+      - name: Archive Webpack build artifacts
+        uses: actions/upload-artifact@v3
+        continue-on-error: true
+        with:
+          name: webpack-dist
+          path: .github/workflows/cd-packaging-tests/bundler-webpack/dist

--- a/.github/workflows/cd-preview.yml
+++ b/.github/workflows/cd-preview.yml
@@ -51,7 +51,8 @@ jobs:
           VERSION_NR=$(cat packages/browser/package.json | npx json version)
           echo "::set-output name=version-nr::$VERSION_NR"
       - run: npm run build
-      - run: npm run publish-preview -- --dist-tag "$TAG_SLUG" --yes
+        # Disable lerna's access verification as our npm token is an automation token:
+      - run: npm run publish-preview -- --no-verify-access --dist-tag "$TAG_SLUG" --yes
         env:
           NODE_AUTH_TOKEN: ${{ secrets.INRUPT_NPM_TOKEN }}
       - run: |
@@ -79,7 +80,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: "https://registry.npmjs.org"
       - name: Install the preview release of solid-client-authn-node in the packaging test project
         run: |
           cd .github/workflows/cd-packaging-tests/node

--- a/.github/workflows/cd-release.yml
+++ b/.github/workflows/cd-release.yml
@@ -125,46 +125,45 @@ jobs:
           cd .github/workflows/cd-packaging-tests/node
           node --unhandled-rejections=strict esmodule.mjs
 
-
   verify-imports-parcel:
     runs-on: ubuntu-20.04
     needs: [publish-npm]
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
-      with:
-        node-version: '16.x'
-        registry-url: 'https://registry.npmjs.org'
-    - name: Verify that the package can be imported in a Parcel project
-      run: |
-        cd .github/workflows/cd-packaging-tests/bundler-parcel
-        npm install @inrupt/solid-client-authn-browser
-        npx parcel@1.12.3 build index.ts
-    - name: Archive Parcel build artifacts
-      uses: actions/upload-artifact@v3
-      continue-on-error: true
-      with:
-        name: parcel-dist
-        path: .github/workflows/cd-packaging-tests/bundler-parcel/dist
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "16.x"
+          registry-url: "https://registry.npmjs.org"
+      - name: Verify that the package can be imported in a Parcel project
+        run: |
+          cd .github/workflows/cd-packaging-tests/bundler-parcel
+          npm install @inrupt/solid-client-authn-browser
+          npx parcel@1.12.3 build index.ts
+      - name: Archive Parcel build artifacts
+        uses: actions/upload-artifact@v3
+        continue-on-error: true
+        with:
+          name: parcel-dist
+          path: .github/workflows/cd-packaging-tests/bundler-parcel/dist
 
   verify-imports-webpack:
     runs-on: ubuntu-20.04
     needs: [publish-npm]
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
-      with:
-        node-version: '16.x'
-        registry-url: 'https://registry.npmjs.org'
-    - name: Verify that the package can be imported in a Webpack project
-      run: |
-        cd .github/workflows/cd-packaging-tests/bundler-webpack
-        npm install @inrupt/solid-client-authn-browser
-        npm install webpack@5 webpack-cli buffer
-        npx webpack --devtool source-map
-    - name: Archive Webpack build artifacts
-      uses: actions/upload-artifact@v3
-      continue-on-error: true
-      with:
-        name: webpack-dist
-        path: .github/workflows/cd-packaging-tests/bundler-webpack/dist
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "16.x"
+          registry-url: "https://registry.npmjs.org"
+      - name: Verify that the package can be imported in a Webpack project
+        run: |
+          cd .github/workflows/cd-packaging-tests/bundler-webpack
+          npm install @inrupt/solid-client-authn-browser
+          npm install webpack@5 webpack-cli buffer
+          npx webpack --devtool source-map
+      - name: Archive Webpack build artifacts
+        uses: actions/upload-artifact@v3
+        continue-on-error: true
+        with:
+          name: webpack-dist
+          path: .github/workflows/cd-packaging-tests/bundler-webpack/dist

--- a/.github/workflows/cd-release.yml
+++ b/.github/workflows/cd-release.yml
@@ -63,8 +63,9 @@ jobs:
         #        "access": "public"
         #      }
         #    }
+        # Disable lerna's access verification as our npm token is an automation token:
         run: |
-          npm run publish -- from-package --yes 
+          npm run publish -- from-package --no-verify-access --yes 
           echo "Packages published. To install, run:"
           echo ""
           echo "    npm install @inrupt/solid-client-authn-XXXX"
@@ -110,7 +111,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: "https://registry.npmjs.org"
       - name: Install the preview release of solid-client-authn-node in the packaging test project
         run: |
           cd .github/workflows/cd-packaging-tests/node

--- a/.github/workflows/cd-teardown.yml
+++ b/.github/workflows/cd-teardown.yml
@@ -10,26 +10,26 @@ jobs:
     # Dependabot cannot access secrets, so it doesn't have a token to publish to NPM.
     # Since all the other jobs of this workflow depend on this one, skipping it should
     # skip the entire workflow.
-    if: ${{github.event.ref_type == 'branch' && github.actor != 'dependabot[bot]'}} 
+    if: ${{github.event.ref_type == 'branch' && github.actor != 'dependabot[bot]'}}
     steps:
-    - name: Prepare for unpublication from npm
-      uses: actions/setup-node@v3
-      with:
-        node-version: '16.x'
-        registry-url: 'https://registry.npmjs.org'
-    - name: Determine npm tag
-      # Remove non-alphanumeric characters
-      # See https://help.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
-      run: echo "TAG_SLUG=$(echo "${{ github.event.ref }}" | tr -cd '[:alnum:]-')" >> $GITHUB_ENV
-    - name: Remove npm tag for the deleted branch
-      run: |
-        export EXISTING_TAGS=$(npm dist-tag ls @inrupt/solid-client-authn-core | grep --count $TAG_SLUG)
-        # Unfortunately GitHub Actions does not currently let us do something like
-        #     if: secrets.INRUPT_NPM_TOKEN != ''
-        # so simply skip the command if the env var is not set:
-        if [ -n $NODE_AUTH_TOKEN ] && [ $EXISTING_TAGS -eq 1 ]; then
-        lerna exec -- npm dist-tag rm \$LERNA_PACKAGE_NAME $TAG_SLUG
-        fi
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.INRUPT_NPM_TOKEN }}
-    - run: echo "Package tag \`$TAG_SLUG\` unpublished."
+      - name: Prepare for unpublication from npm
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16.x"
+          registry-url: "https://registry.npmjs.org"
+      - name: Determine npm tag
+        # Remove non-alphanumeric characters
+        # See https://help.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
+        run: echo "TAG_SLUG=$(echo "${{ github.event.ref }}" | tr -cd '[:alnum:]-')" >> $GITHUB_ENV
+      - name: Remove npm tag for the deleted branch
+        run: |
+          export EXISTING_TAGS=$(npm dist-tag ls @inrupt/solid-client-authn-core | grep --count $TAG_SLUG)
+          # Unfortunately GitHub Actions does not currently let us do something like
+          #     if: secrets.INRUPT_NPM_TOKEN != ''
+          # so simply skip the command if the env var is not set:
+          if [ -n $NODE_AUTH_TOKEN ] && [ $EXISTING_TAGS -eq 1 ]; then
+          lerna exec -- npm dist-tag rm \$LERNA_PACKAGE_NAME $TAG_SLUG
+          fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.INRUPT_NPM_TOKEN }}
+      - run: echo "Package tag \`$TAG_SLUG\` unpublished."

--- a/.github/workflows/cd-teardown.yml
+++ b/.github/workflows/cd-teardown.yml
@@ -28,9 +28,7 @@ jobs:
         #     if: secrets.INRUPT_NPM_TOKEN != ''
         # so simply skip the command if the env var is not set:
         if [ -n $NODE_AUTH_TOKEN ] && [ $EXISTING_TAGS -eq 1 ]; then
-        npm dist-tag rm @inrupt/solid-client-authn-browser $TAG_SLUG;
-        npm dist-tag rm @inrupt/solid-client-authn-core $TAG_SLUG;
-        npm dist-tag rm @inrupt/oidc-client-ext $TAG_SLUG;
+        lerna exec -- npm dist-tag rm \$LERNA_PACKAGE_NAME $TAG_SLUG
         fi
       env:
         NODE_AUTH_TOKEN: ${{ secrets.INRUPT_NPM_TOKEN }}


### PR DESCRIPTION
When we migrated to the new NPM tokens, we also switched this repository to using an automation token, which turns out not to work with lerna unless `--no-verify-access` is passed, see here for details: https://github.com/npm/feedback/discussions/698

This disabled access verification, as well as fixing a small bug in cd-teardown where it didn't delete all packages, and some other minor formatting issues.