### PR TITLE
Wait for URL update on redirect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,6 @@ The following changes have been implemented but not released yet:
 - [Mismatching redirect URI](https://github.com/inrupt/solid-client-authn-js/issues/2891) on refresh: the root cause of the bug was a race
   condition because of the asynchronous nature of updating the browser URL. The appropriate event is now awaited for, which should prevent
   the issue from manifesting.
- 
 
 ## [1.17.2](https://github.com/inrupt/solid-client-authn-js/releases/tag/v1.17.2) - 2023-09-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,15 @@ The following have been deprecated, and will be removed in future major releases
 
 The following changes have been implemented but not released yet:
 
+### Bugfixes
+
+#### browser
+
+- [Mismatching redirect URI](https://github.com/inrupt/solid-client-authn-js/issues/2891) on refresh: the root cause of the bug was a race
+  condition because of the asynchronous nature of updating the browser URL. The appropriate event is now awaited for, which should prevent
+  the issue from manifesting.
+ 
+
 ## [1.17.2](https://github.com/inrupt/solid-client-authn-js/releases/tag/v1.17.2) - 2023-09-15
 
 ### Bugfixes

--- a/packages/browser/src/ClientAuthentication.spec.ts
+++ b/packages/browser/src/ClientAuthentication.spec.ts
@@ -336,11 +336,11 @@ describe("ClientAuthentication", () => {
     // TODO: add tests for events & errors
 
     it("reverts back to un-authenticated fetch on logout", async () => {
-      window.history.replaceState = jest.fn();
-      window.addEventListener = jest
-        .fn()
-        .mockImplementation((_event: unknown, callback: unknown) => {
-          (callback as () => void)();
+      window.history.replaceState = jest
+        .fn<typeof window.history.replaceState>()
+        .mockImplementationOnce((_data, _unused, url) => {
+          // Pretend the current location is updated
+          window.location.href = url as string;
         });
       const clientAuthn = getClientAuthentication();
 
@@ -406,17 +406,17 @@ describe("ClientAuthentication", () => {
     mockEmitter.emit = jest.fn<typeof mockEmitter.emit>();
 
     it("calls handle redirect", async () => {
-      window.history.replaceState = jest.fn();
-      window.addEventListener = jest
-        .fn()
-        .mockImplementation((_event: unknown, callback: unknown) => {
-          (callback as () => void)();
+      window.history.replaceState = jest
+        .fn<typeof window.history.replaceState>()
+        .mockImplementationOnce((_data, _unused, url) => {
+          // Pretend the current location is updated
+          window.location.href = url as string;
         });
       const expectedResult = SessionCreatorCreateResponse;
       const clientAuthn = getClientAuthentication();
       const unauthFetch = clientAuthn.fetch;
       const url =
-        "https://coolapp.com/redirect?state=userId&id_token=idToken&access_token=accessToken";
+        "https://example.org/redirect?state=userId&id_token=idToken&access_token=accessToken";
       const redirectInfo = await clientAuthn.handleIncomingRedirect(
         url,
         mockEmitter,
@@ -444,11 +444,11 @@ describe("ClientAuthentication", () => {
     });
 
     it("clears the current IRI from OAuth query parameters in the auth code flow", async () => {
-      window.history.replaceState = jest.fn();
-      window.addEventListener = jest
-        .fn()
-        .mockImplementation((_event: unknown, callback: unknown) => {
-          (callback as () => void)();
+      window.history.replaceState = jest
+        .fn<typeof window.history.replaceState>()
+        .mockImplementationOnce((_data, _unused, url) => {
+          // Pretend the current location is updated
+          window.location.href = url as string;
         });
       const clientAuthn = getClientAuthentication();
       const url =
@@ -464,11 +464,11 @@ describe("ClientAuthentication", () => {
     });
 
     it("clears the current IRI from OAuth query parameters even if auth flow fails", async () => {
-      window.history.replaceState = jest.fn();
-      window.addEventListener = jest
-        .fn()
-        .mockImplementation((_event: unknown, callback: unknown) => {
-          (callback as () => void)();
+      window.history.replaceState = jest
+        .fn<typeof window.history.replaceState>()
+        .mockImplementationOnce((_data, _unused, url) => {
+          // Pretend the current location is updated
+          window.location.href = url as string;
         });
 
       mockHandleIncomingRedirect.mockImplementationOnce(() =>
@@ -494,11 +494,11 @@ describe("ClientAuthentication", () => {
     });
 
     it("clears the current IRI from OAuth query parameters in the implicit flow", async () => {
-      window.history.replaceState = jest.fn();
-      window.addEventListener = jest
-        .fn()
-        .mockImplementation((_event: unknown, callback: unknown) => {
-          (callback as () => void)();
+      window.history.replaceState = jest
+        .fn<typeof window.history.replaceState>()
+        .mockImplementationOnce((_data, _unused, url) => {
+          // Pretend the current location is updated
+          window.location.href = url as string;
         });
       const clientAuthn = getClientAuthentication();
       const url =
@@ -513,11 +513,11 @@ describe("ClientAuthentication", () => {
     });
 
     it("preserves non-OAuth query strings", async () => {
-      window.history.replaceState = jest.fn();
-      window.addEventListener = jest
-        .fn()
-        .mockImplementation((_event: unknown, callback: unknown) => {
-          (callback as () => void)();
+      window.history.replaceState = jest
+        .fn<typeof window.history.replaceState>()
+        .mockImplementationOnce((_data, _unused, url) => {
+          // Pretend the current location is updated
+          window.location.href = url as string;
         });
       const clientAuthn = getClientAuthentication();
       const url =

--- a/packages/browser/src/ClientAuthentication.spec.ts
+++ b/packages/browser/src/ClientAuthentication.spec.ts
@@ -436,8 +436,12 @@ describe("ClientAuthentication", () => {
     });
 
     it("clears the current IRI from OAuth query parameters in the auth code flow", async () => {
-      // eslint-disable-next-line no-restricted-globals
-      history.replaceState = jest.fn();
+      window.history.replaceState = jest.fn();
+      window.addEventListener = jest
+        .fn()
+        .mockImplementation((_event: unknown, callback: unknown) => {
+          (callback as () => void)();
+        });
       const clientAuthn = getClientAuthentication();
       const url =
         "https://coolapp.com/redirect?state=someState&code=someAuthCode&iss=someIssuer";

--- a/packages/browser/src/ClientAuthentication.spec.ts
+++ b/packages/browser/src/ClientAuthentication.spec.ts
@@ -336,8 +336,12 @@ describe("ClientAuthentication", () => {
     // TODO: add tests for events & errors
 
     it("reverts back to un-authenticated fetch on logout", async () => {
-      // eslint-disable-next-line no-restricted-globals
-      history.replaceState = jest.fn();
+      window.history.replaceState = jest.fn();
+      window.addEventListener = jest
+        .fn()
+        .mockImplementation((_event: unknown, callback: unknown) => {
+          (callback as () => void)();
+        });
       const clientAuthn = getClientAuthentication();
 
       const unauthFetch = clientAuthn.fetch;
@@ -402,8 +406,12 @@ describe("ClientAuthentication", () => {
     mockEmitter.emit = jest.fn<typeof mockEmitter.emit>();
 
     it("calls handle redirect", async () => {
-      // eslint-disable-next-line no-restricted-globals
-      history.replaceState = jest.fn();
+      window.history.replaceState = jest.fn();
+      window.addEventListener = jest
+        .fn()
+        .mockImplementation((_event: unknown, callback: unknown) => {
+          (callback as () => void)();
+        });
       const expectedResult = SessionCreatorCreateResponse;
       const clientAuthn = getClientAuthentication();
       const unauthFetch = clientAuthn.fetch;
@@ -456,8 +464,12 @@ describe("ClientAuthentication", () => {
     });
 
     it("clears the current IRI from OAuth query parameters even if auth flow fails", async () => {
-      // eslint-disable-next-line no-restricted-globals
-      history.replaceState = jest.fn();
+      window.history.replaceState = jest.fn();
+      window.addEventListener = jest
+        .fn()
+        .mockImplementation((_event: unknown, callback: unknown) => {
+          (callback as () => void)();
+        });
 
       mockHandleIncomingRedirect.mockImplementationOnce(() =>
         Promise.reject(new Error("Something went wrong")),
@@ -468,8 +480,7 @@ describe("ClientAuthentication", () => {
       const url =
         "https://coolapp.com/redirect?state=someState&code=someAuthCode";
       await clientAuthn.handleIncomingRedirect(url, mockEmitter);
-      // eslint-disable-next-line no-restricted-globals
-      expect(history.replaceState).toHaveBeenCalledWith(
+      expect(window.history.replaceState).toHaveBeenCalledWith(
         null,
         "",
         "https://coolapp.com/redirect",
@@ -483,14 +494,17 @@ describe("ClientAuthentication", () => {
     });
 
     it("clears the current IRI from OAuth query parameters in the implicit flow", async () => {
-      // eslint-disable-next-line no-restricted-globals
-      history.replaceState = jest.fn();
+      window.history.replaceState = jest.fn();
+      window.addEventListener = jest
+        .fn()
+        .mockImplementation((_event: unknown, callback: unknown) => {
+          (callback as () => void)();
+        });
       const clientAuthn = getClientAuthentication();
       const url =
         "https://coolapp.com/redirect?state=someState&id_token=idToken&access_token=accessToken";
       await clientAuthn.handleIncomingRedirect(url, mockEmitter);
-      // eslint-disable-next-line no-restricted-globals
-      expect(history.replaceState).toHaveBeenCalledWith(
+      expect(window.history.replaceState).toHaveBeenCalledWith(
         null,
         "",
         "https://coolapp.com/redirect",
@@ -499,14 +513,17 @@ describe("ClientAuthentication", () => {
     });
 
     it("preserves non-OAuth query strings", async () => {
-      // eslint-disable-next-line no-restricted-globals
-      history.replaceState = jest.fn();
+      window.history.replaceState = jest.fn();
+      window.addEventListener = jest
+        .fn()
+        .mockImplementation((_event: unknown, callback: unknown) => {
+          (callback as () => void)();
+        });
       const clientAuthn = getClientAuthentication();
       const url =
         "https://coolapp.com/redirect?state=someState&code=someAuthCode&someQuery=someValue";
       await clientAuthn.handleIncomingRedirect(url, mockEmitter);
-      // eslint-disable-next-line no-restricted-globals
-      expect(history.replaceState).toHaveBeenCalledWith(
+      expect(window.history.replaceState).toHaveBeenCalledWith(
         null,
         "",
         "https://coolapp.com/redirect?someQuery=someValue",

--- a/packages/browser/src/Session.spec.ts
+++ b/packages/browser/src/Session.spec.ts
@@ -246,10 +246,9 @@ describe("Session", () => {
     it("uses current window location as default redirect URL", async () => {
       mockLocation("https://some.url");
       const clientAuthentication = mockClientAuthentication();
-      const incomingRedirectHandler = jest.spyOn(
-        clientAuthentication,
-        "handleIncomingRedirect",
-      );
+      const incomingRedirectHandler = jest
+        .spyOn(clientAuthentication, "handleIncomingRedirect")
+        .mockResolvedValue(undefined);
 
       const mySession = new Session({ clientAuthentication });
       await mySession.handleIncomingRedirect();
@@ -259,13 +258,12 @@ describe("Session", () => {
       );
     });
 
-    it("wraps up ClientAuthentication handleIncomingRedirect", async () => {
+    it("wraps ClientAuthentication handleIncomingRedirect", async () => {
       mockLocation("https://some.url");
       const clientAuthentication = mockClientAuthentication();
-      const incomingRedirectHandler = jest.spyOn(
-        clientAuthentication,
-        "handleIncomingRedirect",
-      );
+      const incomingRedirectHandler = jest
+        .spyOn(clientAuthentication, "handleIncomingRedirect")
+        .mockResolvedValue(undefined);
       const mySession = new Session({ clientAuthentication });
       await mySession.handleIncomingRedirect("https://some.url");
       expect(incomingRedirectHandler).toHaveBeenCalled();
@@ -401,10 +399,9 @@ describe("Session", () => {
 
     it("preserves a binding to its Session instance", async () => {
       const clientAuthentication = mockClientAuthentication();
-      const incomingRedirectHandler = jest.spyOn(
-        clientAuthentication,
-        "handleIncomingRedirect",
-      );
+      const incomingRedirectHandler = jest
+        .spyOn(clientAuthentication, "handleIncomingRedirect")
+        .mockResolvedValue(undefined);
       const mySession = new Session({ clientAuthentication });
       const objectWithHandleIncomingRedirect = {
         handleIncomingRedirect: mySession.handleIncomingRedirect,

--- a/packages/browser/src/Session.ts
+++ b/packages/browser/src/Session.ts
@@ -338,12 +338,10 @@ export class Session extends EventEmitter implements IHasSessionEventListener {
     const url = options.url ?? window.location.href;
 
     this.tokenRequestInProgress = true;
-    window.console.log("Awaiting incoming redirect handling");
     const sessionInfo = await this.clientAuthentication.handleIncomingRedirect(
       url,
       this.events,
     );
-    window.console.log("incoming redirect handled");
     if (isLoggedIn(sessionInfo)) {
       this.setSessionInfo(sessionInfo);
       const currentUrl = window.localStorage.getItem(KEY_CURRENT_URL);

--- a/packages/browser/src/Session.ts
+++ b/packages/browser/src/Session.ts
@@ -338,10 +338,12 @@ export class Session extends EventEmitter implements IHasSessionEventListener {
     const url = options.url ?? window.location.href;
 
     this.tokenRequestInProgress = true;
+    window.console.log("Awaiting incoming redirect handling");
     const sessionInfo = await this.clientAuthentication.handleIncomingRedirect(
       url,
       this.events,
     );
+    window.console.log("incoming redirect handled");
     if (isLoggedIn(sessionInfo)) {
       this.setSessionInfo(sessionInfo);
       const currentUrl = window.localStorage.getItem(KEY_CURRENT_URL);


### PR DESCRIPTION
Updating the URL through the window object is an asynchronous operation, but it has a synchronous signature. This enforces that the code waits on the appropriate event before proceeding, preventing a race condition resulting in the behavior observed in
https://github.com/inrupt/solid-client-authn-js/issues/2891.

This PR fixes bug #2891.

- [X] I've added a unit test to test for potential regressions of this bug.
- [X] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).