### PR TITLE
Skip codeQL analysis on dependabot PRs

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -22,6 +22,7 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
 
     strategy:
       fail-fast: false

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -22,7 +22,7 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
-    if: github.actor != 'dependabot[bot]'
+    if: ${{ github.actor != 'dependabot[bot]' }}
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
Dependabot opening multiple PRs in parallel, all of them running CodeQL analysis hits API rate limits. This enforces the CodeQL analysis only runs on non-dependabot PRs.