### PR TITLE
Fix units inconsistency using expires_in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ The following have been deprecated, and will be removed in future major releases
 
 The following changes have been implemented but not released yet:
 
+### node
+
+#### Bugfixes
+
+- The session expiration date was incorrectly computed in the authorization code flow.
+
 ## [1.13.4](https://github.com/inrupt/solid-client-authn-js/releases/tag/v1.13.4) - 2023-03-16
 
 ### browser

--- a/e2e/node/e2e-test.spec.ts
+++ b/e2e/node/e2e-test.spec.ts
@@ -256,7 +256,7 @@ describe("Session events", () => {
     }
     const expiresIn = session.info.expirationDate - Date.now();
     await new Promise((resolve) => {
-      setTimeout(resolve, expiresIn * 1000);
+      setTimeout(resolve, expiresIn);
     });
 
     expect(expirationSignalReceived).toBe(true);

--- a/packages/node/src/login/oidc/incomingRedirectHandler/AuthCodeRedirectHandler.spec.ts
+++ b/packages/node/src/login/oidc/incomingRedirectHandler/AuthCodeRedirectHandler.spec.ts
@@ -64,6 +64,7 @@ jest.mock("@inrupt/solid-client-authn-core", () => {
   };
 });
 jest.useFakeTimers();
+const DEFAULT_EXPIRATION_TIME_SECONDS = 300;
 
 const mockJwk = (): JWK => {
   return {
@@ -125,7 +126,7 @@ const mockBearerTokens = (): TokenSet => {
     token_type: "Bearer",
     expired: () => false,
     claims: mockIdTokenPayload,
-    expires_in: 3600,
+    expires_in: DEFAULT_EXPIRATION_TIME_SECONDS,
   };
 };
 
@@ -136,7 +137,7 @@ const mockDpopTokens = (): TokenSet => {
     token_type: "DPoP",
     expired: () => false,
     claims: mockIdTokenPayload,
-    expires_in: 3600,
+    expires_in: DEFAULT_EXPIRATION_TIME_SECONDS,
   };
 };
 
@@ -275,7 +276,9 @@ describe("AuthCodeRedirectHandler", () => {
       expect(result.sessionId).toBe("mySession");
       expect(result.isLoggedIn).toBe(true);
       expect(result.webId).toEqual(mockWebId());
-      expect(result.expirationDate).toEqual(Date.now() + 360 * 1000);
+      expect(result.expirationDate).toEqual(
+        Date.now() + DEFAULT_EXPIRATION_TIME_SECONDS * 1000
+      );
     });
 
     it("properly performs DPoP token exchange", async () => {

--- a/packages/node/src/login/oidc/incomingRedirectHandler/AuthCodeRedirectHandler.spec.ts
+++ b/packages/node/src/login/oidc/incomingRedirectHandler/AuthCodeRedirectHandler.spec.ts
@@ -275,7 +275,7 @@ describe("AuthCodeRedirectHandler", () => {
       expect(result.sessionId).toBe("mySession");
       expect(result.isLoggedIn).toBe(true);
       expect(result.webId).toEqual(mockWebId());
-      expect(result.expirationDate).toBeGreaterThan(Date.now());
+      expect(result.expirationDate).toEqual(Date.now() + 360 * 1000);
     });
 
     it("properly performs DPoP token exchange", async () => {

--- a/packages/node/src/login/oidc/incomingRedirectHandler/AuthCodeRedirectHandler.ts
+++ b/packages/node/src/login/oidc/incomingRedirectHandler/AuthCodeRedirectHandler.ts
@@ -175,10 +175,7 @@ export class AuthCodeRedirectHandler implements IIncomingRedirectHandler {
         dpopKey,
         refreshOptions,
         eventEmitter,
-        expiresIn:
-          tokenSet.expires_in ?? typeof tokenSet.expires_at === "number"
-            ? (tokenSet.expires_at as number) - Date.now()
-            : undefined,
+        expiresIn: tokenSet.expires_in,
       }
     );
 
@@ -213,8 +210,8 @@ export class AuthCodeRedirectHandler implements IIncomingRedirectHandler {
     return Object.assign(sessionInfo, {
       fetch: authFetch,
       expirationDate:
-        tokenSet.expires_at ?? typeof tokenSet.expires_in === "number"
-          ? (tokenSet.expires_in as number) + Date.now()
+        typeof tokenSet.expires_in === "number"
+          ? (tokenSet.expires_in as number) * 1000 + Date.now()
           : undefined,
     });
   }

--- a/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.spec.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.spec.ts
@@ -62,6 +62,7 @@ jest.mock("@inrupt/solid-client-authn-core", () => {
   };
 });
 jest.useFakeTimers();
+const DEFAULT_EXPIRATION_TIME_SECONDS = 300;
 
 const mockJwk = (): JWK => {
   return {
@@ -121,7 +122,7 @@ const mockDpopTokens = (): TokenSet => {
     token_type: "DPoP",
     expired: () => false,
     claims: mockIdTokenPayload,
-    expires_in: 3600,
+    expires_in: DEFAULT_EXPIRATION_TIME_SECONDS,
   };
 };
 
@@ -132,6 +133,7 @@ const mockBearerTokens = (): TokenSet => {
     token_type: "Bearer",
     expired: () => false,
     claims: mockIdTokenPayload,
+    expires_in: DEFAULT_EXPIRATION_TIME_SECONDS,
   };
 };
 
@@ -472,6 +474,8 @@ describe("handle", () => {
     expect(result?.isLoggedIn).toBe(true);
     expect(result?.sessionId).toBe(standardOidcOptions.sessionId);
     expect(result?.webId).toBe("https://my.webid/");
-    expect(result?.expirationDate).toBeGreaterThan(Date.now());
+    expect(result?.expirationDate).toBe(
+      Date.now() + DEFAULT_EXPIRATION_TIME_SECONDS * 1000
+    );
   });
 });

--- a/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.ts
@@ -124,12 +124,6 @@ export default class ClientCredentialsOidcHandler implements IOidcHandler {
         oidcLoginOptions.client.clientId
       );
     }
-    let expiresIn: number | undefined;
-    if (typeof tokens.expires_in === "number") {
-      expiresIn = tokens.expires_in;
-    } else if (typeof tokens.expires_at === "number") {
-      expiresIn = tokens.expires_at - Date.now();
-    }
 
     const authFetch = await buildAuthenticatedFetch(
       globalFetch,
@@ -144,7 +138,7 @@ export default class ClientCredentialsOidcHandler implements IOidcHandler {
             }
           : undefined,
         eventEmitter: oidcLoginOptions.eventEmitter,
-        expiresIn,
+        expiresIn: tokens.expires_in,
       }
     );
 
@@ -153,7 +147,9 @@ export default class ClientCredentialsOidcHandler implements IOidcHandler {
       sessionId: oidcLoginOptions.sessionId,
       webId,
       expirationDate:
-        expiresIn !== undefined ? Date.now() + expiresIn : undefined,
+        tokens.expires_in !== undefined
+          ? Date.now() + tokens.expires_in * 1000
+          : undefined,
     };
     return Object.assign(sessionInfo, {
       fetch: authFetch,


### PR DESCRIPTION
All units in the OAuth token set are in seconds, while Date.now() is in milliseconds, which created a misalignment. In addition, only expires_in is covered by the OAuth spec, so the code now disregards expires_at even if present and only considers expires_in from the token endpoint response.

- [X] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).