### PR TITLE
Feat/prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The following have been deprecated, and will be removed in future major releases
 ## Unreleased
 
 The following changes have been implemented but not released yet:
+ - Added `prompt` as a login option.
 
 ## [1.17.1](https://github.com/inrupt/solid-client-authn-js/releases/tag/v1.17.1) - 2023-07-15
 

--- a/packages/core/src/ILoginInputOptions.ts
+++ b/packages/core/src/ILoginInputOptions.ts
@@ -55,4 +55,9 @@ export default interface ILoginInputOptions {
    * secret to authenticate.
    */
   refreshToken?: string;
+  /**
+   * OIDC prompt. Options include "none", "login", "consent", "select_account", and "create". Not all Solid Identity
+   * Providers support OIDC prompt.
+   */
+  prompt?: string;
 }

--- a/packages/node/src/login/oidc/OidcLoginHandler.ts
+++ b/packages/node/src/login/oidc/OidcLoginHandler.ts
@@ -119,6 +119,7 @@ export default class OidcLoginHandler implements ILoginHandler {
         )),
       handleRedirect: options.handleRedirect,
       eventEmitter: options.eventEmitter,
+      prompt: options.prompt
     };
     // Call proper OIDC Handler
     return this.oidcHandler.handle(oidcOptions);


### PR DESCRIPTION

<!-- When adding a new feature: -->

# New feature description

Added the support to pass a `prompt` to the underlying oidc library. This was once a feature, but I think it might have been accidentally removed.

# Checklist

- [ ] All acceptance criteria are met.
- [ ] Relevant documentation, if any, has been written/updated. (No. I don't have access to update Inrupt docs)
- [X] The changelog has been updated, if applicable.
- [X] New functions/types have been exported in `index.ts`, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
