### PR TITLE
Removed e2e test coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "test:unit:browser": "jest --coverage --verbose --selectProjects browser",
     "test:unit:core": "jest --coverage --verbose --selectProjects core",
     "test:unit:oidc-node": "jest --coverage --verbose --selectProjects oidc-node",
-    "test:e2e:node": "jest --selectProjects e2e-node",
+    "test:e2e:node": "jest --selectProjects e2e-node --collectCoverage false",
     "test:e2e:browser": "playwright test",
     "lerna-version": "lerna version --no-push --no-git-tag-version",
     "build-docs-preview-site": "lerna run build-docs-preview-site; rm -r dist/website || true; lerna exec -- mkdir -p ../../dist/website/\\${PWD##*/}; lerna exec -- \"cp -r docs/api/build/html/. ../../dist/website/\\${PWD##*/}/ || true\"; echo 'API documentation: <a href=\"./browser/\">solid-client-authn-browser</a>, <a href=\"./node/\">solid-client-authn-node</a>, <a href=\"./core/\">solid-client-authn-core</a>, <a href=\"./demo/\">demo app</a>.' >> dist/website/index.html",


### PR DESCRIPTION
This PR is part of a wider clean up effort to remove test coverage for our E2E node tests.
It is part of [ticket SDK-2973](https://inrupt.atlassian.net/browse/SDK-2973).

Details:
The E2E Node.js tests now run via Jest, but we have Jest usually configured to collect code coverage metrics. For now, these metrics do not make sense to collect for our E2E tests, which have traditionally been much lighter (as we rely more on unit tests with mocking), and we’d be better collecting not metrics of the amount of code executed as part of an E2E test run, but instead the number of features/scenarios that were exercised and able to be tested consistently.