### PR TITLE
chore: remove unused typescript dev-dependencies

### DIFF
--- a/e2e/browser/test-app/package.json
+++ b/e2e/browser/test-app/package.json
@@ -22,7 +22,6 @@
     "@types/react": "^18.2.14",
     "@types/react-dom": "^18.2.6",
     "eslint": "^8.43.0",
-    "eslint-config-next": "^13.4.7",
-    "typescript": "^5.1.3"
+    "eslint-config-next": "^13.4.7"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,8 +72,7 @@
         "@types/react": "^18.2.14",
         "@types/react-dom": "^18.2.6",
         "eslint": "^8.43.0",
-        "eslint-config-next": "^13.4.7",
-        "typescript": "^5.1.3"
+        "eslint-config-next": "^13.4.7"
       }
     },
     "e2e/browser/test-app/node_modules/@inrupt/internal-playwright-testids": {
@@ -86,19 +85,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.2.tgz",
       "integrity": "sha512-vOBLVQeCQfIcF/2Y7eKFTqrMnizK5lRNQ7ykML/5RuwVXVWxYkgwS7xbt4B6fKCUPgbSL5FSsjHQpaGQP/dQmw==",
       "dev": true
-    },
-    "e2e/browser/test-app/node_modules/typescript": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.5.tgz",
-      "integrity": "sha512-FOH+WN/DQjUvN6WgW+c4Ml3yi0PH+a/8q+kNIfRehv1wLhWONedw85iu+vQ39Wp49IzTJEsZ2lyLXpBF7mkF1g==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.2.1",
@@ -23538,9 +23524,6 @@
         "@inrupt/solid-client-authn-node": "^1.16.0",
         "express": "^4.17.3",
         "yargs": "^16.1.1"
-      },
-      "devDependencies": {
-        "typescript": "^4.1.3"
       }
     },
     "packages/node/examples/demoClientApp": {
@@ -23575,8 +23558,7 @@
       },
       "devDependencies": {
         "@types/cookie-session": "^2.0.42",
-        "@types/express": "^4.17.11",
-        "typescript": "^4.9.4"
+        "@types/express": "^4.17.11"
       }
     },
     "packages/node/node_modules/@eslint/eslintrc": {
@@ -24111,19 +24093,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "packages/node/node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
       }
     },
     "packages/node/node_modules/uuid": {
@@ -25703,7 +25672,6 @@
       "requires": {
         "@inrupt/solid-client-authn-node": "^1.16.0",
         "express": "^4.17.3",
-        "typescript": "^4.1.3",
         "yargs": "^16.1.1"
       }
     },
@@ -25714,8 +25682,7 @@
         "@types/cookie-session": "^2.0.42",
         "@types/express": "^4.17.11",
         "cookie-session": "^1.4.0",
-        "express": "^4.17.1",
-        "typescript": "^4.9.4"
+        "express": "^4.17.1"
       }
     },
     "@inrupt/eslint-config-base": {
@@ -26396,12 +26363,6 @@
           "requires": {
             "has-flag": "^4.0.0"
           }
-        },
-        "typescript": {
-          "version": "4.9.5",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-          "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-          "dev": true
         },
         "uuid": {
           "version": "9.0.0",
@@ -40732,8 +40693,7 @@
         "eslint-config-next": "^13.4.7",
         "next": "^13.4.7",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0",
-        "typescript": "^5.1.3"
+        "react-dom": "^18.2.0"
       },
       "dependencies": {
         "@inrupt/internal-playwright-testids": {
@@ -40745,12 +40705,6 @@
           "version": "20.3.2",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.2.tgz",
           "integrity": "sha512-vOBLVQeCQfIcF/2Y7eKFTqrMnizK5lRNQ7ykML/5RuwVXVWxYkgwS7xbt4B6fKCUPgbSL5FSsjHQpaGQP/dQmw==",
-          "dev": true
-        },
-        "typescript": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.5.tgz",
-          "integrity": "sha512-FOH+WN/DQjUvN6WgW+c4Ml3yi0PH+a/8q+kNIfRehv1wLhWONedw85iu+vQ39Wp49IzTJEsZ2lyLXpBF7mkF1g==",
           "dev": true
         }
       }

--- a/packages/node/examples/bootstrappedApp/package.json
+++ b/packages/node/examples/bootstrappedApp/package.json
@@ -21,8 +21,5 @@
     "express": "^4.17.3",
     "yargs": "^16.1.1",
     "@inrupt/solid-client-authn-node": "^1.16.0"
-  },
-  "devDependencies": {
-    "typescript": "^4.1.3"
   }
 }

--- a/packages/node/examples/multiSession/package.json
+++ b/packages/node/examples/multiSession/package.json
@@ -24,7 +24,6 @@
   },
   "devDependencies": {
     "@types/cookie-session": "^2.0.42",
-    "@types/express": "^4.17.11",
-    "typescript": "^4.9.4"
+    "@types/express": "^4.17.11"
   }
 }


### PR DESCRIPTION
We have a typescript version pinned at the root. Having it in the
dev dependencies of other packages is just creating issues with
versioning conflicts.

Hopefully this will also stop https://github.com/inrupt/solid-client-authn-js/pull/3024 complaining.
