### PR TITLE
Fix "Mismatching redirect URL"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,17 @@ The following have been deprecated, and will be removed in future major releases
 
 The following changes have been implemented but not released yet:
 
+### Bugfixes
+
+#### browser
+
+- [Mismatching redirect URI](https://github.com/inrupt/solid-client-authn-js/issues/2891) on refresh: this bug was caused by an invalid redirect URL stored with session data.
+  Saving an invalid redirect URL is now prohibited, and in addition the storage of users impacted by this bug will be cleared so that they don't have to do anything manually
+  to clear their local storage. Users affected by this bug will be asked to log back in, as if they logged out.
+
 ## [1.17.1](https://github.com/inrupt/solid-client-authn-js/releases/tag/v1.17.1) - 2023-07-15
 
-#### Bugfixes
+### Bugfixes
 
 - The `fetch` function is now bound to the window object in all uses within `authn-browser`
 

--- a/packages/browser/src/ClientAuthentication.spec.ts
+++ b/packages/browser/src/ClientAuthentication.spec.ts
@@ -274,6 +274,34 @@ describe("ClientAuthentication", () => {
       ).rejects.toThrow("hash fragment");
     });
 
+    it("throws if the redirect IRI contains a reserved query parameter, with a helpful message", async () => {
+      const clientAuthn = getClientAuthentication();
+      await expect(() =>
+        clientAuthn.login(
+          {
+            sessionId: "someUser",
+            tokenType: "DPoP",
+            clientId: "coolApp",
+            redirectUrl: "https://example.org/redirect?state=1234",
+            oidcIssuer: "https://idp.com",
+          },
+          mockEmitter,
+        ),
+      ).rejects.toThrow("query parameter");
+      await expect(() =>
+        clientAuthn.login(
+          {
+            sessionId: "someUser",
+            tokenType: "DPoP",
+            clientId: "coolApp",
+            redirectUrl: "https://example.org/redirect?code=1234",
+            oidcIssuer: "https://idp.com",
+          },
+          mockEmitter,
+        ),
+      ).rejects.toThrow("query parameter");
+    });
+
     it("does not normalize the redirect URL if provided by the user", async () => {
       const clientAuthn = getClientAuthentication();
       await clientAuthn.login(

--- a/packages/browser/src/ClientAuthentication.ts
+++ b/packages/browser/src/ClientAuthentication.ts
@@ -65,7 +65,7 @@ export default class ClientAuthentication extends ClientAuthenticationBase {
       options.redirectUrl ?? removeOidcQueryParam(window.location.href);
     if (!isValidRedirectUrl(redirectUrl)) {
       throw new Error(
-        `${redirectUrl} is not a valid redirect URL, it is either a malformed IRI or it includes a hash fragment.`,
+        `${redirectUrl} is not a valid redirect URL, it is either a malformed IRI, includes a hash fragment, or reserved query parameters ('code' or 'state').`,
       );
     }
     await this.loginHandler.handle({

--- a/packages/browser/src/sessionInfo/SessionInfoManager.spec.ts
+++ b/packages/browser/src/sessionInfo/SessionInfoManager.spec.ts
@@ -161,6 +161,28 @@ describe("SessionInfoManager", () => {
       });
     });
 
+    it("returns undefined and clears storage if the redirect URL is invalid", async () => {
+      const sessionId = "commanderCool";
+      const storageMock = new StorageUtility(
+        mockStorage({}),
+        mockStorage({
+          [`solidClientAuthenticationUser:${sessionId}`]: {
+            // The state query parameter is reserved in OpenID.
+            redirectUrl: "https://client.example.org/callback?state=1234",
+          },
+        }),
+      );
+      const spiedClear = jest.spyOn(storageMock, "deleteAllUserData");
+      const sessionManager = getSessionInfoManager({
+        storageUtility: storageMock,
+      });
+
+      const session = await sessionManager.get(sessionId);
+      expect(session).toBeUndefined();
+      expect(spiedClear).toHaveBeenCalledWith(sessionId, { secure: false });
+      expect(spiedClear).toHaveBeenCalledWith(sessionId, { secure: true });
+    });
+
     it("returns undefined if the specified storage does not contain the user", async () => {
       const sessionManager = getSessionInfoManager({
         storageUtility: mockStorageUtility({}, true),

--- a/packages/core/src/login/oidc/validateRedirectIri.ts
+++ b/packages/core/src/login/oidc/validateRedirectIri.ts
@@ -23,9 +23,13 @@ export function isValidRedirectUrl(redirectUrl: string): boolean {
   // If the redirect URL is not a valid URL, an error will be thrown.
   try {
     const urlObject = new URL(redirectUrl);
+    const noReservedQuery =
+      !urlObject.searchParams.has("code") &&
+      !urlObject.searchParams.has("state");
     // As per https://tools.ietf.org/html/rfc6749#section-3.1.2, the redirect URL
     // must not include a hash fragment.
-    return urlObject.hash === "";
+    const noHash = urlObject.hash === "";
+    return noReservedQuery && noHash;
   } catch (e) {
     return false;
   }

--- a/packages/node/src/ClientAuthentication.spec.ts
+++ b/packages/node/src/ClientAuthentication.spec.ts
@@ -122,6 +122,34 @@ describe("ClientAuthentication", () => {
       ).rejects.toThrow("hash fragment");
     });
 
+    it("throws if the redirect IRI contains a reserved query parameter, with a helpful message", async () => {
+      const clientAuthn = getClientAuthentication();
+      await expect(() =>
+        clientAuthn.login(
+          "mySession",
+          {
+            tokenType: "DPoP",
+            clientId: "coolApp",
+            redirectUrl: "https://example.org/redirect?state=1234",
+            oidcIssuer: "https://idp.com",
+          },
+          mockEmitter,
+        ),
+      ).rejects.toThrow("query parameter");
+      await expect(() =>
+        clientAuthn.login(
+          "mySession",
+          {
+            tokenType: "DPoP",
+            clientId: "coolApp",
+            redirectUrl: "https://example.org/redirect?code=1234",
+            oidcIssuer: "https://idp.com",
+          },
+          mockEmitter,
+        ),
+      ).rejects.toThrow("query parameter");
+    });
+
     it("does not normalize the redirect URL if provided by the user", async () => {
       const clientAuthn = getClientAuthentication();
       await clientAuthn.login(

--- a/packages/node/src/ClientAuthentication.ts
+++ b/packages/node/src/ClientAuthentication.ts
@@ -52,7 +52,7 @@ export default class ClientAuthentication extends ClientAuthenticationBase {
       !isValidRedirectUrl(options.redirectUrl)
     ) {
       throw new Error(
-        `${options.redirectUrl} is not a valid redirect URL, it is either a malformed IRI or it includes a hash fragment.`,
+        `${options.redirectUrl} is not a valid redirect URL, it is either a malformed IRI, includes a hash fragment, or reserved query parameters ('code' or 'state').`,
       );
     }
     const loginReturn = await this.loginHandler.handle({


### PR DESCRIPTION
This PR fixes bug #2891.

This bug was caused by an invalid redirect URL stored with session data. Saving an invalid redirect URL is now prohibited, and in addition the storage of users impacted by this bug will be cleared so that they don't have to do anything manually  to clear their local storage. Users affected by this bug will be asked to log back in, as if they logged out.

- [X] I've added a unit test to test for potential regressions of this bug.
- [X] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).