### PR TITLE
fix: use semver operator for openid client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4099,81 +4099,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
       "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
-    "node_modules/@nrwl/nx-darwin-arm64": {
-      "version": "15.9.4",
-      "resolved": "https://registry.npmjs.org/@nrwl/nx-darwin-arm64/-/nx-darwin-arm64-15.9.4.tgz",
-      "integrity": "sha512-XnvrnT9BJsgThY/4xUcYtE077ERq/img8CkRj7MOOBNOh0/nVcR4LGbBKDHtwE3HPk0ikyS/SxRyNa9msvi3QQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nrwl/nx-darwin-x64": {
-      "version": "15.9.4",
-      "resolved": "https://registry.npmjs.org/@nrwl/nx-darwin-x64/-/nx-darwin-x64-15.9.4.tgz",
-      "integrity": "sha512-WKSfSlpVMLchpXkax0geeUNyhvNxwO7qUz/s0/HJWBekt8fizwKDwDj1gP7fOu+YWb/tHiSscbR1km8PtdjhQw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nrwl/nx-linux-arm-gnueabihf": {
-      "version": "15.9.4",
-      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-15.9.4.tgz",
-      "integrity": "sha512-a/b4PP7lP/Cgrh0LjC4O2YTt5pyf4DQTGtuE8qlo8o486UiofCtk4QGJX72q80s23L0ejCaKY2ULKx/3zMLjuA==",
-      "cpu": [
-        "arm"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nrwl/nx-linux-arm64-gnu": {
-      "version": "15.9.4",
-      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-15.9.4.tgz",
-      "integrity": "sha512-ibBV8fMhSfLVd/2WzcDuUm32BoZsattuKkvMmOoyU6Pzoznc3AqyDjJR4xCIoAn5Rf+Nu1oeQONr5FAtb1Ugow==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nrwl/nx-linux-arm64-musl": {
-      "version": "15.9.4",
-      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-arm64-musl/-/nx-linux-arm64-musl-15.9.4.tgz",
-      "integrity": "sha512-iIjvVYd7+uM4jVD461+PvU5XTALgSvJOODUaMRGOoDl0KlMuTe6pQZlw0eXjl5rcTd6paKaVFWT5j6awr8kj7w==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/@nrwl/nx-linux-x64-gnu": {
       "version": "15.9.4",
       "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-x64-gnu/-/nx-linux-x64-gnu-15.9.4.tgz",
@@ -4199,36 +4124,6 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nrwl/nx-win32-arm64-msvc": {
-      "version": "15.9.4",
-      "resolved": "https://registry.npmjs.org/@nrwl/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-15.9.4.tgz",
-      "integrity": "sha512-2rEsq3eOGVCYpYJn2tTJkOGNJm/U8rP/FmqtZXYa6VJv/00XP3Gl00IXFEDaYV6rZo7SWqLxtEPUbjK5LwPzZA==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@nrwl/nx-win32-x64-msvc": {
-      "version": "15.9.4",
-      "resolved": "https://registry.npmjs.org/@nrwl/nx-win32-x64-msvc/-/nx-win32-x64-msvc-15.9.4.tgz",
-      "integrity": "sha512-bogVju4Z/hy1jbppqaTNbmV1R4Kg0R5fKxXAXC2LaL7FL0dup31wPumdV+mXttXBNOBDjV8V/Oz1ZqdmxpOJUw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
       ],
       "engines": {
         "node": ">= 10"
@@ -23237,36 +23132,6 @@
         }
       }
     },
-    "@nrwl/nx-darwin-arm64": {
-      "version": "15.9.4",
-      "resolved": "https://registry.npmjs.org/@nrwl/nx-darwin-arm64/-/nx-darwin-arm64-15.9.4.tgz",
-      "integrity": "sha512-XnvrnT9BJsgThY/4xUcYtE077ERq/img8CkRj7MOOBNOh0/nVcR4LGbBKDHtwE3HPk0ikyS/SxRyNa9msvi3QQ==",
-      "optional": true
-    },
-    "@nrwl/nx-darwin-x64": {
-      "version": "15.9.4",
-      "resolved": "https://registry.npmjs.org/@nrwl/nx-darwin-x64/-/nx-darwin-x64-15.9.4.tgz",
-      "integrity": "sha512-WKSfSlpVMLchpXkax0geeUNyhvNxwO7qUz/s0/HJWBekt8fizwKDwDj1gP7fOu+YWb/tHiSscbR1km8PtdjhQw==",
-      "optional": true
-    },
-    "@nrwl/nx-linux-arm-gnueabihf": {
-      "version": "15.9.4",
-      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-15.9.4.tgz",
-      "integrity": "sha512-a/b4PP7lP/Cgrh0LjC4O2YTt5pyf4DQTGtuE8qlo8o486UiofCtk4QGJX72q80s23L0ejCaKY2ULKx/3zMLjuA==",
-      "optional": true
-    },
-    "@nrwl/nx-linux-arm64-gnu": {
-      "version": "15.9.4",
-      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-15.9.4.tgz",
-      "integrity": "sha512-ibBV8fMhSfLVd/2WzcDuUm32BoZsattuKkvMmOoyU6Pzoznc3AqyDjJR4xCIoAn5Rf+Nu1oeQONr5FAtb1Ugow==",
-      "optional": true
-    },
-    "@nrwl/nx-linux-arm64-musl": {
-      "version": "15.9.4",
-      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-arm64-musl/-/nx-linux-arm64-musl-15.9.4.tgz",
-      "integrity": "sha512-iIjvVYd7+uM4jVD461+PvU5XTALgSvJOODUaMRGOoDl0KlMuTe6pQZlw0eXjl5rcTd6paKaVFWT5j6awr8kj7w==",
-      "optional": true
-    },
     "@nrwl/nx-linux-x64-gnu": {
       "version": "15.9.4",
       "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-x64-gnu/-/nx-linux-x64-gnu-15.9.4.tgz",
@@ -23277,18 +23142,6 @@
       "version": "15.9.4",
       "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-x64-musl/-/nx-linux-x64-musl-15.9.4.tgz",
       "integrity": "sha512-67+/XNMR1CgLPyeGX8jqSG6l8yYD0iiwUgcu1Vaxq6N05WwnqVisIW8XzLSRUtKt4WyVQgOWk3aspImpMVOG3Q==",
-      "optional": true
-    },
-    "@nrwl/nx-win32-arm64-msvc": {
-      "version": "15.9.4",
-      "resolved": "https://registry.npmjs.org/@nrwl/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-15.9.4.tgz",
-      "integrity": "sha512-2rEsq3eOGVCYpYJn2tTJkOGNJm/U8rP/FmqtZXYa6VJv/00XP3Gl00IXFEDaYV6rZo7SWqLxtEPUbjK5LwPzZA==",
-      "optional": true
-    },
-    "@nrwl/nx-win32-x64-msvc": {
-      "version": "15.9.4",
-      "resolved": "https://registry.npmjs.org/@nrwl/nx-win32-x64-msvc/-/nx-win32-x64-msvc-15.9.4.tgz",
-      "integrity": "sha512-bogVju4Z/hy1jbppqaTNbmV1R4Kg0R5fKxXAXC2LaL7FL0dup31wPumdV+mXttXBNOBDjV8V/Oz1ZqdmxpOJUw==",
       "optional": true
     },
     "@nrwl/tao": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4099,6 +4099,81 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
       "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
+    "node_modules/@nrwl/nx-darwin-arm64": {
+      "version": "15.9.4",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-darwin-arm64/-/nx-darwin-arm64-15.9.4.tgz",
+      "integrity": "sha512-XnvrnT9BJsgThY/4xUcYtE077ERq/img8CkRj7MOOBNOh0/nVcR4LGbBKDHtwE3HPk0ikyS/SxRyNa9msvi3QQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nrwl/nx-darwin-x64": {
+      "version": "15.9.4",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-darwin-x64/-/nx-darwin-x64-15.9.4.tgz",
+      "integrity": "sha512-WKSfSlpVMLchpXkax0geeUNyhvNxwO7qUz/s0/HJWBekt8fizwKDwDj1gP7fOu+YWb/tHiSscbR1km8PtdjhQw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nrwl/nx-linux-arm-gnueabihf": {
+      "version": "15.9.4",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-15.9.4.tgz",
+      "integrity": "sha512-a/b4PP7lP/Cgrh0LjC4O2YTt5pyf4DQTGtuE8qlo8o486UiofCtk4QGJX72q80s23L0ejCaKY2ULKx/3zMLjuA==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nrwl/nx-linux-arm64-gnu": {
+      "version": "15.9.4",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-15.9.4.tgz",
+      "integrity": "sha512-ibBV8fMhSfLVd/2WzcDuUm32BoZsattuKkvMmOoyU6Pzoznc3AqyDjJR4xCIoAn5Rf+Nu1oeQONr5FAtb1Ugow==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nrwl/nx-linux-arm64-musl": {
+      "version": "15.9.4",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-arm64-musl/-/nx-linux-arm64-musl-15.9.4.tgz",
+      "integrity": "sha512-iIjvVYd7+uM4jVD461+PvU5XTALgSvJOODUaMRGOoDl0KlMuTe6pQZlw0eXjl5rcTd6paKaVFWT5j6awr8kj7w==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@nrwl/nx-linux-x64-gnu": {
       "version": "15.9.4",
       "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-x64-gnu/-/nx-linux-x64-gnu-15.9.4.tgz",
@@ -4124,6 +4199,36 @@
       "optional": true,
       "os": [
         "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nrwl/nx-win32-arm64-msvc": {
+      "version": "15.9.4",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-15.9.4.tgz",
+      "integrity": "sha512-2rEsq3eOGVCYpYJn2tTJkOGNJm/U8rP/FmqtZXYa6VJv/00XP3Gl00IXFEDaYV6rZo7SWqLxtEPUbjK5LwPzZA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nrwl/nx-win32-x64-msvc": {
+      "version": "15.9.4",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-win32-x64-msvc/-/nx-win32-x64-msvc-15.9.4.tgz",
+      "integrity": "sha512-bogVju4Z/hy1jbppqaTNbmV1R4Kg0R5fKxXAXC2LaL7FL0dup31wPumdV+mXttXBNOBDjV8V/Oz1ZqdmxpOJUw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">= 10"
@@ -23132,6 +23237,36 @@
         }
       }
     },
+    "@nrwl/nx-darwin-arm64": {
+      "version": "15.9.4",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-darwin-arm64/-/nx-darwin-arm64-15.9.4.tgz",
+      "integrity": "sha512-XnvrnT9BJsgThY/4xUcYtE077ERq/img8CkRj7MOOBNOh0/nVcR4LGbBKDHtwE3HPk0ikyS/SxRyNa9msvi3QQ==",
+      "optional": true
+    },
+    "@nrwl/nx-darwin-x64": {
+      "version": "15.9.4",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-darwin-x64/-/nx-darwin-x64-15.9.4.tgz",
+      "integrity": "sha512-WKSfSlpVMLchpXkax0geeUNyhvNxwO7qUz/s0/HJWBekt8fizwKDwDj1gP7fOu+YWb/tHiSscbR1km8PtdjhQw==",
+      "optional": true
+    },
+    "@nrwl/nx-linux-arm-gnueabihf": {
+      "version": "15.9.4",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-15.9.4.tgz",
+      "integrity": "sha512-a/b4PP7lP/Cgrh0LjC4O2YTt5pyf4DQTGtuE8qlo8o486UiofCtk4QGJX72q80s23L0ejCaKY2ULKx/3zMLjuA==",
+      "optional": true
+    },
+    "@nrwl/nx-linux-arm64-gnu": {
+      "version": "15.9.4",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-15.9.4.tgz",
+      "integrity": "sha512-ibBV8fMhSfLVd/2WzcDuUm32BoZsattuKkvMmOoyU6Pzoznc3AqyDjJR4xCIoAn5Rf+Nu1oeQONr5FAtb1Ugow==",
+      "optional": true
+    },
+    "@nrwl/nx-linux-arm64-musl": {
+      "version": "15.9.4",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-arm64-musl/-/nx-linux-arm64-musl-15.9.4.tgz",
+      "integrity": "sha512-iIjvVYd7+uM4jVD461+PvU5XTALgSvJOODUaMRGOoDl0KlMuTe6pQZlw0eXjl5rcTd6paKaVFWT5j6awr8kj7w==",
+      "optional": true
+    },
     "@nrwl/nx-linux-x64-gnu": {
       "version": "15.9.4",
       "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-x64-gnu/-/nx-linux-x64-gnu-15.9.4.tgz",
@@ -23142,6 +23277,18 @@
       "version": "15.9.4",
       "resolved": "https://registry.npmjs.org/@nrwl/nx-linux-x64-musl/-/nx-linux-x64-musl-15.9.4.tgz",
       "integrity": "sha512-67+/XNMR1CgLPyeGX8jqSG6l8yYD0iiwUgcu1Vaxq6N05WwnqVisIW8XzLSRUtKt4WyVQgOWk3aspImpMVOG3Q==",
+      "optional": true
+    },
+    "@nrwl/nx-win32-arm64-msvc": {
+      "version": "15.9.4",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-15.9.4.tgz",
+      "integrity": "sha512-2rEsq3eOGVCYpYJn2tTJkOGNJm/U8rP/FmqtZXYa6VJv/00XP3Gl00IXFEDaYV6rZo7SWqLxtEPUbjK5LwPzZA==",
+      "optional": true
+    },
+    "@nrwl/nx-win32-x64-msvc": {
+      "version": "15.9.4",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-win32-x64-msvc/-/nx-win32-x64-msvc-15.9.4.tgz",
+      "integrity": "sha512-bogVju4Z/hy1jbppqaTNbmV1R4Kg0R5fKxXAXC2LaL7FL0dup31wPumdV+mXttXBNOBDjV8V/Oz1ZqdmxpOJUw==",
       "optional": true
     },
     "@nrwl/tao": {

--- a/packages/node/examples/bootstrappedApp/package-lock.json
+++ b/packages/node/examples/bootstrappedApp/package-lock.json
@@ -19,21 +19,21 @@
     },
     "../..": {
       "name": "@inrupt/solid-client-authn-node",
-      "version": "1.12.3",
+      "version": "1.16.0",
       "license": "MIT",
       "dependencies": {
-        "@inrupt/solid-client-authn-core": "^1.12.3",
-        "cross-fetch": "^3.1.5",
+        "@inrupt/solid-client-authn-core": "^1.16.0",
+        "@inrupt/universal-fetch": "^1.0.1",
         "jose": "^4.3.7",
-        "openid-client": "^5.1.0",
+        "openid-client": "~5.4.2",
         "uuid": "^9.0.0"
       },
       "devDependencies": {
-        "@types/node": "^18.0.3",
-        "@types/uuid": "^8.3.0"
+        "@types/node": "^20.1.0",
+        "@types/uuid": "^9.0.1"
       },
       "engines": {
-        "node": "^14.0.0 || ^16.0.0"
+        "node": "^14.0.0 || ^16.0.0 || ^18.0.0 || ^20.0.0"
       }
     },
     "../../..": {},
@@ -712,12 +712,12 @@
     "@inrupt/solid-client-authn-node": {
       "version": "file:../..",
       "requires": {
-        "@inrupt/solid-client-authn-core": "^1.12.3",
-        "@types/node": "^18.0.3",
-        "@types/uuid": "^8.3.0",
-        "cross-fetch": "^3.1.5",
+        "@inrupt/solid-client-authn-core": "^1.16.0",
+        "@inrupt/universal-fetch": "^1.0.1",
+        "@types/node": "^20.1.0",
+        "@types/uuid": "^9.0.1",
         "jose": "^4.3.7",
-        "openid-client": "^5.1.0",
+        "openid-client": "~5.4.2",
         "uuid": "^9.0.0"
       }
     },

--- a/packages/node/examples/demoClientApp/package-lock.json
+++ b/packages/node/examples/demoClientApp/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "@inrupt/solid-client-authn-node": "../../",
-        "cross-fetch": "^3.1.5",
         "express": "^4.17.1",
         "loglevel": "^1.7.0"
       },
@@ -28,21 +27,21 @@
     },
     "../..": {
       "name": "@inrupt/solid-client-authn-node",
-      "version": "1.12.3",
+      "version": "1.16.0",
       "license": "MIT",
       "dependencies": {
-        "@inrupt/solid-client-authn-core": "^1.12.3",
-        "cross-fetch": "^3.1.5",
+        "@inrupt/solid-client-authn-core": "^1.16.0",
+        "@inrupt/universal-fetch": "^1.0.1",
         "jose": "^4.3.7",
-        "openid-client": "^5.1.0",
+        "openid-client": "~5.4.2",
         "uuid": "^9.0.0"
       },
       "devDependencies": {
-        "@types/node": "^18.0.3",
-        "@types/uuid": "^8.3.0"
+        "@types/node": "^20.1.0",
+        "@types/uuid": "^9.0.1"
       },
       "engines": {
-        "node": "^14.0.0 || ^16.0.0"
+        "node": "^14.0.0 || ^16.0.0 || ^18.0.0 || ^20.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -806,14 +805,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
-    },
-    "node_modules/cross-fetch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
-      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
-      "dependencies": {
-        "node-fetch": "2.6.7"
-      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -2264,25 +2255,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/nodemon": {
       "version": "2.0.20",
       "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-2.0.20.tgz",
@@ -3375,11 +3347,6 @@
         "node": "*"
       }
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
-    },
     "node_modules/treeify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/treeify/-/treeify-1.1.0.tgz",
@@ -3532,20 +3499,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
-    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -3674,12 +3627,12 @@
     "@inrupt/solid-client-authn-node": {
       "version": "file:../..",
       "requires": {
-        "@inrupt/solid-client-authn-core": "^1.12.3",
-        "@types/node": "^18.0.3",
-        "@types/uuid": "^8.3.0",
-        "cross-fetch": "^3.1.5",
+        "@inrupt/solid-client-authn-core": "^1.16.0",
+        "@inrupt/universal-fetch": "^1.0.1",
+        "@types/node": "^20.1.0",
+        "@types/uuid": "^9.0.1",
         "jose": "^4.3.7",
-        "openid-client": "^5.1.0",
+        "openid-client": "~5.4.2",
         "uuid": "^9.0.0"
       }
     },
@@ -4152,14 +4105,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
-    },
-    "cross-fetch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
-      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
-      "requires": {
-        "node-fetch": "2.6.7"
-      }
     },
     "cross-spawn": {
       "version": "7.0.3",
@@ -5251,14 +5196,6 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
     },
-    "node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-      "requires": {
-        "whatwg-url": "^5.0.0"
-      }
-    },
     "nodemon": {
       "version": "2.0.20",
       "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-2.0.20.tgz",
@@ -6097,11 +6034,6 @@
         }
       }
     },
-    "tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
-    },
     "treeify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/treeify/-/treeify-1.1.0.tgz",
@@ -6219,20 +6151,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
-    },
-    "webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
-    },
-    "whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
-      "requires": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
     },
     "which": {
       "version": "2.0.2",

--- a/packages/node/examples/multiSession/package-lock.json
+++ b/packages/node/examples/multiSession/package-lock.json
@@ -21,21 +21,21 @@
     },
     "../..": {
       "name": "@inrupt/solid-client-authn-node",
-      "version": "1.12.3",
+      "version": "1.16.0",
       "license": "MIT",
       "dependencies": {
-        "@inrupt/solid-client-authn-core": "^1.12.3",
-        "cross-fetch": "^3.1.5",
+        "@inrupt/solid-client-authn-core": "^1.16.0",
+        "@inrupt/universal-fetch": "^1.0.1",
         "jose": "^4.3.7",
-        "openid-client": "^5.1.0",
+        "openid-client": "~5.4.2",
         "uuid": "^9.0.0"
       },
       "devDependencies": {
-        "@types/node": "^18.0.3",
-        "@types/uuid": "^8.3.0"
+        "@types/node": "^20.1.0",
+        "@types/uuid": "^9.0.1"
       },
       "engines": {
-        "node": "^14.0.0 || ^16.0.0"
+        "node": "^14.0.0 || ^16.0.0 || ^18.0.0 || ^20.0.0"
       }
     },
     "node_modules/@inrupt/solid-client-authn-node": {
@@ -777,12 +777,12 @@
     "@inrupt/solid-client-authn-node": {
       "version": "file:../..",
       "requires": {
-        "@inrupt/solid-client-authn-core": "^1.12.3",
-        "@types/node": "^18.0.3",
-        "@types/uuid": "^8.3.0",
-        "cross-fetch": "^3.1.5",
+        "@inrupt/solid-client-authn-core": "^1.16.0",
+        "@inrupt/universal-fetch": "^1.0.1",
+        "@types/node": "^20.1.0",
+        "@types/uuid": "^9.0.1",
         "jose": "^4.3.7",
-        "openid-client": "^5.1.0",
+        "openid-client": "~5.4.2",
         "uuid": "^9.0.0"
       }
     },

--- a/packages/node/package-lock.json
+++ b/packages/node/package-lock.json
@@ -12,7 +12,7 @@
         "@inrupt/solid-client-authn-core": "^1.16.0",
         "@inrupt/universal-fetch": "^1.0.1",
         "jose": "^4.3.7",
-        "openid-client": "^5.1.0",
+        "openid-client": "~5.4.2",
         "uuid": "^9.0.0"
       },
       "devDependencies": {

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -23,7 +23,7 @@
     "@inrupt/solid-client-authn-core": "^1.16.0",
     "@inrupt/universal-fetch": "^1.0.1",
     "jose": "^4.3.7",
-    "openid-client": "^5.1.0",
+    "openid-client": "~5.4.2",
     "uuid": "^9.0.0"
   },
   "publishConfig": {


### PR DESCRIPTION
Per the following warning from the package:

The DPoP APIs implements an IETF draft (https://www.ietf.org/archive/id/draft-ietf-oauth-dpop-04.html). Breaking draft implementations are included as minor versions of the openid-client library, therefore, the ~ semver operator should be used and close attention be payed to library changelog as well as the drafts themselves.


This PR:
 - Sets the `~` semver operator for our `*-authn-node` package
 - Runs `npm i` in the package, and dependent e2e tests to refresh their lockfiles for the changes.