### PR TITLE
rm build-api-docs from oidc-browser as it prevents authn-browser api …

### DIFF
--- a/packages/oidc-browser/package.json
+++ b/packages/oidc-browser/package.json
@@ -15,7 +15,6 @@
     "clean-browser": "rimraf ./browserDist",
     "build": "rollup --config rollup.config.mjs",
     "licenses:check": "license-checker --production --out license.csv --failOn \"AGPL-1.0-only; AGPL-1.0-or-later; AGPL-3.0-only; AGPL-3.0-or-later; Beerware; CC-BY-NC-1.0; CC-BY-NC-2.0; CC-BY-NC-2.5; CC-BY-NC-3.0; CC-BY-NC-4.0; CC-BY-NC-ND-1.0; CC-BY-NC-ND-2.0; CC-BY-NC-ND-2.5; CC-BY-NC-ND-3.0; CC-BY-NC-ND-4.0; CC-BY-NC-SA-1.0; CC-BY-NC-SA-2.0; CC-BY-NC-SA-2.5; CC-BY-NC-SA-3.0; CC-BY-NC-SA-4.0; CPAL-1.0; EUPL-1.0; EUPL-1.1; EUPL-1.1;  GPL-1.0-only; GPL-1.0-or-later; GPL-2.0-only;  GPL-2.0-or-later; GPL-3.0; GPL-3.0-only; GPL-3.0-or-later; SISSL;  SISSL-1.2; WTFPL\"",
-    "build-api-docs": "npx typedoc --out docs/api/source/api",
     "build-docs-preview-site": "npm run build-api-docs; cd docs/prose; make html; cd ../api; make html; cd ../; rm -r dist || true; mkdir -p dist/prose dist/api; cp -r prose/build/html/. dist/prose/; cp -r api/build/html/. dist/api/; echo 'Draft documentation: <a href=\"./prose/\">Prose</a>, <a href=\"./api/\">API docs</a>.' >> dist/index.html"
   },
   "license": "MIT",


### PR DESCRIPTION
…docs from building
We don't publish the oidc-browser api docs.  So,  it shouldn't prevent authn-browser api docs from building.

Currently, the oidc-browser api docs fail with:
```sh
lerna notice cli v6.5.1

    ✔  @inrupt/solid-client-authn-core:build-api-docs (17s)

    ✖  @inrupt/oidc-client-ext:build-api-docs
       > @inrupt/oidc-client-ext@1.14.0 build-api-docs
       > npx typedoc --out docs/api/source/api
       
       Loaded plugin /Users/kaykim-inrupt/inrupt/docs/temp/node_modules/typedoc-plugin-markdown
       node_modules/@types/node/globals.d.ts:72:13 - error TS2403: Subsequent variable declarations must have the same type.  Variable 'AbortSignal' must be of type '{ new (): AbortSignal; prototype: AbortSignal; abort(reason?: any): AbortSignal; timeout(milliseconds: number): AbortSignal; }', but here has type '{ new (): AbortSignal; prototype: AbortSignal; timeout(milliseconds: number): AbortSignal; }'.
       
       72 declare var AbortSignal: {
                      ~~~~~~~~~~~
       
         ../../node_modules/typescript/lib/lib.dom.d.ts:2071:13
           2071 declare var AbortSignal: {
                            ~~~~~~~~~~~
           'AbortSignal' was also declared here.
       
    ✔  @inrupt/solid-client-authn-node:build-api-docs (23s)

 ——————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————

 >  Lerna (powered by Nx)   Ran target build-api-docs for 4 projects (40s)
```