### PR TITLE
Set session expiration date when using Client Credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ The following changes have been implemented but not released yet:
   went unnoticed because of a misconfiguration of the browser-based test app that
   should have covered this scenario. Both issues are now resolved.
 
+### node
+
+#### Bugfix
+
+- The `Session` expiration date was not set in all contexts: `session.info.expirationDate`
+  wasn't set properly using Client Credentials.
+
 ## 1.13.3 - 2023-03-07
 
 ### browser

--- a/e2e/browser/test-app/components/appContainer/index.tsx
+++ b/e2e/browser/test-app/components/appContainer/index.tsx
@@ -31,6 +31,7 @@ import {
   logout,
   handleIncomingRedirect,
   ISessionInfo,
+  getDefaultSession,
 } from "@inrupt/solid-client-authn-browser";
 import AuthenticatedFetch from "../authenticatedFetch";
 
@@ -56,10 +57,22 @@ export default function AppContainer() {
   const [issuer, setIssuer] = useState<string>(DEFAULT_ISSUER);
   const [clientId, setClientId] = useState<string>();
   const [errorMessage, setErrorMessage] = useState<string>();
+  const [loginSignalReceived, setLoginSignalReceived] =
+    useState<boolean>(false);
+  const [logoutSignalReceived, setLogoutSignalReceived] =
+    useState<boolean>(false);
 
   const onError = (error: string) => {
     setErrorMessage(error);
   };
+
+  getDefaultSession().onLogin(() => {
+    setLoginSignalReceived(true);
+  });
+
+  getDefaultSession().onLogout(() => {
+    setLogoutSignalReceived(true);
+  });
 
   useEffect(() => {
     handleIncomingRedirect({ restorePreviousSession: true })
@@ -144,7 +157,23 @@ export default function AppContainer() {
         <strong>{errorMessage}</strong>
       </p>
       <br />
-      <AuthenticatedFetch onError={onError} />
+      <table>
+        <tr>
+          <td>Signals</td>
+          <td>Login</td>
+          <td>Logout</td>
+        </tr>
+        <tr>
+          <td>Received?</td>
+          <td data-testId="loginSignalReceived">
+            {loginSignalReceived ? "Yes" : "No"}
+          </td>
+          <td data-testId="logoutSignalReceived">
+            {logoutSignalReceived ? "Yes" : "No"}
+          </td>
+        </tr>
+      </table>
+      <AuthenticatedFetch onError={onError} sessionInfo={sessionInfo} />
     </div>
   );
 }

--- a/e2e/browser/test-app/components/appContainer/index.tsx
+++ b/e2e/browser/test-app/components/appContainer/index.tsx
@@ -165,12 +165,18 @@ export default function AppContainer() {
         </tr>
         <tr>
           <td>Received?</td>
-          <td data-testId="loginSignalReceived">
-            {loginSignalReceived ? "Yes" : "No"}
-          </td>
-          <td data-testId="logoutSignalReceived">
-            {logoutSignalReceived ? "Yes" : "No"}
-          </td>
+          {/* Only set the testId when the value is set so that the test driver waits for React rendering. */}
+          {loginSignalReceived ? (
+            <td data-testId="loginSignalReceived">Yes</td>
+          ) : (
+            <td>No</td>
+          )}
+
+          {logoutSignalReceived ? (
+            <td data-testId="logoutSignalReceived">Yes</td>
+          ) : (
+            <td>No</td>
+          )}
         </tr>
       </table>
       <AuthenticatedFetch onError={onError} sessionInfo={sessionInfo} />

--- a/e2e/browser/test-app/components/authenticatedFetch/index.tsx
+++ b/e2e/browser/test-app/components/authenticatedFetch/index.tsx
@@ -27,6 +27,7 @@ import {
 
 export default function AuthenticatedFetch({
   onError,
+  sessionInfo,
 }: {
   sessionInfo?: ISessionInfo;
   onError: (err: string) => void;
@@ -50,6 +51,12 @@ export default function AuthenticatedFetch({
   return (
     <>
       <div>
+        <p>
+          Session expires at{" "}
+          <span data-testId="sessionExpiration">
+            {sessionInfo?.expirationDate}
+          </span>
+        </p>
         <input
           data-testId="fetchUriTextbox"
           type="text"

--- a/e2e/browser/test/e2e.playwright.ts
+++ b/e2e/browser/test/e2e.playwright.ts
@@ -64,6 +64,16 @@ test.describe("Logged In", () => {
     await auth.login({ allow: true });
   });
 
+  test("The session information are set appropriately", async ({
+    app,
+    page,
+  }) => {
+    expect(await app.isLoginSignalReceived()).toBe(true);
+    expect(await app.getExpirationDate()).toBeGreaterThan(Date.now());
+    await page.click(TESTID_SELECTORS.LOGOUT_BUTTON);
+    expect(await app.isLogoutSignalReceived()).toBe(true);
+  });
+
   test("Public resource in my Pod", async ({ app, testContainer }) => {
     expect(await app.getFetchResponse()).toBe("not fetched");
 

--- a/e2e/browser/test/pageModels/AppPage.ts
+++ b/e2e/browser/test/pageModels/AppPage.ts
@@ -34,6 +34,12 @@ export class AppPage {
 
   private readonly fetchResponseText: Locator;
 
+  private readonly loginSignalReceived: Locator;
+
+  private readonly logoutSignalReceived: Locator;
+
+  private readonly expirationDate: Locator;
+
   constructor(page: Page, options: AppPageOptions) {
     this.page = page;
     this.url = options.clientApplicationUrl;
@@ -41,6 +47,15 @@ export class AppPage {
 
     this.fetchResponseText = this.page.locator(
       '[data-testid="fetchResponseTextbox"]'
+    );
+    this.loginSignalReceived = this.page.locator(
+      '[data-testid="loginSignalReceived"]'
+    );
+    this.logoutSignalReceived = this.page.locator(
+      '[data-testid="loginSignalReceived"]'
+    );
+    this.expirationDate = this.page.locator(
+      '[data-testid="sessionExpiration"]'
     );
   }
 
@@ -65,5 +80,23 @@ export class AppPage {
 
   async getFetchResponse() {
     return this.fetchResponseText.textContent();
+  }
+
+  async isLoginSignalReceived(): Promise<boolean> {
+    const loginSignalText = await this.loginSignalReceived.textContent();
+    return loginSignalText === "Yes";
+  }
+
+  async isLogoutSignalReceived(): Promise<boolean> {
+    const logoutSignalText = await this.logoutSignalReceived.textContent();
+    return logoutSignalText === "Yes";
+  }
+
+  async getExpirationDate(): Promise<number> {
+    const expirationDateText = await this.expirationDate.textContent();
+    if (expirationDateText === null) {
+      throw new Error("No expiration date found.");
+    }
+    return Number.parseInt(expirationDateText, 10);
   }
 }

--- a/e2e/node/e2e-test.spec.ts
+++ b/e2e/node/e2e-test.spec.ts
@@ -57,6 +57,9 @@ describe(`End-to-end authentication tests for environment [${ENV.environment}}]`
       expect(authenticatedSession.info.isLoggedIn).toBe(true);
       expect(authenticatedSession.info.sessionId).toBeDefined();
       expect(authenticatedSession.info.webId).toBeDefined();
+      expect(authenticatedSession.info.expirationDate).toBeGreaterThan(
+        Date.now()
+      );
     });
 
     it("can fetch a public resource when logged in", async () => {

--- a/packages/node/src/ClientAuthentication.ts
+++ b/packages/node/src/ClientAuthentication.ts
@@ -82,11 +82,7 @@ export default class ClientAuthentication {
 
     if (loginReturn !== undefined) {
       this.fetch = loginReturn.fetch;
-      return {
-        isLoggedIn: true,
-        sessionId,
-        webId: loginReturn.webId,
-      };
+      return loginReturn;
     }
 
     // undefined is returned in the case when the login must be completed

--- a/packages/node/src/Session.spec.ts
+++ b/packages/node/src/Session.spec.ts
@@ -482,6 +482,7 @@ describe("getSessionFromStorage", () => {
         webId: "https://my.webid",
         isLoggedIn: true,
         sessionId: "mySession",
+        expirationDate: Date.now() + 3600,
       });
     // Mocking the type definitions of the entire DI framework is a bit too
     // involved at this time, so settling for `any`:
@@ -490,11 +491,14 @@ describe("getSessionFromStorage", () => {
       .fn()
       .mockReturnValue(clientAuthentication);
     const mySession = await getSessionFromStorage("mySession", mockStorage({}));
-    expect(mySession?.info).toStrictEqual({
-      webId: "https://my.webid",
-      isLoggedIn: true,
-      sessionId: "mySession",
-    });
+    expect(mySession?.info).toStrictEqual(
+      expect.objectContaining({
+        webId: "https://my.webid",
+        isLoggedIn: true,
+        sessionId: "mySession",
+      })
+    );
+    expect(mySession?.info.expirationDate).toBeGreaterThan(Date.now());
   });
 
   it("returns a logged out Session if no refresh token is available", async () => {

--- a/packages/node/src/Session.ts
+++ b/packages/node/src/Session.ts
@@ -183,6 +183,7 @@ export class Session extends EventEmitter {
       this.info.isLoggedIn = loginInfo.isLoggedIn;
       this.info.sessionId = loginInfo.sessionId;
       this.info.webId = loginInfo.webId;
+      this.info.expirationDate = loginInfo.expirationDate;
     }
   };
 

--- a/packages/node/src/login/oidc/incomingRedirectHandler/AuthCodeRedirectHandler.spec.ts
+++ b/packages/node/src/login/oidc/incomingRedirectHandler/AuthCodeRedirectHandler.spec.ts
@@ -25,7 +25,7 @@ import {
   mockStorageUtility,
   EVENTS,
 } from "@inrupt/solid-client-authn-core";
-import { IdTokenClaims, TokenSet } from "openid-client";
+import { IdTokenClaims, TokenSet, BaseClient } from "openid-client";
 import { JWK } from "jose";
 import { Response as NodeResponse, Headers as NodeHeaders } from "cross-fetch";
 import type * as CrossFetch from "cross-fetch";
@@ -37,7 +37,10 @@ import {
   mockDefaultIssuerConfig,
 } from "../__mocks__/IssuerConfigFetcher";
 import { mockDefaultClientRegistrar } from "../__mocks__/ClientRegistrar";
-import { mockDefaultTokenRefresher } from "../refresh/__mocks__/TokenRefresher";
+import {
+  mockDefaultTokenRefresher,
+  mockDefaultTokenSet,
+} from "../refresh/__mocks__/TokenRefresher";
 import { configToIssuerMetadata } from "../IssuerConfigFetcher";
 
 jest.mock("openid-client");
@@ -125,6 +128,7 @@ const mockBearerTokens = (): TokenSet => {
     token_type: "Bearer",
     expired: () => false,
     claims: mockIdTokenPayload,
+    expires_in: 3600,
   };
 };
 
@@ -135,6 +139,7 @@ const mockDpopTokens = (): TokenSet => {
     token_type: "DPoP",
     expired: () => false,
     claims: mockIdTokenPayload,
+    expires_in: 3600,
   };
 };
 
@@ -229,7 +234,11 @@ describe("AuthCodeRedirectHandler", () => {
           code: "someCode",
           state: "someState",
         }),
-        callback: callback ?? jest.fn().mockResolvedValue(tokenSet as never),
+        callback:
+          callback ??
+          jest
+            .fn<BaseClient["callback"]>()
+            .mockResolvedValue(tokenSet ?? mockDpopTokens()),
         metadata: {
           client_id: "https://some.client#id",
         },
@@ -252,7 +261,7 @@ describe("AuthCodeRedirectHandler", () => {
       );
     });
 
-    it("properly performs DPoP token exchange", async () => {
+    it("sets the correct session information", async () => {
       setupDefaultOidcClientMock();
       const mockedStorage = mockDefaultRedirectStorage();
 
@@ -269,6 +278,21 @@ describe("AuthCodeRedirectHandler", () => {
       expect(result.sessionId).toBe("mySession");
       expect(result.isLoggedIn).toBe(true);
       expect(result.webId).toEqual(mockWebId());
+      expect(result.expirationDate).toBeGreaterThan(Date.now());
+    });
+
+    it("properly performs DPoP token exchange", async () => {
+      setupDefaultOidcClientMock();
+      const mockedStorage = mockDefaultRedirectStorage();
+
+      const authCodeRedirectHandler = getAuthCodeRedirectHandler({
+        storageUtility: mockedStorage,
+        sessionInfoManager: mockSessionInfoManager(mockedStorage),
+      });
+
+      const result = await authCodeRedirectHandler.handle(
+        "https://my.app/redirect?code=someCode&state=someState"
+      );
 
       // Check that the session information is stored in the provided storage
       await expect(

--- a/packages/node/src/login/oidc/incomingRedirectHandler/AuthCodeRedirectHandler.spec.ts
+++ b/packages/node/src/login/oidc/incomingRedirectHandler/AuthCodeRedirectHandler.spec.ts
@@ -37,10 +37,7 @@ import {
   mockDefaultIssuerConfig,
 } from "../__mocks__/IssuerConfigFetcher";
 import { mockDefaultClientRegistrar } from "../__mocks__/ClientRegistrar";
-import {
-  mockDefaultTokenRefresher,
-  mockDefaultTokenSet,
-} from "../refresh/__mocks__/TokenRefresher";
+import { mockDefaultTokenRefresher } from "../refresh/__mocks__/TokenRefresher";
 import { configToIssuerMetadata } from "../IssuerConfigFetcher";
 
 jest.mock("openid-client");

--- a/packages/node/src/login/oidc/incomingRedirectHandler/AuthCodeRedirectHandler.ts
+++ b/packages/node/src/login/oidc/incomingRedirectHandler/AuthCodeRedirectHandler.ts
@@ -175,7 +175,10 @@ export class AuthCodeRedirectHandler implements IIncomingRedirectHandler {
         dpopKey,
         refreshOptions,
         eventEmitter,
-        expiresIn: tokenSet.expires_in,
+        expiresIn:
+          tokenSet.expires_in ?? typeof tokenSet.expires_at === "number"
+            ? (tokenSet.expires_at as number) - Date.now()
+            : undefined,
       }
     );
 
@@ -209,6 +212,10 @@ export class AuthCodeRedirectHandler implements IIncomingRedirectHandler {
 
     return Object.assign(sessionInfo, {
       fetch: authFetch,
+      expirationDate:
+        tokenSet.expires_at ?? typeof tokenSet.expires_in === "number"
+          ? (tokenSet.expires_in as number) + Date.now()
+          : undefined,
     });
   }
 }

--- a/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.spec.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.spec.ts
@@ -121,7 +121,7 @@ const mockDpopTokens = (): TokenSet => {
     token_type: "DPoP",
     expired: () => false,
     claims: mockIdTokenPayload,
-    expires_in: 1662266216,
+    expires_in: 3600,
   };
 };
 
@@ -446,7 +446,7 @@ describe("handle", () => {
       expect.anything(),
       expect.anything(),
       expect.objectContaining({
-        expiresIn: 1662266216,
+        expiresIn: mockDpopTokens().expires_in,
       })
     );
   });

--- a/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.spec.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.spec.ts
@@ -472,5 +472,6 @@ describe("handle", () => {
     expect(result?.isLoggedIn).toBe(true);
     expect(result?.sessionId).toBe(standardOidcOptions.sessionId);
     expect(result?.webId).toBe("https://my.webid/");
+    expect(result?.expirationDate).toBeGreaterThan(Date.now());
   });
 });

--- a/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.ts
@@ -124,7 +124,6 @@ export default class ClientCredentialsOidcHandler implements IOidcHandler {
         oidcLoginOptions.client.clientId
       );
     }
-
     const authFetch = await buildAuthenticatedFetch(
       globalFetch,
       tokens.access_token,
@@ -138,7 +137,10 @@ export default class ClientCredentialsOidcHandler implements IOidcHandler {
             }
           : undefined,
         eventEmitter: oidcLoginOptions.eventEmitter,
-        expiresIn: tokens.expires_in,
+        expiresIn:
+          tokens.expires_in ?? typeof tokens.expires_at === "number"
+            ? (tokens.expires_at as number) - Date.now()
+            : undefined,
       }
     );
 
@@ -146,8 +148,11 @@ export default class ClientCredentialsOidcHandler implements IOidcHandler {
       isLoggedIn: true,
       sessionId: oidcLoginOptions.sessionId,
       webId,
+      expirationDate:
+        tokens.expires_at ?? typeof tokens.expires_in === "number"
+          ? (tokens.expires_in as number) + Date.now()
+          : undefined,
     };
-
     return Object.assign(sessionInfo, {
       fetch: authFetch,
     });

--- a/packages/node/src/login/oidc/oidcHandlers/RefreshTokenOidcHandler.spec.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/RefreshTokenOidcHandler.spec.ts
@@ -185,6 +185,7 @@ describe("RefreshTokenOidcHandler", () => {
       )) as SolidClientAuthnCore.LoginResult;
       expect(result).toBeDefined();
       expect(result?.webId).toBe("https://my.webid/");
+      expect(result?.expirationDate).toBeGreaterThan(Date.now());
 
       const { fetch: mockedFetch } = jest.requireMock(
         "cross-fetch"

--- a/packages/node/src/login/oidc/oidcHandlers/RefreshTokenOidcHandler.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/RefreshTokenOidcHandler.ts
@@ -214,6 +214,12 @@ export default class RefreshTokenOidcHandler implements IOidcHandler {
         clientName: oidcLoginOptions.client.clientName,
       });
     }
+    let expirationDate: number | undefined;
+    expirationDate = accessInfo.expiresAt;
+    if (expirationDate === undefined && accessInfo.expiresIn !== undefined) {
+      expirationDate = accessInfo.expiresIn + Date.now();
+    }
+    sessionInfo.expirationDate = expirationDate;
 
     return Object.assign(sessionInfo, {
       fetch: accessInfo.fetch,

--- a/packages/node/src/login/oidc/refresh/__mocks__/TokenRefresher.ts
+++ b/packages/node/src/login/oidc/refresh/__mocks__/TokenRefresher.ts
@@ -50,6 +50,7 @@ export const mockDefaultTokenSet = (): TokenEndpointResponse => {
   return {
     accessToken: "some refreshed access token",
     idToken: JSON.stringify(mockIdTokenPayload()),
+    expiresAt: Date.now() + 3600,
   };
 };
 

--- a/packages/node/src/multiSession.spec.ts
+++ b/packages/node/src/multiSession.spec.ts
@@ -58,6 +58,7 @@ describe("getSessionFromStorage", () => {
         webId: "https://my.webid",
         isLoggedIn: true,
         sessionId: "mySession",
+        expirationDate: Date.now() + 3600,
       });
     // Mocking the type definitions of the entire DI framework is a bit too
     // involved at this time, so settling for `any`:
@@ -66,11 +67,14 @@ describe("getSessionFromStorage", () => {
       .fn()
       .mockReturnValue(clientAuthentication);
     const mySession = await getSessionFromStorage("mySession", mockStorage({}));
-    expect(mySession?.info).toStrictEqual({
-      webId: "https://my.webid",
-      isLoggedIn: true,
-      sessionId: "mySession",
-    });
+    expect(mySession?.info).toStrictEqual(
+      expect.objectContaining({
+        webId: "https://my.webid",
+        isLoggedIn: true,
+        sessionId: "mySession",
+      })
+    );
+    expect(mySession?.info.expirationDate).toBeGreaterThan(Date.now());
   });
 
   it("returns a logged out Session if no refresh token is available", async () => {


### PR DESCRIPTION
The Node session didn't have the expiration time set appropriately on login. This fixes the issue and adds tests to prevent regression. Browser tests are also added, even though there wasn't any bugs there.

- [X] I've added a unit test to test for potential regressions of this bug.
- [X] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).