### PR TITLE
docs: fix broken link to examples in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Go to http://localhost:3001/.
 
 #### Running an authenticated script
 
-See [the dedicated documentation](/packages/node/example/bootstrappedApp/README.md).
+See [the dedicated documentation](/packages/node/examples/bootstrappedApp/README.md).
 
 ## Using with jest
 


### PR DESCRIPTION
Rebase of #2237 