### PR TITLE
release: prepare v1.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 The following changes have been implemented but not released yet:
 
+## 1.12.0 - 2022-06-06
+
 ### Breaking Changes
 
 - Support for Node.js v12.x has been dropped as that version has reached

--- a/e2e/browser/package-lock.json
+++ b/e2e/browser/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "e2e-browser",
-  "version": "1.11.8",
+  "version": "1.12.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/e2e/browser/package.json
+++ b/e2e/browser/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "e2e-browser",
-  "version": "1.11.8",
+  "version": "1.12.0",
   "description": "Playwright end-2-end test runner for solid-client-authn-browser",
   "scripts": {
     "start": "cd ../../packages/browser/examples/demoClientApp && npm run start",
@@ -16,7 +16,7 @@
   "license": "MIT",
   "devDependencies": {
     "@inrupt/solid-client": "^1.20.1",
-    "@inrupt/solid-client-authn-node": "^1.11.8",
+    "@inrupt/solid-client-authn-node": "^1.12.0",
     "@inrupt/vocab-common-rdf": "^1.0.3",
     "@playwright/test": "^1.18.0",
     "dotenv-flow": "^3.2.0",

--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
     "packages/*",
     "e2e/browser"
   ],
-  "version": "1.11.9"
+  "version": "1.12.0"
 }

--- a/packages/browser/package-lock.json
+++ b/packages/browser/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/solid-client-authn-browser",
-  "version": "1.11.9",
+  "version": "1.12.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/solid-client-authn-browser",
-  "version": "1.11.9",
+  "version": "1.12.0",
   "license": "MIT",
   "types": "dist/index",
   "browser": "dist/index.js",
@@ -33,8 +33,8 @@
     "webpack-merge": "^5.7.2"
   },
   "dependencies": {
-    "@inrupt/oidc-client-ext": "^1.11.8",
-    "@inrupt/solid-client-authn-core": "^1.11.8",
+    "@inrupt/oidc-client-ext": "^1.12.0",
+    "@inrupt/solid-client-authn-core": "^1.12.0",
     "@types/lodash.clonedeep": "^4.5.6",
     "@types/node": "^17.0.2",
     "@types/uuid": "^8.3.0",

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/solid-client-authn-core",
-  "version": "1.11.8",
+  "version": "1.12.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/solid-client-authn-core",
-  "version": "1.11.8",
+  "version": "1.12.0",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/node/package-lock.json
+++ b/packages/node/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/solid-client-authn-node",
-  "version": "1.11.8",
+  "version": "1.12.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/solid-client-authn-node",
-  "version": "1.11.8",
+  "version": "1.12.0",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index",
@@ -26,7 +26,7 @@
     "@types/uuid": "^8.3.0"
   },
   "dependencies": {
-    "@inrupt/solid-client-authn-core": "^1.11.8",
+    "@inrupt/solid-client-authn-core": "^1.12.0",
     "cross-fetch": "^3.1.5",
     "jose": "^4.3.7",
     "openid-client": "^5.1.0",

--- a/packages/oidc/package-lock.json
+++ b/packages/oidc/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/oidc-client-ext",
-  "version": "1.11.8",
+  "version": "1.12.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/packages/oidc/package.json
+++ b/packages/oidc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/oidc-client-ext",
-  "version": "1.11.8",
+  "version": "1.12.0",
   "description": "A module extending oidc-client-js with new features, such as dynamic client registration and DPoP support.",
   "homepage": "https://github.com/inrupt/solid-client-authn-js/tree/main/packages/oidc/",
   "bugs": "https://github.com/inrupt/solid-client-authn-js/issues",
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@inrupt/oidc-client": "^1.11.6",
-    "@inrupt/solid-client-authn-core": "^1.11.8",
+    "@inrupt/solid-client-authn-core": "^1.12.0",
     "@types/jest": "^27.0.3",
     "@types/uuid": "^8.3.0",
     "jose": "^4.3.7",


### PR DESCRIPTION
This PR bumps the version to v1.12.0.

# Checklist

- [x] I used `npm run lerna-version -- <major|minor|patch> --no-push --no-git-tag-version` to update the version number, first inspecting the CHANGELOG to determine if the release was major, minor or patch.
- [x] The CHANGELOG has been updated to show version and release date - https://keepachangelog.com/en/1.0.0/.
- [x] The **only** changes in this PR are a single commit for:
  - the CHANGELOG update.
  - the version update.
- [ ] I will make sure **not** to squash these commits, but **rebase** instead.
- [ ] Once this PR is merged, I will push the tag created by `lerna version ...` (e.g. `git push origin vX.X.X`).
