### PR TITLE
Temporarily disable production e2e tests

### DIFF
--- a/.github/workflows/e2e-browser.yml
+++ b/.github/workflows/e2e-browser.yml
@@ -20,6 +20,8 @@ jobs:
         # so we only need to test in one.
         node-version: ["16"]
         # NSS does not support static client registration, which we rely on for testing.
+        # Note: "ESS Production" has been disabled due to the migration
+        # "ESS Dev-Next" is a 2.0-like environment.
         environment-name: ["ESS Dev-Next"]
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/e2e-browser.yml
+++ b/.github/workflows/e2e-browser.yml
@@ -20,7 +20,7 @@ jobs:
         # so we only need to test in one.
         node-version: ["16"]
         # NSS does not support static client registration, which we rely on for testing.
-        environment-name: ["ESS Production", "ESS Dev-Next"]
+        environment-name: ["ESS Dev-Next"]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/e2e-node.yml
+++ b/.github/workflows/e2e-node.yml
@@ -19,7 +19,7 @@ jobs:
         os: [ubuntu-latest]
         node-version: ["16"]
         # NSS does not support static client registration, which we rely on for testing.
-        environment-name: ["ESS Production", "ESS Dev-Next"]
+        environment-name: ["ESS Dev-Next"]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/e2e-node.yml
+++ b/.github/workflows/e2e-node.yml
@@ -19,6 +19,8 @@ jobs:
         os: [ubuntu-latest]
         node-version: ["16"]
         # NSS does not support static client registration, which we rely on for testing.
+        # Note: "ESS Production" has been disabled due to the migration
+        # "ESS Dev-Next" is a 2.0-like environment.
         environment-name: ["ESS Dev-Next"]
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Since the ESS-production environment is migrating from ESS1.1 to ESS2.0, the tests need to be upgraded accordingly. They are disabled in the meantime because they will start to break when the migration happens. They will be re-enabled when secret sharing is properly configured to reduce the manual work as much as possible.
