### PR TITLE
Preserve JSDoc comments in emitted files

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -11,7 +11,9 @@
     "strict": true,
     "declaration": true,
     "noImplicitAny": true,
-    "removeComments": true,
+    // Preserve JSDoc comments in .d.ts files so that they are available
+    // to consumers at development time. 
+    "removeComments": false,
     "noLib": false,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
@@ -23,7 +25,7 @@
     "resolveJsonModule": true,
     "outDir": "./dist",
     // This is required to transform native ESM from our dependencies using ts-jest.
-    "allowJs": true
+    "allowJs": true,
   },
   "exclude": ["node_modules", "dist"],
 

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -11,9 +11,6 @@
     "strict": true,
     "declaration": true,
     "noImplicitAny": true,
-    "noLib": false,
-    "emitDecoratorMetadata": true,
-    "experimentalDecorators": true,
     "esModuleInterop": true,
     "target": "es2018",
     "sourceMap": true,
@@ -22,7 +19,7 @@
     "resolveJsonModule": true,
     "outDir": "./dist",
     // This is required to transform native ESM from our dependencies using ts-jest.
-    "allowJs": true,
+    "allowJs": true
   },
   "exclude": ["node_modules", "dist"],
 

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -11,9 +11,6 @@
     "strict": true,
     "declaration": true,
     "noImplicitAny": true,
-    // Preserve JSDoc comments in .d.ts files so that they are available
-    // to consumers at development time. 
-    "removeComments": false,
     "noLib": false,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,


### PR DESCRIPTION
This makes JSDoc comments available to developers using our libraries at development time for IDEs supporting it.