### PR TITLE
docs: fix typo in README.md and docs related to environments supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The libraries share a common API and include different modules for different dep
 
 [@inrupt/solid-common-vocab-rdf](https://github.com/inrupt/solid-common-vocab-rdf) allows developers to build interoperable apps by reusing well-known vocabularies. These libraries provide vocabulary terms as constants that you just have to import.
 
-# Supported environment
+# Supported environments
 
 Our JavaScript Client Libraries use relatively modern JavaScript, aligned with
 the [ES2018](https://262.ecma-international.org/9.0/) Specification features, we
@@ -34,8 +34,8 @@ ship both [ESM](https://nodejs.org/docs/latest-v16.x/api/esm.html) and
 [CommonJS](https://nodejs.org/docs/latest-v16.x/api/modules.html), with type
 definitions for TypeScript alongside.
 
-This mean that we only support environments (browsers or runtimes) that were
-released after mid-2018 out of the box, if you wish to target these
+This means that out of the box, we only support environments (browsers or
+runtimes) that were released after mid-2018, if you wish to target other (older)
 environments, then you will need to cross-compile our SDKs via the use of
 [Babel](https://babeljs.io), [webpack](https://webpack.js.org/),
 [SWC](https://swc.rs/), or similar.
@@ -48,6 +48,11 @@ and `String.prototype.endsWith`.
 Additionally, when using this package in an environment other than Node.js, you
 will need [a polyfill for Node's `buffer`
 module](https://www.npmjs.com/package/buffer).
+
+## Node.js Support
+
+Our JavaScript Client Libraries track Node.js [LTS
+releases](https://nodejs.org/en/about/releases/), and support 14.x, and 16.x.
 
 # Installation
 


### PR DESCRIPTION
This continues on from #2597 — note: this repository currently does not include per-package README in the docs, so this change is just to the README.md at the root of the repository.