### PR TITLE
Pin urllib3 to v1.x in API docs

### DIFF
--- a/packages/browser/docs/api/requirements.txt
+++ b/packages/browser/docs/api/requirements.txt
@@ -2,4 +2,10 @@
 
 pydata-sphinx-theme==0.13.3
 myst-parser==1.0.0
-Sphinx==6.1.3
+# Currently myst-parse is incompatible with sphinx v7
+Sphinx==6.2.1
+# urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled
+# with OpenSSL 1.0.2k-fips  26 Jan 2017.
+# See: https://github.com/urllib3/urllib3/issues/2168, 
+# https://github.com/psf/requests/releases/tag/v2.30.0, )
+urllib3<2

--- a/packages/core/docs/api/requirements.txt
+++ b/packages/core/docs/api/requirements.txt
@@ -1,5 +1,11 @@
 # pip install -r requirements.txt
 
-pydata-sphinx-theme==0.13.2
+pydata-sphinx-theme==0.13.3
 myst-parser==1.0.0
-Sphinx==6.1.3
+# Currently myst-parse is incompatible with sphinx v7
+Sphinx==6.2.1
+# urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled
+# with OpenSSL 1.0.2k-fips  26 Jan 2017.
+# See: https://github.com/urllib3/urllib3/issues/2168, 
+# https://github.com/psf/requests/releases/tag/v2.30.0, )
+urllib3<2

--- a/packages/node/docs/api/requirements.txt
+++ b/packages/node/docs/api/requirements.txt
@@ -1,5 +1,11 @@
 # pip install -r requirements.txt
 
-pydata-sphinx-theme==0.13.2
+pydata-sphinx-theme==0.13.3
 myst-parser==1.0.0
-Sphinx==6.1.3
+# Currently myst-parse is incompatible with sphinx v7
+Sphinx==6.2.1
+# urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled
+# with OpenSSL 1.0.2k-fips  26 Jan 2017.
+# See: https://github.com/urllib3/urllib3/issues/2168, 
+# https://github.com/psf/requests/releases/tag/v2.30.0, )
+urllib3<2


### PR DESCRIPTION
The requests v2.30.0 release introduced support for urllib3 v2, which appears to be breaking for sphinx. This pins the version of urllib3 to a working version until a patch in sphinx. More context in https://github.com/psf/requests/releases/tag/v2.30.0 and urllib3/urllib3#2168.