### PR TITLE
Typedoc api docs fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "ts-node": "^10.9.1",
         "tsc-watch": "^5.0.2",
         "typedoc": "^0.23.1",
+        "typedoc-plugin-markdown": "^3.13.3",
         "typescript": "^4.9.4",
         "webpack": "^5.73.0",
         "webpack-cli": "^4.10.0",
@@ -15986,6 +15987,18 @@
         "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x"
       }
     },
+    "node_modules/typedoc-plugin-markdown": {
+      "version": "3.13.6",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.13.6.tgz",
+      "integrity": "sha512-ISSc9v3BK7HkokxSBuJPttXox4tJ6hP0N9wfSIk0fmLN67+eqtAxbk97gs2nDiuha+RTO5eW9gdeAb+RPP0mgg==",
+      "dev": true,
+      "dependencies": {
+        "handlebars": "^4.7.7"
+      },
+      "peerDependencies": {
+        "typedoc": ">=0.23.0"
+      }
+    },
     "node_modules/typedoc/node_modules/brace-expansion": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
@@ -28812,6 +28825,15 @@
             "brace-expansion": "^2.0.1"
           }
         }
+      }
+    },
+    "typedoc-plugin-markdown": {
+      "version": "3.13.6",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.13.6.tgz",
+      "integrity": "sha512-ISSc9v3BK7HkokxSBuJPttXox4tJ6hP0N9wfSIk0fmLN67+eqtAxbk97gs2nDiuha+RTO5eW9gdeAb+RPP0mgg==",
+      "dev": true,
+      "requires": {
+        "handlebars": "^4.7.7"
       }
     },
     "typescript": {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "tsc-watch": "^5.0.2",
     "typedoc": "^0.23.1",
     "typescript": "^4.9.4",
+    "typedoc-plugin-markdown": "^3.13.3",
     "webpack": "^5.73.0",
     "webpack-cli": "^4.10.0",
     "webpack-merge": "^5.8.0"

--- a/packages/browser/docs/api/Makefile
+++ b/packages/browser/docs/api/Makefile
@@ -7,7 +7,7 @@ SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = source
 GIT_BRANCH    :=$(shell git rev-parse --abbrev-ref HEAD)
 BUILDDIR      = build
-SPHINXOPTS    = -d $(BUILDDIR)/doctrees -W 
+SPHINXOPTS    = -d $(BUILDDIR)/doctrees 
 SOURCECOPYDIR = $(BUILDDIR)/source/
 
 # Will need later for scrubbing generated .md files

--- a/packages/browser/docs/api/conf.py
+++ b/packages/browser/docs/api/conf.py
@@ -77,6 +77,7 @@ html_theme_path = ['./build/docs-assets/themes']
 html_copy_source = False
 
 html_title = 'Inrupt {0} API Documentation'.format(name)
+html_favicon = "https://docs.inrupt.com/inrupt_stickers_v2-03.png"
 
 # These theme options are declared in ./themes/inrupt/theme.conf
 # as well as some for pydata_sphinx_theme
@@ -126,6 +127,14 @@ html_theme_options = {
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['./build/docs-assets/_static']
+
+html_css_files = [
+    'css/inrupt.css',
+]
+
+html_context = {
+   "default_mode": "auto"
+}
 
 html_sidebars = {
     '**': [  'search-field.html',  'docs-sidebar.html'],

--- a/packages/browser/docs/api/requirements.txt
+++ b/packages/browser/docs/api/requirements.txt
@@ -1,5 +1,5 @@
 # pip install -r requirements.txt
 
 pydata-sphinx-theme==0.12.0
-myst-parser
-Sphinx
+myst-parser==0.18.1
+Sphinx==5.3.0

--- a/packages/browser/docs/api/source/functions.md
+++ b/packages/browser/docs/api/source/functions.md
@@ -1,3 +1,2 @@
 # Functions
 
-## Table of contents

--- a/packages/browser/tsconfig.json
+++ b/packages/browser/tsconfig.json
@@ -9,7 +9,8 @@
   "typedocOptions": {
     "out": "website/docs/api/browser",
     "entryPoints": ["./src/index.ts"],
-    "entryDocument": "index.md"
+    "entryDocument": "index.md",
+    "hideInPageTOC": true,
   },
 
   "include": ["src/**/*"],

--- a/packages/core/docs/api/Makefile
+++ b/packages/core/docs/api/Makefile
@@ -7,7 +7,7 @@ SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = source
 GIT_BRANCH    :=$(shell git rev-parse --abbrev-ref HEAD)
 BUILDDIR      = build
-SPHINXOPTS    = -d $(BUILDDIR)/doctrees -W 
+SPHINXOPTS    = -d $(BUILDDIR)/doctrees 
 SOURCECOPYDIR = $(BUILDDIR)/source/
 
 # Will need later for scrubbing generated .md files

--- a/packages/core/docs/api/conf.py
+++ b/packages/core/docs/api/conf.py
@@ -77,6 +77,7 @@ html_theme_path = ['./build/docs-assets/themes']
 html_copy_source = False
 
 html_title = 'Inrupt {0} API Documentation'.format(name)
+html_favicon = "https://docs.inrupt.com/inrupt_stickers_v2-03.png"
 
 # These theme options are declared in ./themes/inrupt/theme.conf
 # as well as some for pydata_sphinx_theme
@@ -129,10 +130,15 @@ html_theme_options = {
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['./build/docs-assets/_static']
 
+html_css_files = [
+    'css/inrupt.css',
+]
 
 html_sidebars = {
     '**': [  'search-field.html',  'docs-sidebar.html'],
 }
-
+html_context = {
+   "default_mode": "auto"
+}
 locale_dirs = ['locale/']   # path is example but recommended.
 gettext_compact = False     # optional.

--- a/packages/core/docs/api/requirements.txt
+++ b/packages/core/docs/api/requirements.txt
@@ -1,5 +1,5 @@
 # pip install -r requirements.txt
 
-pydata-sphinx-theme==0.6.1
-myst-parser
-Sphinx
+pydata-sphinx-theme==0.12.0
+myst-parser==0.18.1
+Sphinx==5.3.0

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -9,7 +9,8 @@
   "typedocOptions": {
     "out": "website/docs/api/core",
     "entryPoints": ["./src/index.ts"],
-    "entryDocument": "index.md"
+    "entryDocument": "index.md",
+    "hideInPageTOC": true,
   },
 
   "include": ["src/**/*"],

--- a/packages/node/docs/api/Makefile
+++ b/packages/node/docs/api/Makefile
@@ -7,7 +7,7 @@ SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = source
 GIT_BRANCH    :=$(shell git rev-parse --abbrev-ref HEAD)
 BUILDDIR      = build
-SPHINXOPTS    = -d $(BUILDDIR)/doctrees -W 
+SPHINXOPTS    = -d $(BUILDDIR)/doctrees 
 SOURCECOPYDIR = $(BUILDDIR)/source/
 
 # Will need later for scrubbing generated .md files

--- a/packages/node/docs/api/conf.py
+++ b/packages/node/docs/api/conf.py
@@ -77,6 +77,7 @@ html_theme_path = ['./build/docs-assets/themes']
 html_copy_source = False
 
 html_title = 'Inrupt {0} API Documentation'.format(name)
+html_favicon = "https://docs.inrupt.com/inrupt_stickers_v2-03.png"
 
 # These theme options are declared in ./themes/inrupt/theme.conf
 # as well as some for pydata_sphinx_theme
@@ -127,10 +128,16 @@ html_theme_options = {
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['./build/docs-assets/_static']
 
+html_css_files = [
+    'css/inrupt.css',
+]
 
 html_sidebars = {
     '**': [  'search-field.html',  'docs-sidebar.html'],
 }
 
+html_context = {
+   "default_mode": "auto"
+}
 locale_dirs = ['locale/']   # path is example but recommended.
 gettext_compact = False     # optional.

--- a/packages/node/docs/api/requirements.txt
+++ b/packages/node/docs/api/requirements.txt
@@ -1,5 +1,5 @@
 # pip install -r requirements.txt
 
-pydata-sphinx-theme==0.6.1
-myst-parser
-Sphinx
+pydata-sphinx-theme==0.12.0
+myst-parser==0.18.1
+Sphinx==5.3.0

--- a/packages/node/docs/api/source/functions.md
+++ b/packages/node/docs/api/source/functions.md
@@ -1,4 +1,3 @@
 # Functions
 
-## Table of contents
 

--- a/packages/node/tsconfig.json
+++ b/packages/node/tsconfig.json
@@ -9,7 +9,8 @@
   "typedocOptions": {
     "out": "website/docs/api/node",
     "entryPoints": ["./src/index.ts"],
-    "entryDocument": "index.md"
+    "entryDocument": "index.md",
+    "hideInPageTOC": true,
   },
 
   "include": ["src/**/*"],


### PR DESCRIPTION
Noticed that the API docs for authn wasn't building. Added patch to fix + additional patches in prep for dependency updates:

1. Patch 1: [add back typedoc-plugin-markdown dependency](https://github.com/inrupt/solid-client-authn-js/commit/0b2cdd372afa71bf8519394b479b29d2ea9f7296): This fixes the build. I think the dependency accidentally got dropped during https://github.com/inrupt/solid-client-authn-js/pull/2118/files.  
2. The other patches are in prep for dependency updates.


- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

