### PR TITLE
Skip jobs at a matrix level for dependabot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,6 @@ jobs:
   sonar-scan:
     needs: [test]
     runs-on: ubuntu-latest
-    if: ${{ github.actor != 'dependabot[bot]' }}
     strategy:
       matrix:
         # Since this is a monorepo, the Sonar scan must be run on each of the packages but this will pull in the test
@@ -58,6 +57,7 @@ jobs:
           path: coverage/
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@v1.8
+        if: ${{ github.actor != 'dependabot[bot]' }}
         with:
           projectBaseDir: ${{ matrix.project-root }}
         env:

--- a/.github/workflows/e2e-browser.yml
+++ b/.github/workflows/e2e-browser.yml
@@ -8,9 +8,6 @@ env:
   CI: true
 jobs:
   test:
-    # Running end-to-end tests requires accessing secrets which aren't available to dependabot.
-    # https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
-    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     environment:
       name: ${{ matrix.environment-name }}
@@ -40,6 +37,12 @@ jobs:
         run: npm ci
         working-directory: e2e/browser/test-app
       - name: Run browser-based end-to-end tests
+        # Running end-to-end tests requires accessing secrets which aren't available to dependabot.
+        # https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
+        # We want jobs in this workflow to be gating PRs, so the whole matrix must
+        # run even for dependabot so that the matrixed jobs are skipped, instead
+        # of the whole pipeline.
+        if: github.actor != 'dependabot[bot]'
         run: npm run test:e2e:browser
         env:
           E2E_DEMO_CLIENT_APP_URL: http://localhost:3001

--- a/.github/workflows/e2e-node.yml
+++ b/.github/workflows/e2e-node.yml
@@ -9,10 +9,6 @@ env:
   CI: true
 jobs:
   e2e-node:
-    # Dependabot cannot access secrets, so it doesn't have a token to authenticate to ESS.
-    # Since all the other jobs of this workflow depend on this one, skipping it should
-    # skip the entire workflow.
-    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ${{ matrix.os }}
     environment:
       name: ${{ matrix.environment-name }}
@@ -38,7 +34,12 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: npm
       - run: npm ci
-      - run: npm run test:e2e:node
+      - # Dependabot cannot access secrets, so it doesn't have a token to authenticate to ESS.
+        # We want jobs in this workflow to be gating PRs, so the whole matrix must
+        # run even for dependabot so that the matrixed jobs are skipped, instead
+        # of the whole pipeline.
+        if: ${{ github.actor != 'dependabot[bot]' }}
+        run: npm run test:e2e:node
         env:
           E2E_TEST_IDP: ${{ secrets.E2E_TEST_IDP }}
           E2E_TEST_OWNER_CLIENT_ID: ${{ secrets.E2E_TEST_OWNER_CLIENT_ID }}


### PR DESCRIPTION
Skipping jobs at the top-level prevents the e2e tests being gating in the non-dependabot PRs, while skipping them at a lower level in the matrix allow for them to be consistently present in all PRs. They can then be marked as gating.
