### PR TITLE
Accelerate dependabot CI by skipping more steps

### DIFF
--- a/.github/workflows/e2e-browser.yml
+++ b/.github/workflows/e2e-browser.yml
@@ -29,12 +29,16 @@ jobs:
           node-version: 16.x
           cache: npm
       - run: npm ci
+        if: github.actor != 'dependabot[bot]'
       - run: npm run bootstrap -- --ci
       - run: npm run build
+        if: github.actor != 'dependabot[bot]'
       - name: Install e2e tests dependencies
         run: npx playwright install --with-deps
+        if: github.actor != 'dependabot[bot]'
       - name: Prepare browser-based end-to-end tests
         run: npm ci
+        if: github.actor != 'dependabot[bot]'
         working-directory: e2e/browser/test-app
       - name: Run browser-based end-to-end tests
         # Running end-to-end tests requires accessing secrets which aren't available to dependabot.

--- a/.github/workflows/e2e-node.yml
+++ b/.github/workflows/e2e-node.yml
@@ -34,6 +34,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: npm
       - run: npm ci
+        if: github.actor != 'dependabot[bot]'
       - # Dependabot cannot access secrets, so it doesn't have a token to authenticate to ESS.
         # We want jobs in this workflow to be gating PRs, so the whole matrix must
         # run even for dependabot so that the matrixed jobs are skipped, instead


### PR DESCRIPTION
The end-to-end tests are eventually skipped in dependabot in any case, this just skips more steps, targeting the more time-consuming ones. This directly builds on b1aab125d732f530649a5b3b39d2f04c9a416c47.
