### PR TITLE
Feat: support RFC9207, strip iss parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 The following changes have been implemented but not released yet:
 
+## 1.13.0 - 2023-01-12
+
+### node and browser
+
+- Added support for [RFC 9207](https://www.rfc-editor.org/rfc/rfc9207.html)
+
+### Bugfixes
+
+- Clean up `iss` parameter from redirect URL after redirect
+
 ## 1.12.4 - 2023-01-09
 
 - Upgrades dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,13 @@ The following changes have been implemented but not released yet:
 
 ### node and browser
 
+#### New feature
+
 - Added support for [RFC 9207](https://www.rfc-editor.org/rfc/rfc9207.html)
 
-### Bugfixes
+### Browser
+
+#### Bugfixes
 
 - Clean up `iss` parameter from redirect URL after redirect
 
@@ -104,7 +108,7 @@ The following changes have been implemented but not released yet:
 
 - Silent authentication is only attempted once, and no longer retries indefinitely on failure.
 - Default values are provided for the OIDC Provider supported scopes if not present
-  in the configuration. This fixes https://github.com/inrupt/solid-client-authn-js/issues/1991.
+  in the configuration. This fixes <https://github.com/inrupt/solid-client-authn-js/issues/1991>.
 
 ## 1.11.5 - 2022-02-14
 
@@ -558,7 +562,7 @@ The following sections document changes that have been released already:
 ### New features
 
 - Updating the browser window will no longer log the user out if their WebID is
-  hosted on an ESS instance (such as https://pod.inrupt.com). A better, global
+  hosted on an ESS instance (such as <https://pod.inrupt.com>). A better, global
   solution will be implemented later in order not to break compatibility in the
   ecosystem. The current solution is based on a custom `/session` endpoint lookup,
   and a Resource Server cookie.
@@ -616,7 +620,7 @@ The following sections document changes that have been released already:
 
 ### Bugfix
 
-- Addressed part of issue https://github.com/inrupt/solid-client-authn-js/issues/684,
+- Addressed part of issue <https://github.com/inrupt/solid-client-authn-js/issues/684>,
   by providing a `browser` entry in the `package.json` file. The ES modules export will
   be adressed in a different PR.
 - The WebID is now set on the session when logging in a script.
@@ -712,7 +716,7 @@ we will bump the major version when we change our publicly documented interface.
 
 - Fixed typo in `detachSession` function name for the browser `SessionManager`.
 
-### Internal refactor:
+### Internal refactor
 
 - Uses [oidc-client-js](https://github.com/IdentityModel/oidc-client-js) now to
   perform the Auth Code Flow (replacing lots of hand-rolled code).
@@ -724,7 +728,7 @@ we will bump the major version when we change our publicly documented interface.
 
 ## [0.1.4] - 2020-09-11
 
-### NOTE: We skipped v0.1.3 due to testing the release process!
+### NOTE: We skipped v0.1.3 due to testing the release process
 
 ### Bugfixes
 
@@ -732,7 +736,7 @@ we will bump the major version when we change our publicly documented interface.
   - Login now clears the local storage, so that you can log into a different server
     even if not logged out properly.
 
-### Internal refactor:
+### Internal refactor
 
 - Created multiple sub-packages, specifically the core and oidc-dpop-client-browser.
 - Moved interfaces down into Core.
@@ -743,7 +747,7 @@ we will bump the major version when we change our publicly documented interface.
 
 ## [0.1.2] - 2020-09-07
 
-### Internal refactor:
+### Internal refactor
 
 - Moved to Lerna (currently only the browser module is available).
 

--- a/packages/browser/src/ClientAuthentication.spec.ts
+++ b/packages/browser/src/ClientAuthentication.spec.ts
@@ -353,7 +353,7 @@ describe("ClientAuthentication", () => {
       history.replaceState = jest.fn();
       const clientAuthn = getClientAuthentication();
       const url =
-        "https://coolapp.com/redirect?state=someState&code=someAuthCode";
+        "https://coolapp.com/redirect?state=someState&code=someAuthCode&iss=someIssuer";
       await clientAuthn.handleIncomingRedirect(url, mockEmitter);
       // eslint-disable-next-line no-restricted-globals
       expect(history.replaceState).toHaveBeenCalledWith(

--- a/packages/browser/src/ClientAuthentication.ts
+++ b/packages/browser/src/ClientAuthentication.ts
@@ -173,6 +173,7 @@ export default class ClientAuthentication {
     // For login error
     cleanedUpUrl.searchParams.delete("error");
     cleanedUpUrl.searchParams.delete("error_description");
+    cleanedUpUrl.searchParams.delete("iss");
 
     // Remove OAuth-specific query params (since the login flow finishes with
     // the browser being redirected back with OAuth2 query params (e.g. for

--- a/packages/browser/src/login/oidc/incomingRedirectHandler/AuthCodeRedirectHandler.spec.ts
+++ b/packages/browser/src/login/oidc/incomingRedirectHandler/AuthCodeRedirectHandler.spec.ts
@@ -381,6 +381,28 @@ describe("AuthCodeRedirectHandler", () => {
       ).rejects.toThrow("Could not retrieve session");
     });
 
+    it("throws if the iss parameter does not match stored issuer", async () => {
+      const redirectUrl = new URL(DEFAULT_REDIRECT_URL);
+      redirectUrl.searchParams.append("state", DEFAULT_OAUTH_STATE);
+      redirectUrl.searchParams.append("code", DEFAULT_AUTHORIZATION_CODE);
+      redirectUrl.searchParams.append("iss", "someIssuer");
+
+      mockOidcClient();
+      mockFetch(
+        new Response("", {
+          status: 200,
+        })
+      );
+      const storageUtility = mockDefaultStorageUtility();
+      const authCodeRedirectHandler = getAuthCodeRedirectHandler({
+        storageUtility,
+      });
+
+      await expect(
+        authCodeRedirectHandler.handle(redirectUrl.href)
+      ).rejects.toThrow();
+    });
+
     it("returns an authenticated bearer fetch if requested", async () => {
       mockOidcClient();
       const mockedFetch = jest.mocked<typeof fetch>(window.fetch);

--- a/packages/browser/src/login/oidc/incomingRedirectHandler/AuthCodeRedirectHandler.ts
+++ b/packages/browser/src/login/oidc/incomingRedirectHandler/AuthCodeRedirectHandler.ts
@@ -105,9 +105,9 @@ export class AuthCodeRedirectHandler implements IIncomingRedirectHandler {
       this.issuerConfigFetcher
     );
 
-    const iss = url.searchParams.get("iss") as string;
+    const iss = url.searchParams.get("iss");
 
-    if (iss && iss !== issuerConfig.issuer) {
+    if (typeof iss === "string" && iss !== issuerConfig.issuer) {
       throw new Error(
         `The value of the iss parameter (${iss}) does not match the issuer identifier of the authorization server (${issuerConfig.issuer}). See [rfc9207](https://www.rfc-editor.org/rfc/rfc9207.html#section-2.3-3.1.1)`
       );

--- a/packages/browser/src/login/oidc/incomingRedirectHandler/AuthCodeRedirectHandler.ts
+++ b/packages/browser/src/login/oidc/incomingRedirectHandler/AuthCodeRedirectHandler.ts
@@ -105,6 +105,14 @@ export class AuthCodeRedirectHandler implements IIncomingRedirectHandler {
       this.issuerConfigFetcher
     );
 
+    const iss = url.searchParams.get("iss") as string;
+
+    if (iss && iss !== issuerConfig.issuer) {
+      throw new Error(
+        `The value of the iss parameter (${iss}) does not match the issuer identifier of the authorization server (${issuerConfig.issuer}). See [rfc9207](https://www.rfc-editor.org/rfc/rfc9207.html#section-2.3-3.1.1)`
+      );
+    }
+
     if (codeVerifier === undefined) {
       throw new Error(
         `The code verifier for session ${storedSessionId} is missing from storage.`

--- a/packages/node/src/login/oidc/incomingRedirectHandler/AuthCodeRedirectHandler.spec.ts
+++ b/packages/node/src/login/oidc/incomingRedirectHandler/AuthCodeRedirectHandler.spec.ts
@@ -441,6 +441,26 @@ describe("AuthCodeRedirectHandler", () => {
       );
     });
 
+    it("throws if the iss parameter does not match stored issuer", async () => {
+      const mockedStorage = mockDefaultRedirectStorage();
+      const mockedTokens = mockDpopTokens();
+      setupOidcClientMock(mockedTokens);
+      const authCodeRedirectHandler = getAuthCodeRedirectHandler({
+        storageUtility: mockedStorage,
+        sessionInfoManager: mockSessionInfoManager(mockedStorage),
+      });
+
+      await expect(
+        authCodeRedirectHandler.handle(
+          "https://my.app/redirect?code=someCode&state=someState&iss=someIssuer"
+        )
+      ).rejects.toThrow(
+        `The value of the iss parameter (someIssuer) does not match the issuer identifier of the authorization server (${
+          mockDefaultIssuerConfig().issuer
+        }). See [rfc9207](https://www.rfc-editor.org/rfc/rfc9207.html#section-2.3-3.1.1)`
+      );
+    });
+
     it("throws if the IdP does not return an access token", async () => {
       const mockedTokens = mockDpopTokens();
       mockedTokens.access_token = undefined;

--- a/packages/node/src/login/oidc/incomingRedirectHandler/AuthCodeRedirectHandler.ts
+++ b/packages/node/src/login/oidc/incomingRedirectHandler/AuthCodeRedirectHandler.ts
@@ -142,6 +142,14 @@ export class AuthCodeRedirectHandler implements IIncomingRedirectHandler {
       { DPoP: dpopKey?.privateKey as KeyObject }
     );
 
+    const iss = url.searchParams.get("iss") as string;
+
+    if (iss && iss !== oidcContext.issuerConfig.issuer) {
+      throw new Error(
+        `The value of the iss parameter (${iss}) does not match the issuer identifier of the authorization server (${oidcContext.issuerConfig.issuer}). See [rfc9207](https://www.rfc-editor.org/rfc/rfc9207.html#section-2.3-3.1.1)`
+      );
+    }
+
     if (
       tokenSet.access_token === undefined ||
       tokenSet.id_token === undefined

--- a/packages/node/src/login/oidc/incomingRedirectHandler/AuthCodeRedirectHandler.ts
+++ b/packages/node/src/login/oidc/incomingRedirectHandler/AuthCodeRedirectHandler.ts
@@ -142,9 +142,9 @@ export class AuthCodeRedirectHandler implements IIncomingRedirectHandler {
       { DPoP: dpopKey?.privateKey as KeyObject }
     );
 
-    const iss = url.searchParams.get("iss") as string;
+    const iss = url.searchParams.get("iss");
 
-    if (iss && iss !== oidcContext.issuerConfig.issuer) {
+    if (typeof iss === "string" && iss !== oidcContext.issuerConfig.issuer) {
       throw new Error(
         `The value of the iss parameter (${iss}) does not match the issuer identifier of the authorization server (${oidcContext.issuerConfig.issuer}). See [rfc9207](https://www.rfc-editor.org/rfc/rfc9207.html#section-2.3-3.1.1)`
       );


### PR DESCRIPTION
# New feature description

- Added support for [RFC 9207](https://www.rfc-editor.org/rfc/rfc9207.html)
- Clean up `iss` parameter from redirect URL after redirect

Closes #2103 

# Checklist

- [x] All acceptance criteria are met.
- [ ] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [ ] New functions/types have been exported in `index.ts`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
