### PR TITLE
Fix/token expiration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 The following changes have been implemented but not released yet:
 
+### node
+
+#### Bugfixes
+
+- The Client Credential flow had a bug where the expiration time set by the OpenID
+  Provider for the token was ignored, and an arbitrary default was applied instead.
+  This resulted in the session being unable to make authenticated requests, but
+  still acting as if it were logged in. The session now uses the expiration time
+  set by the OpenID Provider.
+
 ## 1.13.1 - 2023-02-15
 
 ### node and browser

--- a/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.spec.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.spec.ts
@@ -121,6 +121,7 @@ const mockDpopTokens = (): TokenSet => {
     token_type: "DPoP",
     expired: () => false,
     claims: mockIdTokenPayload,
+    expires_in: 1662266216,
   };
 };
 
@@ -412,6 +413,7 @@ describe("handle", () => {
           sessionId: "mySession",
           tokenRefresher: mockedRefresher,
         },
+        expiresIn: expect.anything(),
       })
     );
   });

--- a/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.spec.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.spec.ts
@@ -413,7 +413,40 @@ describe("handle", () => {
           sessionId: "mySession",
           tokenRefresher: mockedRefresher,
         },
-        expiresIn: expect.anything(),
+      })
+    );
+  });
+
+  it("builds a fetch authenticated including the expiration value if present", async () => {
+    const tokens = mockDpopTokens();
+    setupOidcClientMock(tokens);
+    const coreModule = jest.requireMock(
+      "@inrupt/solid-client-authn-core"
+    ) as typeof SolidClientAuthnCore;
+    const mockAuthenticatedFetchBuild = jest.spyOn(
+      coreModule,
+      "buildAuthenticatedFetch"
+    );
+    const mockedRefresher = mockDefaultTokenRefresher();
+    const clientCredentialsOidcHandler = new ClientCredentialsOidcHandler(
+      mockedRefresher,
+      mockStorageUtility({})
+    );
+    await clientCredentialsOidcHandler.handle({
+      ...standardOidcOptions,
+      dpop: true,
+      client: {
+        clientId: "some client ID",
+        clientSecret: "some client secret",
+        clientType: "static",
+      },
+    });
+
+    expect(mockAuthenticatedFetchBuild).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({
+        expiresIn: 1662266216,
       })
     );
   });

--- a/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.ts
@@ -138,6 +138,7 @@ export default class ClientCredentialsOidcHandler implements IOidcHandler {
             }
           : undefined,
         eventEmitter: oidcLoginOptions.eventEmitter,
+        expiresIn: tokens.expires_in,
       }
     );
 


### PR DESCRIPTION
This PR is to ensure that the token expiration is passed on to `buildAuthenticatedFetch`, so that the proper expiration time is set and the logout signal is sent at the correct time.  

- [x] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
