### PR TITLE
Replaces events with tiny-emitter

### DIFF
--- a/packages/browser/package-lock.json
+++ b/packages/browser/package-lock.json
@@ -14,9 +14,9 @@
         "@types/lodash.clonedeep": "^4.5.6",
         "@types/node": "^18.0.3",
         "@types/uuid": "^8.3.0",
-        "events": "^3.3.0",
         "jose": "^4.3.7",
         "lodash.clonedeep": "^4.5.0",
+        "tiny-emitter": "^2.1.0",
         "uuid": "^9.0.0"
       },
       "devDependencies": {
@@ -39,75 +39,29 @@
       }
     },
     "node_modules/@inrupt/oidc-client-ext": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@inrupt/oidc-client-ext/-/oidc-client-ext-1.12.2.tgz",
-      "integrity": "sha512-9JZeBfySsU06KSz/sNDSM2FPyE1SGj1VEa4J7s9TngyQ8Bu+Z347E4+ULZesglmXfgtF1IOTaQcBE2XQTOgVPA==",
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/@inrupt/oidc-client-ext/-/oidc-client-ext-1.12.3.tgz",
+      "integrity": "sha512-7nbrokn02T+WGHLbGq3uNHpYO6AGQUA5BVZSqrUs0FB9mSK203stqdKcW6FKndjUtggchWLecsZV5TQX62Yljg==",
       "dependencies": {
         "@inrupt/oidc-client": "^1.11.6",
-        "@inrupt/solid-client-authn-core": "^1.12.2",
-        "@types/jest": "^27.0.3",
-        "@types/uuid": "^8.3.0",
-        "jose": "^4.3.7",
-        "uuid": "^8.3.1"
-      }
-    },
-    "node_modules/@inrupt/oidc-client-ext/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
+        "@inrupt/solid-client-authn-core": "^1.12.3",
+        "jose": "^4.10.0",
+        "uuid": "^9.0.0"
       }
     },
     "node_modules/@inrupt/solid-client-authn-core": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-core/-/solid-client-authn-core-1.12.2.tgz",
-      "integrity": "sha512-UitzMHfUKVHy5ogYgdRLo82CUkHrFLJfnYH8jxpELEK+EzOg3zDT0vmNyNjpZ9vL9th9BOzy8RBuwWusZuo/wg==",
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-core/-/solid-client-authn-core-1.12.3.tgz",
+      "integrity": "sha512-hHVaSSojOC73ag3PyhyKW0FQPu7wMyKJWZhG2RSF+EwIwMUoSVPtsImxG/SU3SnfeQQInUHNfyqWeTNy6k3X8A==",
       "dependencies": {
-        "@inrupt/solid-common-vocab": "^1.0.0",
-        "@types/lodash.clonedeep": "^4.5.6",
-        "@types/uuid": "^8.3.0",
         "cross-fetch": "^3.1.5",
         "events": "^3.3.0",
-        "jose": "^4.3.7",
+        "jose": "^4.10.0",
         "lodash.clonedeep": "^4.5.0",
-        "uuid": "^8.3.1"
+        "uuid": "^9.0.0"
       },
       "engines": {
         "node": "^14.0.0 || ^16.0.0"
-      }
-    },
-    "node_modules/@inrupt/solid-client-authn-core/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/@inrupt/solid-common-vocab": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-common-vocab/-/solid-common-vocab-1.0.1.tgz",
-      "integrity": "sha512-daCb8amQHzfB9N5bop3enur6l6UHjt9/fxvC8Or9wdzybAGMSF7UcrW3Pr/MM5H0GOKrVBczlxR4t6sMWgul1g==",
-      "dependencies": {
-        "@rdfjs/types": "^1.1.0"
-      }
-    },
-    "node_modules/@rdfjs/types": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.0.tgz",
-      "integrity": "sha512-5zm8bN2/CC634dTcn/0AhTRLaQRjXDZs3QfcAsQKNturHT7XVWcKy/8p3P5gXl+YkZTAmy7T5M/LyiT/jbkENw==",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/jest": {
-      "version": "27.4.1",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.4.1.tgz",
-      "integrity": "sha512-23iPJADSmicDVrWk+HT58LMJtzLAnB2AgIzplQuq/bSrGaxCrlvRFjGbXmamnnk/mAmCdLStiGqggu28ocUyiw==",
-      "dependencies": {
-        "jest-matcher-utils": "^27.0.0",
-        "pretty-format": "^27.0.0"
       }
     },
     "node_modules/@types/lodash": {
@@ -144,28 +98,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -184,37 +116,6 @@
           "url": "https://feross.org/support"
         }
       ]
-    },
-    "node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/core-js": {
       "version": "3.21.1",
@@ -239,64 +140,12 @@
       "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
       "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
     },
-    "node_modules/diff-sequences": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.5.1.tgz",
-      "integrity": "sha512-k1gCAXAsNgLwEL+Y8Wvl+M6oEFj5bgazfZULpS5CneoPPXRaCCW7dm+q21Ky2VEE5X+VeRDBVg1Pcvvsr4TtNQ==",
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
     "node_modules/events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
       "engines": {
         "node": ">=0.8.x"
-      }
-    },
-    "node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-diff": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.5.1.tgz",
-      "integrity": "sha512-m0NvkX55LDt9T4mctTEgnZk3fmEg3NRYutvMPWM/0iPnkFj2wIeF45O1718cMSOFO1vINkqmxqD8vE37uTEbqw==",
-      "dependencies": {
-        "chalk": "^4.0.0",
-        "diff-sequences": "^27.5.1",
-        "jest-get-type": "^27.5.1",
-        "pretty-format": "^27.5.1"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/jest-get-type": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.5.1.tgz",
-      "integrity": "sha512-2KY95ksYSaK7DMBWQn6dQz3kqAf3BB64y2udeG+hv4KfSOb9qwcYQstTJc1KCbsix+wLZWZYN8t7nwX3GOBLRw==",
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/jest-matcher-utils": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-27.5.1.tgz",
-      "integrity": "sha512-z2uTx/T6LBaCoNWNFWwChLBKYxTMcGBRjAt+2SbP929/Fflb9aa5LGma654Rz8z9HLxsrUaYzxE9T/EFIL/PAw==",
-      "dependencies": {
-        "chalk": "^4.0.0",
-        "jest-diff": "^27.5.1",
-        "jest-get-type": "^27.5.1",
-        "pretty-format": "^27.5.1"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
     "node_modules/jose": {
@@ -350,30 +199,6 @@
         "webidl-conversions": "^3.0.0"
       }
     },
-    "node_modules/pretty-format": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-      "dependencies": {
-        "ansi-regex": "^5.0.1",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^17.0.1"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/pretty-format/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -381,11 +206,6 @@
       "dependencies": {
         "safe-buffer": "^5.1.0"
       }
-    },
-    "node_modules/react-is": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
@@ -400,16 +220,10 @@
         "randombytes": "^2.1.0"
       }
     },
-    "node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
+    "node_modules/tiny-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
     },
     "node_modules/uuid": {
       "version": "9.0.0",
@@ -434,70 +248,26 @@
       }
     },
     "@inrupt/oidc-client-ext": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@inrupt/oidc-client-ext/-/oidc-client-ext-1.12.2.tgz",
-      "integrity": "sha512-9JZeBfySsU06KSz/sNDSM2FPyE1SGj1VEa4J7s9TngyQ8Bu+Z347E4+ULZesglmXfgtF1IOTaQcBE2XQTOgVPA==",
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/@inrupt/oidc-client-ext/-/oidc-client-ext-1.12.3.tgz",
+      "integrity": "sha512-7nbrokn02T+WGHLbGq3uNHpYO6AGQUA5BVZSqrUs0FB9mSK203stqdKcW6FKndjUtggchWLecsZV5TQX62Yljg==",
       "requires": {
         "@inrupt/oidc-client": "^1.11.6",
-        "@inrupt/solid-client-authn-core": "^1.12.2",
-        "@types/jest": "^27.0.3",
-        "@types/uuid": "^8.3.0",
-        "jose": "^4.3.7",
-        "uuid": "^8.3.1"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "8.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
-        }
+        "@inrupt/solid-client-authn-core": "^1.12.3",
+        "jose": "^4.10.0",
+        "uuid": "^9.0.0"
       }
     },
     "@inrupt/solid-client-authn-core": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-core/-/solid-client-authn-core-1.12.2.tgz",
-      "integrity": "sha512-UitzMHfUKVHy5ogYgdRLo82CUkHrFLJfnYH8jxpELEK+EzOg3zDT0vmNyNjpZ9vL9th9BOzy8RBuwWusZuo/wg==",
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-core/-/solid-client-authn-core-1.12.3.tgz",
+      "integrity": "sha512-hHVaSSojOC73ag3PyhyKW0FQPu7wMyKJWZhG2RSF+EwIwMUoSVPtsImxG/SU3SnfeQQInUHNfyqWeTNy6k3X8A==",
       "requires": {
-        "@inrupt/solid-common-vocab": "^1.0.0",
-        "@types/lodash.clonedeep": "^4.5.6",
-        "@types/uuid": "^8.3.0",
         "cross-fetch": "^3.1.5",
         "events": "^3.3.0",
-        "jose": "^4.3.7",
+        "jose": "^4.10.0",
         "lodash.clonedeep": "^4.5.0",
-        "uuid": "^8.3.1"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "8.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
-        }
-      }
-    },
-    "@inrupt/solid-common-vocab": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-common-vocab/-/solid-common-vocab-1.0.1.tgz",
-      "integrity": "sha512-daCb8amQHzfB9N5bop3enur6l6UHjt9/fxvC8Or9wdzybAGMSF7UcrW3Pr/MM5H0GOKrVBczlxR4t6sMWgul1g==",
-      "requires": {
-        "@rdfjs/types": "^1.1.0"
-      }
-    },
-    "@rdfjs/types": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.0.tgz",
-      "integrity": "sha512-5zm8bN2/CC634dTcn/0AhTRLaQRjXDZs3QfcAsQKNturHT7XVWcKy/8p3P5gXl+YkZTAmy7T5M/LyiT/jbkENw==",
-      "requires": {
-        "@types/node": "*"
-      }
-    },
-    "@types/jest": {
-      "version": "27.4.1",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.4.1.tgz",
-      "integrity": "sha512-23iPJADSmicDVrWk+HT58LMJtzLAnB2AgIzplQuq/bSrGaxCrlvRFjGbXmamnnk/mAmCdLStiGqggu28ocUyiw==",
-      "requires": {
-        "jest-matcher-utils": "^27.0.0",
-        "pretty-format": "^27.0.0"
+        "uuid": "^9.0.0"
       }
     },
     "@types/lodash": {
@@ -528,45 +298,10 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
     },
-    "ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
-    },
-    "ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "requires": {
-        "color-convert": "^2.0.1"
-      }
-    },
     "base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
-    },
-    "chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "requires": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      }
-    },
-    "color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "requires": {
-        "color-name": "~1.1.4"
-      }
-    },
-    "color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "core-js": {
       "version": "3.21.1",
@@ -586,47 +321,10 @@
       "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
       "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
     },
-    "diff-sequences": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.5.1.tgz",
-      "integrity": "sha512-k1gCAXAsNgLwEL+Y8Wvl+M6oEFj5bgazfZULpS5CneoPPXRaCCW7dm+q21Ky2VEE5X+VeRDBVg1Pcvvsr4TtNQ=="
-    },
     "events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
-    },
-    "has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-    },
-    "jest-diff": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.5.1.tgz",
-      "integrity": "sha512-m0NvkX55LDt9T4mctTEgnZk3fmEg3NRYutvMPWM/0iPnkFj2wIeF45O1718cMSOFO1vINkqmxqD8vE37uTEbqw==",
-      "requires": {
-        "chalk": "^4.0.0",
-        "diff-sequences": "^27.5.1",
-        "jest-get-type": "^27.5.1",
-        "pretty-format": "^27.5.1"
-      }
-    },
-    "jest-get-type": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.5.1.tgz",
-      "integrity": "sha512-2KY95ksYSaK7DMBWQn6dQz3kqAf3BB64y2udeG+hv4KfSOb9qwcYQstTJc1KCbsix+wLZWZYN8t7nwX3GOBLRw=="
-    },
-    "jest-matcher-utils": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-27.5.1.tgz",
-      "integrity": "sha512-z2uTx/T6LBaCoNWNFWwChLBKYxTMcGBRjAt+2SbP929/Fflb9aa5LGma654Rz8z9HLxsrUaYzxE9T/EFIL/PAw==",
-      "requires": {
-        "chalk": "^4.0.0",
-        "jest-diff": "^27.5.1",
-        "jest-get-type": "^27.5.1",
-        "pretty-format": "^27.5.1"
-      }
     },
     "jose": {
       "version": "4.11.1",
@@ -667,23 +365,6 @@
         }
       }
     },
-    "pretty-format": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-      "requires": {
-        "ansi-regex": "^5.0.1",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^17.0.1"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="
-        }
-      }
-    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -691,11 +372,6 @@
       "requires": {
         "safe-buffer": "^5.1.0"
       }
-    },
-    "react-is": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
     "safe-buffer": {
       "version": "5.1.2",
@@ -710,13 +386,10 @@
         "randombytes": "^2.1.0"
       }
     },
-    "supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "requires": {
-        "has-flag": "^4.0.0"
-      }
+    "tiny-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
     },
     "uuid": {
       "version": "9.0.0",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -34,9 +34,9 @@
     "@types/lodash.clonedeep": "^4.5.6",
     "@types/node": "^18.0.3",
     "@types/uuid": "^8.3.0",
-    "events": "^3.3.0",
     "jose": "^4.3.7",
     "lodash.clonedeep": "^4.5.0",
+    "tiny-emitter": "^2.1.0",
     "uuid": "^9.0.0"
   },
   "publishConfig": {

--- a/packages/browser/src/ClientAuthentication.spec.ts
+++ b/packages/browser/src/ClientAuthentication.spec.ts
@@ -20,7 +20,7 @@
  */
 
 import { jest, it, describe, expect, beforeEach } from "@jest/globals";
-import { EventEmitter } from "events";
+import { TinyEmitter } from "tiny-emitter";
 import * as SolidClientAuthnCore from "@inrupt/solid-client-authn-core";
 
 import {
@@ -115,7 +115,7 @@ describe("ClientAuthentication", () => {
   });
 
   describe("login", () => {
-    const mockEmitter = new EventEmitter();
+    const mockEmitter = new TinyEmitter();
     // TODO: add tests for events & errors
 
     it("calls login, and uses the window.location.href for the redirect if no redirectUrl is set", async () => {
@@ -243,7 +243,7 @@ describe("ClientAuthentication", () => {
   });
 
   describe("logout", () => {
-    const mockEmitter = new EventEmitter();
+    const mockEmitter = new TinyEmitter();
     // TODO: add tests for events & errors
 
     it("reverts back to un-authenticated fetch on logout", async () => {
@@ -311,7 +311,7 @@ describe("ClientAuthentication", () => {
   });
 
   describe("handleIncomingRedirect", () => {
-    const mockEmitter = new EventEmitter();
+    const mockEmitter = new TinyEmitter();
     mockEmitter.emit = jest.fn<typeof mockEmitter.emit>();
 
     it("calls handle redirect", async () => {

--- a/packages/browser/src/ClientAuthentication.ts
+++ b/packages/browser/src/ClientAuthentication.ts
@@ -36,7 +36,7 @@ import {
   EVENTS,
 } from "@inrupt/solid-client-authn-core";
 import { removeOidcQueryParam } from "@inrupt/oidc-client-ext";
-import { EventEmitter } from "events";
+import { TinyEmitter } from "tiny-emitter";
 
 // By only referring to `window` at runtime, apps that do server-side rendering
 // won't run into errors when rendering code that instantiates a
@@ -60,7 +60,7 @@ export default class ClientAuthentication {
   // Isn't Javascript fun?
   login = async (
     options: ILoginOptions,
-    eventEmitter: EventEmitter
+    eventEmitter: TinyEmitter
   ): Promise<void> => {
     // In order to get a clean start, make sure that the session is logged out
     // on login.
@@ -128,7 +128,7 @@ export default class ClientAuthentication {
 
   handleIncomingRedirect = async (
     url: string,
-    eventEmitter: EventEmitter
+    eventEmitter: TinyEmitter
   ): Promise<ISessionInfo | undefined> => {
     try {
       const redirectInfo = await this.redirectHandler.handle(url, eventEmitter);

--- a/packages/browser/src/Session.ts
+++ b/packages/browser/src/Session.ts
@@ -22,7 +22,7 @@
 /**
  * @hidden
  */
-import { EventEmitter } from "events";
+import { TinyEmitter } from "tiny-emitter";
 import {
   EVENTS,
   ILoginInputOptions,
@@ -132,7 +132,7 @@ function isLoggedIn(
 /**
  * A {@link Session} object represents a user's session on an application. The session holds state, as it stores information enabling acces to private resources after login for instance.
  */
-export class Session extends EventEmitter {
+export class Session extends TinyEmitter {
   /**
    * Information regarding the current session.
    */

--- a/packages/browser/src/login/oidc/incomingRedirectHandler/AuthCodeRedirectHandler.ts
+++ b/packages/browser/src/login/oidc/incomingRedirectHandler/AuthCodeRedirectHandler.ts
@@ -45,7 +45,7 @@ import {
   getBearerToken,
   CodeExchangeResult,
 } from "@inrupt/oidc-client-ext";
-import { EventEmitter } from "events";
+import { TinyEmitter } from "tiny-emitter";
 
 /**
  * @hidden
@@ -75,7 +75,7 @@ export class AuthCodeRedirectHandler implements IIncomingRedirectHandler {
 
   async handle(
     redirectUrl: string,
-    eventEmitter?: EventEmitter
+    eventEmitter?: TinyEmitter
   ): Promise<ISessionInfo & { fetch: typeof fetch }> {
     if (!(await this.canHandle(redirectUrl))) {
       throw new Error(

--- a/packages/browser/src/login/oidc/incomingRedirectHandler/ErrorOidcHandler.spec.ts
+++ b/packages/browser/src/login/oidc/incomingRedirectHandler/ErrorOidcHandler.spec.ts
@@ -20,7 +20,7 @@
  */
 
 import { jest, it, describe, expect } from "@jest/globals";
-import { EventEmitter } from "events";
+import { TinyEmitter } from "tiny-emitter";
 import { EVENTS } from "@inrupt/solid-client-authn-core";
 import { ErrorOidcHandler } from "./ErrorOidcHandler";
 
@@ -70,7 +70,7 @@ describe("ErrorOidcHandler", () => {
     });
     it("calls the onError callback if given with both parameters", async () => {
       window.fetch = jest.fn<typeof fetch>();
-      const mockEmitter = new EventEmitter();
+      const mockEmitter = new TinyEmitter();
       // error events must be handled: https://nodejs.org/dist/latest-v16.x/docs/api/events.html#error-events
       mockEmitter.on(EVENTS.ERROR, jest.fn());
       const mockEmit = jest.spyOn(mockEmitter, "emit");
@@ -91,7 +91,7 @@ describe("ErrorOidcHandler", () => {
 
     it("calls the onError callback if given with just error parameters if no description is provided", async () => {
       window.fetch = jest.fn<typeof fetch>();
-      const mockEmitter = new EventEmitter();
+      const mockEmitter = new TinyEmitter();
       const mockEmit = jest.spyOn(mockEmitter, "emit");
       // error events must be handled: https://nodejs.org/dist/latest-v16.x/docs/api/events.html#error-events
       mockEmitter.on(EVENTS.ERROR, jest.fn());

--- a/packages/browser/src/login/oidc/incomingRedirectHandler/ErrorOidcHandler.ts
+++ b/packages/browser/src/login/oidc/incomingRedirectHandler/ErrorOidcHandler.ts
@@ -29,7 +29,7 @@ import {
   IIncomingRedirectHandler,
   ISessionInfo,
 } from "@inrupt/solid-client-authn-core";
-import type { EventEmitter } from "events";
+import type { TinyEmitter } from "tiny-emitter";
 
 import { getUnauthenticatedSession } from "../../../sessionInfo/SessionInfoManager";
 
@@ -53,7 +53,7 @@ export class ErrorOidcHandler implements IIncomingRedirectHandler {
 
   async handle(
     redirectUrl: string,
-    eventEmitter?: EventEmitter
+    eventEmitter?: TinyEmitter
   ): Promise<ISessionInfo & { fetch: typeof fetch }> {
     if (eventEmitter !== undefined) {
       const url = new URL(redirectUrl);

--- a/packages/browser/src/login/oidc/refresh/TokenRefresher.spec.ts
+++ b/packages/browser/src/login/oidc/refresh/TokenRefresher.spec.ts
@@ -31,7 +31,7 @@ import {
 } from "@inrupt/solid-client-authn-core/mocks";
 import { JWK, importJWK } from "jose";
 import { refresh } from "@inrupt/oidc-client-ext";
-import { EventEmitter } from "events";
+import { TinyEmitter } from "tiny-emitter";
 import { KeyObject } from "crypto";
 import TokenRefresher from "./TokenRefresher";
 import {
@@ -228,7 +228,7 @@ describe("TokenRefresher", () => {
 
     it("calls the refresh token rotation callback if a new refresh token is issued", async () => {
       const mockedStorage = mockRefresherDefaultStorageUtility();
-      const mockEmitter = new EventEmitter();
+      const mockEmitter = new TinyEmitter();
       const mockEmit = jest.spyOn(mockEmitter, "emit");
 
       await mockOidcModule({

--- a/packages/browser/src/login/oidc/refresh/TokenRefresher.ts
+++ b/packages/browser/src/login/oidc/refresh/TokenRefresher.ts
@@ -36,7 +36,7 @@ import {
   EVENTS,
 } from "@inrupt/solid-client-authn-core";
 import { refresh } from "@inrupt/oidc-client-ext";
-import { EventEmitter } from "events";
+import { TinyEmitter } from "tiny-emitter";
 
 // Some identifiers are not in camelcase on purpose, as they are named using the
 // official names from the OIDC/OAuth2 specifications.
@@ -56,7 +56,7 @@ export default class TokenRefresher implements ITokenRefresher {
     sessionId: string,
     refreshToken?: string,
     dpopKey?: KeyPair,
-    eventEmitter?: EventEmitter
+    eventEmitter?: TinyEmitter
   ): Promise<TokenEndpointResponse> {
     const oidcContext = await loadOidcContextFromStorage(
       sessionId,

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -10,9 +10,9 @@
       "license": "MIT",
       "dependencies": {
         "cross-fetch": "^3.1.5",
-        "events": "^3.3.0",
         "jose": "^4.10.0",
         "lodash.clonedeep": "^4.5.0",
+        "tiny-emitter": "^2.1.0",
         "uuid": "^9.0.0"
       },
       "devDependencies": {
@@ -63,14 +63,6 @@
       "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
       "dependencies": {
         "node-fetch": "2.6.7"
-      }
-    },
-    "node_modules/events": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "engines": {
-        "node": ">=0.8.x"
       }
     },
     "node_modules/jose": {
@@ -124,6 +116,11 @@
         "webidl-conversions": "^3.0.0"
       }
     },
+    "node_modules/tiny-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
+    },
     "node_modules/uuid": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
@@ -163,11 +160,6 @@
         "node-fetch": "2.6.7"
       }
     },
-    "events": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
-    },
     "jose": {
       "version": "4.11.1",
       "resolved": "https://registry.npmjs.org/jose/-/jose-4.11.1.tgz",
@@ -206,6 +198,11 @@
           }
         }
       }
+    },
+    "tiny-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
     },
     "uuid": {
       "version": "9.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -43,9 +43,9 @@
   },
   "dependencies": {
     "cross-fetch": "^3.1.5",
-    "events": "^3.3.0",
     "jose": "^4.10.0",
     "lodash.clonedeep": "^4.5.0",
+    "tiny-emitter": "^2.1.0",
     "uuid": "^9.0.0"
   },
   "publishConfig": {

--- a/packages/core/src/authenticatedFetch/fetchFactory.spec.ts
+++ b/packages/core/src/authenticatedFetch/fetchFactory.spec.ts
@@ -24,7 +24,7 @@
 
 import { jest, it, describe, expect, afterEach } from "@jest/globals";
 import { KeyLike, jwtVerify, generateKeyPair, exportJWK } from "jose";
-import { EventEmitter } from "events";
+import { TinyEmitter } from "tiny-emitter";
 import { Response, Headers } from "cross-fetch";
 import type * as CrossFetch from "cross-fetch";
 import {
@@ -439,7 +439,7 @@ describe("buildAuthenticatedFetch", () => {
       expiresIn: 7,
     });
     const spyTimeout = jest.spyOn(global, "setTimeout");
-    const mockedEmitter = new EventEmitter();
+    const mockedEmitter = new TinyEmitter();
     const spiedEmit = jest.spyOn(mockedEmitter, "emit");
     await buildAuthenticatedFetch(mockedFetch, "myToken", {
       refreshOptions: {
@@ -505,7 +505,7 @@ describe("buildAuthenticatedFetch", () => {
       ...tokenSet,
       expiresIn: 1800,
     });
-    const eventEmitter = new EventEmitter();
+    const eventEmitter = new TinyEmitter();
     const spiedEmit = jest.spyOn(eventEmitter, "emit");
     await buildAuthenticatedFetch(mockedFetch, "myToken", {
       refreshOptions: {
@@ -527,7 +527,7 @@ describe("buildAuthenticatedFetch", () => {
     const tokenSet = mockDefaultTokenSet();
     tokenSet.refreshToken = "some rotated refresh token";
     const mockedFreshener = mockTokenRefresher(tokenSet);
-    const eventEmitter = new EventEmitter();
+    const eventEmitter = new TinyEmitter();
     const spiedEmit = jest.spyOn(eventEmitter, "emit");
     await buildAuthenticatedFetch(mockedFetch, "myToken", {
       refreshOptions: {
@@ -597,7 +597,7 @@ describe("buildAuthenticatedFetch", () => {
           "Some error description"
         )
       ) as any;
-    const mockEmitter = new EventEmitter();
+    const mockEmitter = new TinyEmitter();
     // 'error' events must be listened to.
     mockEmitter.on(EVENTS.ERROR, jest.fn());
     const spiedEmit = jest.spyOn(mockEmitter, "emit");
@@ -637,7 +637,7 @@ describe("buildAuthenticatedFetch", () => {
         ) => ReturnType<ITokenRefresher["refresh"]>
       >()
       .mockRejectedValueOnce(new InvalidResponseError(["access_token"])) as any;
-    const mockEmitter = new EventEmitter();
+    const mockEmitter = new TinyEmitter();
     const spiedEmit = jest.spyOn(mockEmitter, "emit");
 
     await buildAuthenticatedFetch(mockedFetch, "myToken", {
@@ -671,7 +671,7 @@ describe("buildAuthenticatedFetch", () => {
         ) => ReturnType<ITokenRefresher["refresh"]>
       >()
       .mockRejectedValueOnce(new InvalidResponseError(["access_token"])) as any;
-    const mockEmitter = new EventEmitter();
+    const mockEmitter = new TinyEmitter();
     const spiedEmit = jest.spyOn(mockEmitter, "emit");
 
     await buildAuthenticatedFetch(mockedFetch, "myToken", {

--- a/packages/core/src/authenticatedFetch/fetchFactory.ts
+++ b/packages/core/src/authenticatedFetch/fetchFactory.ts
@@ -21,7 +21,7 @@
 
 // eslint-disable-next-line no-shadow
 import { fetch, Headers } from "cross-fetch";
-import { EventEmitter } from "events";
+import { TinyEmitter } from "tiny-emitter";
 import { REFRESH_BEFORE_EXPIRATION_SECONDS, EVENTS } from "../constant";
 import { ITokenRefresher } from "../login/oidc/refresh/ITokenRefresher";
 import { createDpopHeader, KeyPair } from "./dpopUtils";
@@ -111,7 +111,7 @@ async function makeAuthenticatedRequest(
 async function refreshAccessToken(
   refreshOptions: RefreshOptions,
   dpopKey?: KeyPair,
-  eventEmitter?: EventEmitter
+  eventEmitter?: TinyEmitter
 ): Promise<{ accessToken: string; refreshToken?: string; expiresIn?: number }> {
   const tokenSet = await refreshOptions.tokenRefresher.refresh(
     refreshOptions.sessionId,
@@ -163,7 +163,7 @@ export async function buildAuthenticatedFetch(
     dpopKey?: KeyPair;
     refreshOptions?: RefreshOptions;
     expiresIn?: number;
-    eventEmitter?: EventEmitter;
+    eventEmitter?: TinyEmitter;
   }
 ): Promise<typeof fetch> {
   let currentAccessToken = accessToken;

--- a/packages/core/src/login/ILoginOptions.ts
+++ b/packages/core/src/login/ILoginOptions.ts
@@ -24,7 +24,7 @@
  * @packageDocumentation
  */
 
-import { EventEmitter } from "events";
+import { TinyEmitter } from "tiny-emitter";
 import ILoginInputOptions from "../ILoginInputOptions";
 
 /**
@@ -52,5 +52,5 @@ export default interface ILoginOptions extends ILoginInputOptions {
   /**
    * Event emitter enabling calling user-specified callbacks.
    */
-  eventEmitter?: EventEmitter;
+  eventEmitter?: TinyEmitter;
 }

--- a/packages/core/src/login/oidc/IIncomingRedirectHandler.ts
+++ b/packages/core/src/login/oidc/IIncomingRedirectHandler.ts
@@ -26,12 +26,12 @@
 
 // eslint-disable-next-line no-shadow
 import { fetch } from "cross-fetch";
-import { EventEmitter } from "events";
+import { TinyEmitter } from "tiny-emitter";
 import IHandleable from "../../util/handlerPattern/IHandleable";
 import { ISessionInfo } from "../../sessionInfo/ISessionInfo";
 
 export type IncomingRedirectResult = ISessionInfo & { fetch: typeof fetch };
-export type IncomingRedirectInput = [string, EventEmitter | undefined];
+export type IncomingRedirectInput = [string, TinyEmitter | undefined];
 
 /**
  * @hidden

--- a/packages/core/src/login/oidc/IOidcOptions.ts
+++ b/packages/core/src/login/oidc/IOidcOptions.ts
@@ -27,7 +27,7 @@
 /**
  * Defines how OIDC login should proceed
  */
-import { EventEmitter } from "events";
+import { TinyEmitter } from "tiny-emitter";
 import { IIssuerConfig } from "./IIssuerConfig";
 import { IClient } from "./IClient";
 
@@ -63,7 +63,7 @@ export interface IOidcOptions {
    */
   redirectUrl: string;
   handleRedirect?: (url: string) => unknown;
-  eventEmitter?: EventEmitter;
+  eventEmitter?: TinyEmitter;
 }
 
 export default IOidcOptions;

--- a/packages/core/src/login/oidc/__mocks__/IncomingRedirectHandler.ts
+++ b/packages/core/src/login/oidc/__mocks__/IncomingRedirectHandler.ts
@@ -19,14 +19,14 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { EventEmitter } from "events";
+import { TinyEmitter } from "tiny-emitter";
 import { jest } from "@jest/globals";
 
 import IIncomingRedirectHandler from "../IIncomingRedirectHandler";
 
 const canHandle = jest.fn((_url: string) => Promise.resolve(true));
 
-const handle = jest.fn((_url: string, _emitter: EventEmitter | undefined) =>
+const handle = jest.fn((_url: string, _emitter: TinyEmitter | undefined) =>
   Promise.resolve({
     sessionId: "global",
     isLoggedIn: true,

--- a/packages/core/src/login/oidc/refresh/ITokenRefresher.ts
+++ b/packages/core/src/login/oidc/refresh/ITokenRefresher.ts
@@ -19,7 +19,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { EventEmitter } from "events";
+import { TinyEmitter } from "tiny-emitter";
 import { KeyPair } from "../../../authenticatedFetch/dpopUtils";
 
 /**
@@ -69,6 +69,6 @@ export interface ITokenRefresher {
     localUserId: string,
     refreshToken?: string,
     dpopKey?: KeyPair,
-    eventEmitter?: EventEmitter
+    eventEmitter?: TinyEmitter
   ): Promise<TokenEndpointResponse>;
 }

--- a/packages/node/package-lock.json
+++ b/packages/node/package-lock.json
@@ -13,6 +13,7 @@
         "cross-fetch": "^3.1.5",
         "jose": "^4.3.7",
         "openid-client": "^5.1.0",
+        "tiny-emitter": "^2.1.0",
         "uuid": "^9.0.0"
       },
       "devDependencies": {
@@ -24,47 +25,18 @@
       }
     },
     "node_modules/@inrupt/solid-client-authn-core": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-core/-/solid-client-authn-core-1.12.2.tgz",
-      "integrity": "sha512-UitzMHfUKVHy5ogYgdRLo82CUkHrFLJfnYH8jxpELEK+EzOg3zDT0vmNyNjpZ9vL9th9BOzy8RBuwWusZuo/wg==",
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-core/-/solid-client-authn-core-1.12.3.tgz",
+      "integrity": "sha512-hHVaSSojOC73ag3PyhyKW0FQPu7wMyKJWZhG2RSF+EwIwMUoSVPtsImxG/SU3SnfeQQInUHNfyqWeTNy6k3X8A==",
       "dependencies": {
-        "@inrupt/solid-common-vocab": "^1.0.0",
-        "@types/lodash.clonedeep": "^4.5.6",
-        "@types/uuid": "^8.3.0",
         "cross-fetch": "^3.1.5",
         "events": "^3.3.0",
-        "jose": "^4.3.7",
+        "jose": "^4.10.0",
         "lodash.clonedeep": "^4.5.0",
-        "uuid": "^8.3.1"
+        "uuid": "^9.0.0"
       },
       "engines": {
         "node": "^14.0.0 || ^16.0.0"
-      }
-    },
-    "node_modules/@inrupt/solid-client-authn-core/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/@inrupt/solid-common-vocab": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-common-vocab/-/solid-common-vocab-1.0.0.tgz",
-      "integrity": "sha512-LcImhJqqPsNl/OlULzEEK2rYevty0eh1zaOLVz3lnydEU1DQkeaJ8fKBxKdp5/QjCtnIYcaDjh5U11PGh29Dgg=="
-    },
-    "node_modules/@types/lodash": {
-      "version": "4.14.179",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.179.tgz",
-      "integrity": "sha512-uwc1x90yCKqGcIOAT6DwOSuxnrAbpkdPsUOZtwrXb4D/6wZs+6qG7QnIawDuZWg0sWpxl+ltIKCaLoMlna678w=="
-    },
-    "node_modules/@types/lodash.clonedeep": {
-      "version": "4.5.6",
-      "resolved": "https://registry.npmjs.org/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.6.tgz",
-      "integrity": "sha512-cE1jYr2dEg1wBImvXlNtp0xDoS79rfEdGozQVgliDZj1uERH4k+rmEMTudP9b4VQ8O6nRb5gPqft0QzEQGMQgA==",
-      "dependencies": {
-        "@types/lodash": "*"
       }
     },
     "node_modules/@types/node": {
@@ -76,7 +48,8 @@
     "node_modules/@types/uuid": {
       "version": "8.3.4",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
-      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
+      "dev": true
     },
     "node_modules/cross-fetch": {
       "version": "3.1.5",
@@ -186,6 +159,11 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/tiny-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
+    },
     "node_modules/uuid": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
@@ -202,43 +180,15 @@
   },
   "dependencies": {
     "@inrupt/solid-client-authn-core": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-core/-/solid-client-authn-core-1.12.2.tgz",
-      "integrity": "sha512-UitzMHfUKVHy5ogYgdRLo82CUkHrFLJfnYH8jxpELEK+EzOg3zDT0vmNyNjpZ9vL9th9BOzy8RBuwWusZuo/wg==",
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-core/-/solid-client-authn-core-1.12.3.tgz",
+      "integrity": "sha512-hHVaSSojOC73ag3PyhyKW0FQPu7wMyKJWZhG2RSF+EwIwMUoSVPtsImxG/SU3SnfeQQInUHNfyqWeTNy6k3X8A==",
       "requires": {
-        "@inrupt/solid-common-vocab": "^1.0.0",
-        "@types/lodash.clonedeep": "^4.5.6",
-        "@types/uuid": "^8.3.0",
         "cross-fetch": "^3.1.5",
         "events": "^3.3.0",
-        "jose": "^4.3.7",
+        "jose": "^4.10.0",
         "lodash.clonedeep": "^4.5.0",
-        "uuid": "^8.3.1"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "8.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
-        }
-      }
-    },
-    "@inrupt/solid-common-vocab": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-common-vocab/-/solid-common-vocab-1.0.0.tgz",
-      "integrity": "sha512-LcImhJqqPsNl/OlULzEEK2rYevty0eh1zaOLVz3lnydEU1DQkeaJ8fKBxKdp5/QjCtnIYcaDjh5U11PGh29Dgg=="
-    },
-    "@types/lodash": {
-      "version": "4.14.179",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.179.tgz",
-      "integrity": "sha512-uwc1x90yCKqGcIOAT6DwOSuxnrAbpkdPsUOZtwrXb4D/6wZs+6qG7QnIawDuZWg0sWpxl+ltIKCaLoMlna678w=="
-    },
-    "@types/lodash.clonedeep": {
-      "version": "4.5.6",
-      "resolved": "https://registry.npmjs.org/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.6.tgz",
-      "integrity": "sha512-cE1jYr2dEg1wBImvXlNtp0xDoS79rfEdGozQVgliDZj1uERH4k+rmEMTudP9b4VQ8O6nRb5gPqft0QzEQGMQgA==",
-      "requires": {
-        "@types/lodash": "*"
+        "uuid": "^9.0.0"
       }
     },
     "@types/node": {
@@ -250,7 +200,8 @@
     "@types/uuid": {
       "version": "8.3.4",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
-      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
+      "dev": true
     },
     "cross-fetch": {
       "version": "3.1.5",
@@ -332,6 +283,11 @@
         "object-hash": "^2.0.1",
         "oidc-token-hash": "^5.0.1"
       }
+    },
+    "tiny-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
     },
     "uuid": {
       "version": "9.0.0",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -28,6 +28,7 @@
     "cross-fetch": "^3.1.5",
     "jose": "^4.3.7",
     "openid-client": "^5.1.0",
+    "tiny-emitter": "^2.1.0",
     "uuid": "^9.0.0"
   },
   "publishConfig": {

--- a/packages/node/src/ClientAuthentication.spec.ts
+++ b/packages/node/src/ClientAuthentication.spec.ts
@@ -20,7 +20,7 @@
  */
 
 import { jest, it, describe, expect } from "@jest/globals";
-import { EventEmitter } from "events";
+import { TinyEmitter } from "tiny-emitter";
 
 import { ILoginHandler, ILoginOptions } from "@inrupt/solid-client-authn-core";
 import {
@@ -61,7 +61,7 @@ describe("ClientAuthentication", () => {
   }
 
   describe("login", () => {
-    const mockEmitter = new EventEmitter();
+    const mockEmitter = new TinyEmitter();
     it("calls login, and defaults to a DPoP token", async () => {
       const clientAuthn = getClientAuthentication();
       await clientAuthn.login(

--- a/packages/node/src/ClientAuthentication.ts
+++ b/packages/node/src/ClientAuthentication.ts
@@ -35,7 +35,7 @@ import {
 } from "@inrupt/solid-client-authn-core";
 // eslint-disable-next-line no-shadow
 import { fetch } from "cross-fetch";
-import { EventEmitter } from "events";
+import { TinyEmitter } from "tiny-emitter";
 
 /**
  * @hidden
@@ -53,7 +53,7 @@ export default class ClientAuthentication {
   login = async (
     sessionId: string,
     options: ILoginInputOptions,
-    eventEmitter: EventEmitter
+    eventEmitter: TinyEmitter
   ): Promise<ISessionInfo | undefined> => {
     // Keep track of the session ID
     await this.sessionInfoManager.register(sessionId);
@@ -123,7 +123,7 @@ export default class ClientAuthentication {
 
   handleIncomingRedirect = async (
     url: string,
-    eventEmitter: EventEmitter
+    eventEmitter: TinyEmitter
   ): Promise<ISessionInfo | undefined> => {
     const redirectInfo = await this.redirectHandler.handle(url, eventEmitter);
 

--- a/packages/node/src/Session.ts
+++ b/packages/node/src/Session.ts
@@ -22,7 +22,7 @@
 /**
  * @hidden
  */
-import { EventEmitter } from "events";
+import { TinyEmitter } from "tiny-emitter";
 import {
   ILoginInputOptions,
   InMemoryStorage,
@@ -85,7 +85,7 @@ export const defaultStorage = new InMemoryStorage();
 /**
  * A {@link Session} object represents a user's session on an application. The session holds state, as it stores information enabling acces to private resources after login for instance.
  */
-export class Session extends EventEmitter {
+export class Session extends TinyEmitter {
   /**
    * Information regarding the current session.
    */

--- a/packages/node/src/dependencies.spec.ts
+++ b/packages/node/src/dependencies.spec.ts
@@ -22,7 +22,7 @@
 import { jest, it, describe, expect } from "@jest/globals";
 import { mockStorage } from "@inrupt/solid-client-authn-core";
 import type * as SolidClientAuthnCore from "@inrupt/solid-client-authn-core";
-import { EventEmitter } from "events";
+import { TinyEmitter } from "tiny-emitter";
 import {
   buildLoginHandler,
   buildRedirectHandler,
@@ -147,7 +147,7 @@ describe("resolution order", () => {
         refreshToken: "some refresh token",
         oidcIssuer: "https://some.issuer",
       },
-      new EventEmitter()
+      new TinyEmitter()
     );
     await expect(
       handlerSelectSpy.mock.results[0].value
@@ -171,7 +171,7 @@ describe("resolution order", () => {
         clientSecret: "some client secret",
         oidcIssuer: "https://some.issuer",
       },
-      new EventEmitter()
+      new TinyEmitter()
     );
     await expect(
       handlerSelectSpy.mock.results[0].value
@@ -194,7 +194,7 @@ describe("resolution order", () => {
         oidcIssuer: "https://some.issuer",
         handleRedirect: jest.fn(),
       },
-      new EventEmitter()
+      new TinyEmitter()
     );
     await expect(
       handlerSelectSpy.mock.results[0].value

--- a/packages/node/src/login/oidc/AggregateIncomingRedirectHandler.ts
+++ b/packages/node/src/login/oidc/AggregateIncomingRedirectHandler.ts
@@ -32,14 +32,14 @@ import {
   ISessionInfo,
   AggregateHandler,
 } from "@inrupt/solid-client-authn-core";
-import { EventEmitter } from "events";
+import { TinyEmitter } from "tiny-emitter";
 
 /**
  * @hidden
  */
 export default class AggregateIncomingRedirectHandler
   extends AggregateHandler<
-    [string, EventEmitter],
+    [string, TinyEmitter],
     ISessionInfo & { fetch: typeof fetch }
   >
   implements IIncomingRedirectHandler

--- a/packages/node/src/login/oidc/incomingRedirectHandler/AuthCodeRedirectHandler.spec.ts
+++ b/packages/node/src/login/oidc/incomingRedirectHandler/AuthCodeRedirectHandler.spec.ts
@@ -29,7 +29,7 @@ import { IdTokenClaims, TokenSet } from "openid-client";
 import { JWK } from "jose";
 import { Response as NodeResponse, Headers as NodeHeaders } from "cross-fetch";
 import type * as CrossFetch from "cross-fetch";
-import { EventEmitter } from "events";
+import { TinyEmitter } from "tiny-emitter";
 import { AuthCodeRedirectHandler } from "./AuthCodeRedirectHandler";
 import { mockSessionInfoManager } from "../../../sessionInfo/__mocks__/SessionInfoManager";
 import {
@@ -421,7 +421,7 @@ describe("AuthCodeRedirectHandler", () => {
       mockedTokens.refresh_token = "some refresh token";
       setupOidcClientMock(mockedTokens);
       const mockedStorage = mockDefaultRedirectStorage();
-      const mockEmitter = new EventEmitter();
+      const mockEmitter = new TinyEmitter();
       const mockEmit = jest.spyOn(mockEmitter, "emit");
 
       // Run the test

--- a/packages/node/src/login/oidc/incomingRedirectHandler/AuthCodeRedirectHandler.ts
+++ b/packages/node/src/login/oidc/incomingRedirectHandler/AuthCodeRedirectHandler.ts
@@ -49,7 +49,7 @@ import { Issuer } from "openid-client";
 import { KeyObject } from "crypto";
 import { fetch as globalFetch } from "cross-fetch";
 
-import { EventEmitter } from "events";
+import { TinyEmitter } from "tiny-emitter";
 import { configToIssuerMetadata } from "../IssuerConfigFetcher";
 
 /**
@@ -81,7 +81,7 @@ export class AuthCodeRedirectHandler implements IIncomingRedirectHandler {
 
   async handle(
     inputRedirectUrl: string,
-    eventEmitter?: EventEmitter
+    eventEmitter?: TinyEmitter
   ): Promise<ISessionInfo & { fetch: typeof globalFetch }> {
     if (!(await this.canHandle(inputRedirectUrl))) {
       throw new Error(

--- a/packages/node/src/login/oidc/oidcHandlers/RefreshTokenOidcHandler.spec.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/RefreshTokenOidcHandler.spec.ts
@@ -32,7 +32,7 @@ import {
 } from "@inrupt/solid-client-authn-core";
 import type * as SolidClientAuthnCore from "@inrupt/solid-client-authn-core";
 import { jwtVerify, exportJWK } from "jose";
-import { EventEmitter } from "events";
+import { TinyEmitter } from "tiny-emitter";
 import { Headers as NodeHeaders, Response as NodeResponse } from "cross-fetch";
 import type * as CrossFetch from "cross-fetch";
 import {
@@ -405,7 +405,7 @@ describe("RefreshTokenOidcHandler", () => {
     const tokenSet = mockDefaultTokenSet();
     tokenSet.refreshToken = "some rotated refresh token";
     const mockedTokenRefresher = mockTokenRefresher(tokenSet);
-    const mockEmitter = new EventEmitter();
+    const mockEmitter = new TinyEmitter();
 
     // This builds the fetch function holding the refresh token...
     const refreshTokenOidcHandler = new RefreshTokenOidcHandler(

--- a/packages/node/src/login/oidc/oidcHandlers/RefreshTokenOidcHandler.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/RefreshTokenOidcHandler.ts
@@ -45,7 +45,7 @@ import {
 } from "@inrupt/solid-client-authn-core";
 import { JWK, importJWK } from "jose";
 import { fetch as globalFetch } from "cross-fetch";
-import { EventEmitter } from "events";
+import { TinyEmitter } from "tiny-emitter";
 import { KeyObject } from "crypto";
 
 function validateOptions(
@@ -70,7 +70,7 @@ async function refreshAccess(
   refreshOptions: RefreshOptions,
   dpop: boolean,
   refreshBindingKey?: KeyPair,
-  eventEmitter?: EventEmitter
+  eventEmitter?: TinyEmitter
 ): Promise<TokenEndpointResponse & { fetch: typeof globalFetch }> {
   try {
     let dpopKey: KeyPair | undefined;

--- a/packages/node/src/login/oidc/refresh/TokenRefresher.spec.ts
+++ b/packages/node/src/login/oidc/refresh/TokenRefresher.spec.ts
@@ -28,7 +28,7 @@ import {
 } from "@inrupt/solid-client-authn-core";
 import { JWK, importJWK } from "jose";
 import { IdTokenClaims, TokenSet } from "openid-client";
-import { EventEmitter } from "events";
+import { TinyEmitter } from "tiny-emitter";
 import { KeyObject } from "crypto";
 import TokenRefresher from "./TokenRefresher";
 import {
@@ -356,7 +356,7 @@ describe("TokenRefresher", () => {
     mockedTokens.refresh_token = "some new refresh token";
     setupOidcClientMock(mockedTokens);
     const mockedStorage = mockRefresherDefaultStorageUtility();
-    const mockEmitter = new EventEmitter();
+    const mockEmitter = new TinyEmitter();
     const mockEmit = jest.spyOn(mockEmitter, "emit");
 
     const refresher = getTokenRefresher({

--- a/packages/node/src/login/oidc/refresh/TokenRefresher.ts
+++ b/packages/node/src/login/oidc/refresh/TokenRefresher.ts
@@ -38,7 +38,7 @@ import {
 } from "@inrupt/solid-client-authn-core";
 import { Issuer, IssuerMetadata, TokenSet } from "openid-client";
 import { KeyObject } from "crypto";
-import { EventEmitter } from "events";
+import { TinyEmitter } from "tiny-emitter";
 import { configToIssuerMetadata } from "../IssuerConfigFetcher";
 import { negotiateClientSigningAlg } from "../ClientRegistrar";
 
@@ -85,7 +85,7 @@ export default class TokenRefresher implements ITokenRefresher {
     sessionId: string,
     refreshToken?: string,
     dpopKey?: KeyPair,
-    eventEmitter?: EventEmitter
+    eventEmitter?: TinyEmitter
   ): Promise<TokenEndpointResponse> {
     const oidcContext = await loadOidcContextFromStorage(
       sessionId,


### PR DESCRIPTION
`events` implements a bigger set of features than we need, and `tiny-emitter` is sufficient for our purpose. It is more lightweight, and has less bug surface because it has less code.
