### PR TITLE
Reduce dependabot updates frequency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,15 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 10
+    allow: 
+      - dependency-type: production
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    allow: 
+      - dependency-type: development
   - package-ecosystem: npm
     directory: "/e2e/browser/test-app"
     schedule:


### PR DESCRIPTION
Updating dev dependencies doesn't need to happen as often as prod dependencies, and maybe that would help reducing the amount of in-flight PRs.
