### PR TITLE
Add Dev-2-1 to end-to-end environments

### DIFF
--- a/.github/workflows/e2e-browser.yml
+++ b/.github/workflows/e2e-browser.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         # NSS does not support static client registration, which we rely on for testing.
-        environment-name: ["ESS PodSpaces", "ESS Dev-2-1"
+        environment-name: ["ESS PodSpaces", "ESS Dev-2-1"]
         experimental: [false]
         include:
           - environment-name: "ESS Dev-2-2"

--- a/.github/workflows/e2e-browser.yml
+++ b/.github/workflows/e2e-browser.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         # NSS does not support static client registration, which we rely on for testing.
-        environment-name: ["ESS PodSpaces"]
+        environment-name: ["ESS PodSpaces", "ESS Dev-2-1"
         experimental: [false]
         include:
           - environment-name: "ESS Dev-2-2"

--- a/.github/workflows/e2e-node.yml
+++ b/.github/workflows/e2e-node.yml
@@ -18,7 +18,7 @@ jobs:
         os: [ubuntu-latest]
         node-version: ["20.x", "18.x", "16.x"]
         # NSS does not support static client registration, which we rely on for testing.
-        environment-name: ["ESS PodSpaces"]
+        environment-name: ["ESS PodSpaces", "ESS Dev-2-1"]
         experimental: [false]
         include:
           - environment-name: "ESS Dev-2-2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,9 +15,9 @@
       "devDependencies": {
         "@inrupt/base-rollup-config": "^2.4.1",
         "@inrupt/eslint-config-lib": "^2.5.0",
-        "@inrupt/internal-playwright-helpers": "^2.4.1",
+        "@inrupt/internal-playwright-helpers": "^2.6.0",
         "@inrupt/internal-test-env": "^2.6.0",
-        "@inrupt/jest-jsdom-polyfills": "^2.5.0",
+        "@inrupt/jest-jsdom-polyfills": "^2.6.0",
         "@inrupt/solid-client": "^1.30.2",
         "@playwright/test": "^1.40.0",
         "@rollup/plugin-commonjs": "^25.0.7",
@@ -2415,36 +2415,22 @@
       }
     },
     "node_modules/@inrupt/internal-playwright-helpers": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@inrupt/internal-playwright-helpers/-/internal-playwright-helpers-2.4.1.tgz",
-      "integrity": "sha512-SzGcsRRAKqymv5Eha1A4fkfCHu9L36BoXEP28xdYrB1XOojW0+lpiPg4aoAazTRpwkTsmCFDmyMwZyDpXYeNJA==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/internal-playwright-helpers/-/internal-playwright-helpers-2.6.0.tgz",
+      "integrity": "sha512-rVSwTVWIpAHua3xZpxWAodKAovUeNWgo0whZ1fawmr7QztYMgsqG7c8S7kZSdQhTFCw/gADuEDEIuYz9DHJ2CA==",
       "dev": true,
       "dependencies": {
-        "@inrupt/internal-playwright-testids": "2.4.1",
-        "@inrupt/internal-test-env": "2.4.1"
+        "@inrupt/internal-playwright-testids": "2.6.0",
+        "@inrupt/internal-test-env": "2.6.0"
       },
       "peerDependencies": {
         "@playwright/test": "^1.37.0"
       }
     },
-    "node_modules/@inrupt/internal-playwright-helpers/node_modules/@inrupt/internal-test-env": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@inrupt/internal-test-env/-/internal-test-env-2.4.1.tgz",
-      "integrity": "sha512-fOaDUjNybeAYsVN8sxw8VqXrtGBpKrLuXTnhvlrm+xYDBHaJwYCMbMJvctiBW68kSCgCCq1OUt+D/da76UO6DQ==",
-      "dev": true,
-      "dependencies": {
-        "@inrupt/solid-client": "^1.30.0",
-        "@inrupt/solid-client-authn-browser": "^1.17.2",
-        "@inrupt/solid-client-authn-node": "^1.17.2",
-        "@jeswr/css-auth-utils": "^1.4.0",
-        "deepmerge-json": "^1.5.0",
-        "dotenv": "^16.3.1"
-      }
-    },
     "node_modules/@inrupt/internal-playwright-testids": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@inrupt/internal-playwright-testids/-/internal-playwright-testids-2.4.1.tgz",
-      "integrity": "sha512-j5YnuqbzLbYTH2TNMBG09uf8uigf0Q0XC6kAh74lAE9mKUj2s0cYe6pkULu7GX+beOo9HEZaD+h0FXqeuzqanw=="
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/internal-playwright-testids/-/internal-playwright-testids-2.6.0.tgz",
+      "integrity": "sha512-myDnVYvABMGEKTHtelISIxxWNlPW4oM7dEncqPr9E0ZMx6xiBFQlsbt7u3nHlW/QVNt+9re8GhylWoWrCCWtnA=="
     },
     "node_modules/@inrupt/internal-test-env": {
       "version": "2.6.0",
@@ -2461,15 +2447,15 @@
       }
     },
     "node_modules/@inrupt/jest-jsdom-polyfills": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/jest-jsdom-polyfills/-/jest-jsdom-polyfills-2.5.0.tgz",
-      "integrity": "sha512-1n5Ob3nsIOMTuQzkfC/Y3N/vgDwfh4LwaLTAiSr99GaUyJtunSK5ce0atc5k83LyAom6y4ZjrExw6IEXE9ebEg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/jest-jsdom-polyfills/-/jest-jsdom-polyfills-2.6.0.tgz",
+      "integrity": "sha512-EVZ4X6incoQjoE1wM42fk2qoDgC76d8u0+ffzD8HpY5ax/Fo2zMlFe/gC1PH0t0yddZiMARCKZrMs50tLPK71w==",
       "dev": true,
       "dependencies": {
         "@peculiar/webcrypto": "^1.4.0",
         "@web-std/blob": "^3.0.5",
         "@web-std/file": "^3.0.3",
-        "undici": "^5.26.3"
+        "undici": "^5.27.2"
       }
     },
     "node_modules/@inrupt/oidc-client": {
@@ -22611,9 +22597,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.26.4",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.26.4.tgz",
-      "integrity": "sha512-OG+QOf0fTLtazL9P9X7yqWxQ+Z0395Wk6DSkyTxtaq3wQEjIroVe7Y4asCX/vcCxYpNGMnwz8F0qbRYUoaQVMw==",
+      "version": "5.28.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.2.tgz",
+      "integrity": "sha512-wh1pHJHnUeQV5Xa8/kyQhO7WFa8M34l026L5P/+2TYiakvGy5Rdc8jWZVyG7ieht/0WgJLEd3kcU5gKx+6GC8w==",
       "dependencies": {
         "@fastify/busboy": "^2.0.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@inrupt/base-rollup-config": "^2.4.1",
         "@inrupt/eslint-config-lib": "^2.5.0",
         "@inrupt/internal-playwright-helpers": "^2.4.1",
-        "@inrupt/internal-test-env": "^2.4.0",
+        "@inrupt/internal-test-env": "^2.6.0",
         "@inrupt/jest-jsdom-polyfills": "^2.5.0",
         "@inrupt/solid-client": "^1.30.2",
         "@playwright/test": "^1.40.0",
@@ -2427,12 +2427,7 @@
         "@playwright/test": "^1.37.0"
       }
     },
-    "node_modules/@inrupt/internal-playwright-testids": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@inrupt/internal-playwright-testids/-/internal-playwright-testids-2.4.1.tgz",
-      "integrity": "sha512-j5YnuqbzLbYTH2TNMBG09uf8uigf0Q0XC6kAh74lAE9mKUj2s0cYe6pkULu7GX+beOo9HEZaD+h0FXqeuzqanw=="
-    },
-    "node_modules/@inrupt/internal-test-env": {
+    "node_modules/@inrupt/internal-playwright-helpers/node_modules/@inrupt/internal-test-env": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@inrupt/internal-test-env/-/internal-test-env-2.4.1.tgz",
       "integrity": "sha512-fOaDUjNybeAYsVN8sxw8VqXrtGBpKrLuXTnhvlrm+xYDBHaJwYCMbMJvctiBW68kSCgCCq1OUt+D/da76UO6DQ==",
@@ -2441,6 +2436,25 @@
         "@inrupt/solid-client": "^1.30.0",
         "@inrupt/solid-client-authn-browser": "^1.17.2",
         "@inrupt/solid-client-authn-node": "^1.17.2",
+        "@jeswr/css-auth-utils": "^1.4.0",
+        "deepmerge-json": "^1.5.0",
+        "dotenv": "^16.3.1"
+      }
+    },
+    "node_modules/@inrupt/internal-playwright-testids": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@inrupt/internal-playwright-testids/-/internal-playwright-testids-2.4.1.tgz",
+      "integrity": "sha512-j5YnuqbzLbYTH2TNMBG09uf8uigf0Q0XC6kAh74lAE9mKUj2s0cYe6pkULu7GX+beOo9HEZaD+h0FXqeuzqanw=="
+    },
+    "node_modules/@inrupt/internal-test-env": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/internal-test-env/-/internal-test-env-2.6.0.tgz",
+      "integrity": "sha512-uWW7P+HDd9k/fM23lGdU+pf9SlYffoRYlJSKtAMEszRyBVsKlnFj8zZkgjAZrzbcZn1jY+Yj9PlTXnB5GtAu1g==",
+      "dev": true,
+      "dependencies": {
+        "@inrupt/solid-client": "^1.30.2",
+        "@inrupt/solid-client-authn-browser": "^1.17.5",
+        "@inrupt/solid-client-authn-node": "^1.17.5",
         "@jeswr/css-auth-utils": "^1.4.0",
         "deepmerge-json": "^1.5.0",
         "dotenv": "^16.3.1"

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@inrupt/base-rollup-config": "^2.4.1",
     "@inrupt/eslint-config-lib": "^2.5.0",
     "@inrupt/internal-playwright-helpers": "^2.4.1",
-    "@inrupt/internal-test-env": "^2.4.0",
+    "@inrupt/internal-test-env": "^2.6.0",
     "@inrupt/jest-jsdom-polyfills": "^2.5.0",
     "@inrupt/solid-client": "^1.30.2",
     "@playwright/test": "^1.40.0",

--- a/package.json
+++ b/package.json
@@ -44,9 +44,9 @@
   "devDependencies": {
     "@inrupt/base-rollup-config": "^2.4.1",
     "@inrupt/eslint-config-lib": "^2.5.0",
-    "@inrupt/internal-playwright-helpers": "^2.4.1",
+    "@inrupt/internal-playwright-helpers": "^2.6.0",
     "@inrupt/internal-test-env": "^2.6.0",
-    "@inrupt/jest-jsdom-polyfills": "^2.5.0",
+    "@inrupt/jest-jsdom-polyfills": "^2.6.0",
     "@inrupt/solid-client": "^1.30.2",
     "@playwright/test": "^1.40.0",
     "@rollup/plugin-commonjs": "^25.0.7",


### PR DESCRIPTION
This will require a release of the typescript-sdk-tools repository, and a run of the e2e-environments script before it passes.