### PR TITLE
Try restoring client Identifier from storage

### DIFF
--- a/packages/node/src/multiSession.ts
+++ b/packages/node/src/multiSession.ts
@@ -67,6 +67,8 @@ export async function getSessionFromStorage(
   if (sessionInfo.refreshToken) {
     await session.login({
       oidcIssuer: sessionInfo.issuer,
+      clientId: sessionInfo.clientAppId,
+      clientSecret: sessionInfo.clientAppSecret
     });
   }
   return session;

--- a/packages/node/src/sessionInfo/SessionInfoManager.ts
+++ b/packages/node/src/sessionInfo/SessionInfoManager.ts
@@ -123,6 +123,8 @@ export class SessionInfoManager implements ISessionInfoManager {
       "refreshToken"
     );
     const issuer = await this.storageUtility.getForUser(sessionId, "issuer");
+    const clientId = await this.storageUtility.getForUser(sessionId, "clientId");
+    const clientSecret = await this.storageUtility.getForUser(sessionId, "clientSecret");
 
     if (issuer !== undefined) {
       return {
@@ -131,6 +133,8 @@ export class SessionInfoManager implements ISessionInfoManager {
         isLoggedIn: isLoggedIn === "true",
         refreshToken,
         issuer,
+        clientAppId: clientId,
+        clientAppSecret: clientSecret
       };
     }
 


### PR DESCRIPTION
When logging a session back in after restoring it from storage, authentication fails if using a client identifier, while it works well if using dynamic client registration. The call to login from `getSessionFromStorage` does not include the client identifier, and even if it eventually should be retrieved properly from storage, at that point the client has been tagged dynamic, which probably causes the mismatch.

This is an initial commit to see if this resolves the issue, tests will come in a second time.

<!-- When fixing a bug: -->

This PR fixes bug #.

- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
