### PR TITLE
Append .well-known component to full issuer URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 The following changes have been implemented but not released yet:
 
+### browser
+
+#### Bugfixes
+
+- No longer remove the last issuer URL path component if it doesn't have a trailing
+  slash: a bug was introduced in baac030d33163ba08dadebabdaf676450be7fa88, resulting
+  in the issuer configuration discovery failing if the issuer URL had a path that
+  did not end with a trailing slash. This is now fixed.
+
 ## 1.13.2 - 2023-02-16
 
 ### node

--- a/packages/browser/src/login/oidc/IssuerConfigFetcher.ts
+++ b/packages/browser/src/login/oidc/IssuerConfigFetcher.ts
@@ -162,7 +162,7 @@ export default class IssuerConfigFetcher implements IIssuerConfigFetcher {
     const openIdConfigUrl = new URL(
       WELL_KNOWN_OPENID_CONFIG,
       // Make sure to append a slash at issuer URL, so that the .well-known URL
-      // includes the full issuer path.
+      // includes the full issuer path. See https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig.
       issuer.endsWith("/") ? issuer : `${issuer}/`
     ).href;
     const issuerConfigRequestBody = await window.fetch(openIdConfigUrl);

--- a/packages/browser/src/login/oidc/IssuerConfigFetcher.ts
+++ b/packages/browser/src/login/oidc/IssuerConfigFetcher.ts
@@ -159,7 +159,12 @@ export default class IssuerConfigFetcher implements IIssuerConfigFetcher {
   async fetchConfig(issuer: string): Promise<IIssuerConfig> {
     let issuerConfig: IIssuerConfig;
 
-    const openIdConfigUrl = new URL(WELL_KNOWN_OPENID_CONFIG, issuer).href;
+    const openIdConfigUrl = new URL(
+      WELL_KNOWN_OPENID_CONFIG,
+      // Make sure to append a slash at issuer URL, so that the .well-known URL
+      // includes the full issuer path.
+      issuer.endsWith("/") ? issuer : `${issuer}/`
+    ).href;
     const issuerConfigRequestBody = await window.fetch(openIdConfigUrl);
     // Check the validity of the fetched config
     try {

--- a/packages/node/src/login/oidc/IssuerConfigFetcher.ts
+++ b/packages/node/src/login/oidc/IssuerConfigFetcher.ts
@@ -35,8 +35,6 @@ import {
 } from "@inrupt/solid-client-authn-core";
 import { Issuer, IssuerMetadata } from "openid-client";
 
-export const WELL_KNOWN_OPENID_CONFIG = ".well-known/openid-configuration";
-
 /**
  * Transforms an openid-client IssuerMetadata object into an [[IIssuerConfig]]
  * @param metadata the object to transform.


### PR DESCRIPTION
This reverts the change in https://github.com/inrupt/solid-client-authn-js/commit/baac030d33163ba08dadebabdaf676450be7fa88. According to [the specification](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig), /.well-known/openid-configuration should be appended at the end of the full issuer URL, and the current code removed the last path component if it didn't have a trailing slash.

- [X] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).