### PR TITLE
Remove deprecated APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,20 +5,6 @@ within this mono-repo.
 
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## Deprecation notice
-
-The following have been deprecated, and will be removed in future major releases.
-
-### browser and node
-
-- The `Session` class will no longer extend `EventEmitter`. Instead, it will expose
-  an `events` attribute implementing `EventEmitter`. We do not recommand to use
-  either a `Session` instance or its `events` attribute as an arbitrary events emitter,
-  and encourage users to only use the supported events and documented API.
-- `Session` methods `onLogin`, `onLogout`, `onError`, `onSessionRestore`,
-  `onSessionExpiration`, `onNewRefreshToken` are deprecated in favor of `session.events.on`
-  called with the appropriate event name.
-
 ## Unreleased
 
 The following changes have been implemented but not released yet:
@@ -27,6 +13,12 @@ The following changes have been implemented but not released yet:
 
 - Use the global `fetch` function instead of `@inrupt/universal-fetch`. This means this library now only works
   with Node 18 and higher.
+- The `Session` class no longer extends `EventEmitter`. Instead, it exposes an `events` attribute implementing
+  `EventEmitter`. We do not recommand to use `Session` instance's `events` attribute as an arbitrary events emitter,
+  and encourage users to only use the supported events and documented API.
+- `Session` methods `onLogin`, `onLogout`, `onError`, `onSessionRestore`,
+  `onSessionExpiration`, `onNewRefreshToken` have been removed. They are replaced by calls to `session.events.on`,
+  using the appropriate event name.
 - The UMD build of `@inrupt/oidc-client-ext` is no longer available. Since this is a package only intended to be
   consumed by `@inrupt/solid-client-authn-browser`, which doesn't have a UMD build, this change should have no
   impact.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ The following changes have been implemented but not released yet:
 - `Session` methods `onLogin`, `onLogout`, `onError`, `onSessionRestore`,
   `onSessionExpiration`, `onNewRefreshToken` have been removed. They are replaced by calls to `session.events.on`,
   using the appropriate event name.
+- `onNewRefreshToken` is no longer supported as an option to the `Session` constructor. Its usage is replaced by
+  calling `session.events.on` using the `EVENTS.NEW_REFRESH_TOKEN` constant as a first parameter, and a callback
+  handling the token as a second parameter.
 - The UMD build of `@inrupt/oidc-client-ext` is no longer available. Since this is a package only intended to be
   consumed by `@inrupt/solid-client-authn-browser`, which doesn't have a UMD build, this change should have no
   impact.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The following changes have been implemented but not released yet:
 - The UMD build of `@inrupt/oidc-client-ext` is no longer available. Since this is a package only intended to be
   consumed by `@inrupt/solid-client-authn-browser`, which doesn't have a UMD build, this change should have no
   impact.
+- The deprecated `useEssSession` parameter is no longer supported by the `Session` constructor.
 
 ### Build system changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,8 @@ The following changes have been implemented but not released yet:
 - The UMD build of `@inrupt/oidc-client-ext` is no longer available. Since this is a package only intended to be
   consumed by `@inrupt/solid-client-authn-browser`, which doesn't have a UMD build, this change should have no
   impact.
-- The deprecated `useEssSession` parameter is no longer supported by the `Session` constructor.
+- The `useEssSession` parameter is no longer supported by the `Session` constructor.
+- The `getClientAuthenticationWithDependencies` is no longer exported as part of the public API, and is now internal-only.
 
 ### Build system changes
 

--- a/e2e/browser/solid-ui-react/test-app/package.json
+++ b/e2e/browser/solid-ui-react/test-app/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@inrupt/internal-playwright-testids": "^2.4.0",
     "@inrupt/solid-client-authn-browser": "^1.17.5",
-    "@inrupt/solid-ui-react": "^2.9.0",
+    "@inrupt/solid-ui-react": "^2.9.1",
     "next": "^14.0.4",
     "react": "18.2.0",
     "react-dom": "18.2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -95,7 +95,7 @@
       "dependencies": {
         "@inrupt/internal-playwright-testids": "^2.4.0",
         "@inrupt/solid-client-authn-browser": "^1.17.5",
-        "@inrupt/solid-ui-react": "^2.9.0",
+        "@inrupt/solid-ui-react": "^2.9.1",
         "next": "^14.0.4",
         "react": "18.2.0",
         "react-dom": "18.2.0"
@@ -2216,8 +2216,9 @@
       "link": true
     },
     "node_modules/@inrupt/solid-ui-react": {
-      "version": "2.9.0",
-      "license": "MIT",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-ui-react/-/solid-ui-react-2.9.1.tgz",
+      "integrity": "sha512-x1CBDOVJHGh6fBWFlYAt6BXH9NoVWalLZt3NCwLHUqXqiE2xLJfHJ75SoyFBFEup36JZcSgPQC+KGAvX4++14Q==",
       "dependencies": {
         "@inrupt/solid-client": "^1.27.0",
         "@inrupt/solid-client-authn-browser": "^1.15.0",

--- a/packages/browser/src/Session.ts
+++ b/packages/browser/src/Session.ts
@@ -65,7 +65,8 @@ export interface IHandleIncomingRedirectOptions {
    * If your app's access has not expired yet and re-activation completed
    * successfully, a `sessionRestore` event will be fired with the URL the user
    * was at before they were redirected to their Solid Identity Provider.
-   * {@see onSessionRestore}
+   * {@see ISessionEventListener}: a callback can be registered to
+   * `session.events.on(SESSION_RESTORED, callback).
    */
   restorePreviousSession?: boolean;
 

--- a/packages/browser/src/Session.ts
+++ b/packages/browser/src/Session.ts
@@ -135,7 +135,7 @@ function isLoggedIn(
 /**
  * A {@link Session} object represents a user's session on an application. The session holds state, as it stores information enabling acces to private resources after login for instance.
  */
-export class Session extends EventEmitter implements IHasSessionEventListener {
+export class Session implements IHasSessionEventListener {
   /**
    * Information regarding the current session.
    */
@@ -171,18 +171,7 @@ export class Session extends EventEmitter implements IHasSessionEventListener {
     sessionOptions: Partial<ISessionOptions> = {},
     sessionId: string | undefined = undefined,
   ) {
-    super();
-    // Until Session no longer implements EventEmitter, this.events is just a proxy
-    // to this (with some interface filtering). When we make the breaking change,
-    // this.events will be a regular EventEmitter (implementing ISessionEventEmitter):
-    // this.events = new EventEmitter();
-    this.events = new Proxy(
-      this,
-      buildProxyHandler(
-        Session.prototype,
-        "events only implements ISessionEventListener",
-      ),
-    );
+    this.events = new EventEmitter();
     if (sessionOptions.clientAuthentication) {
       this.clientAuthentication = sessionOptions.clientAuthentication;
     } else if (sessionOptions.secureStorage && sessionOptions.insecureStorage) {
@@ -382,68 +371,6 @@ export class Session extends EventEmitter implements IHasSessionEventListener {
     this.tokenRequestInProgress = false;
     return sessionInfo;
   };
-
-  /**
-   * Register a callback function to be called when a user completes login.
-   *
-   * The callback is called when {@link handleIncomingRedirect} completes successfully.
-   *
-   * @param callback The function called when a user completes login.
-   * @deprecated Prefer session.events.on(EVENTS.LOGIN, callback)
-   */
-  onLogin(callback: () => unknown): void {
-    this.events.on(EVENTS.LOGIN, callback);
-  }
-
-  /**
-   * Register a callback function to be called when a user logs out:
-   *
-   * @param callback The function called when a user completes logout.
-   * @deprecated Prefer session.events.on(EVENTS.LOGOUT, callback)
-   */
-  onLogout(callback: () => unknown): void {
-    this.events.on(EVENTS.LOGOUT, callback);
-  }
-
-  /**
-   * Register a callback function to be called when a user logs out:
-   *
-   * @param callback The function called when an error occurs.
-   * @since 1.11.0
-   * @deprecated Prefer session.events.on(EVENTS.ERROR, callback)
-   */
-  onError(
-    callback: (
-      error: string | null,
-      errorDescription?: string | null,
-    ) => unknown,
-  ): void {
-    this.events.on(EVENTS.ERROR, callback);
-  }
-
-  /**
-   * Register a callback function to be called when a session is restored.
-   *
-   * Note: the callback will be called with the saved value of the 'current URL'
-   * at the time the session was restored.
-   *
-   * @param callback The function called when a user's already logged-in session is restored, e.g., after a silent authentication is completed after a page refresh.
-   * @deprecated Prefer session.events.on(EVENTS.SESSION_RESTORED, callback)
-   */
-  onSessionRestore(callback: (currentUrl: string) => unknown): void {
-    this.events.on(EVENTS.SESSION_RESTORED, callback);
-  }
-
-  /**
-   * Register a callback that runs when the session expires and can no longer
-   * make authenticated requests, but following a user logout.
-   * @param callback The function that runs on session expiration.
-   * @since 1.11.0
-   * @deprecated Prefer session.events.on(EVENTS.SESSION_EXPIRED, callback)
-   */
-  onSessionExpiration(callback: () => unknown): void {
-    this.events.on(EVENTS.SESSION_EXPIRED, callback);
-  }
 
   private setSessionInfo(
     sessionInfo: ISessionInfo & { isLoggedIn: true },

--- a/packages/browser/src/Session.ts
+++ b/packages/browser/src/Session.ts
@@ -66,7 +66,7 @@ export interface IHandleIncomingRedirectOptions {
    * successfully, a `sessionRestore` event will be fired with the URL the user
    * was at before they were redirected to their Solid Identity Provider.
    * See {@link ISessionEventListener}: a callback can be registered to
-   * `session.events.on(SESSION_RESTORED, callback)`.
+   * `session.events.on(EVENTS.SESSION_RESTORED, callback)`.
    */
   restorePreviousSession?: boolean;
 

--- a/packages/browser/src/Session.ts
+++ b/packages/browser/src/Session.ts
@@ -65,7 +65,7 @@ export interface IHandleIncomingRedirectOptions {
    * If your app's access has not expired yet and re-activation completed
    * successfully, a `sessionRestore` event will be fired with the URL the user
    * was at before they were redirected to their Solid Identity Provider.
-   * {@see ISessionEventListener}: a callback can be registered to
+   * See {@link ISessionEventListener}: a callback can be registered to
    * `session.events.on(SESSION_RESTORED, callback).
    */
   restorePreviousSession?: boolean;
@@ -291,7 +291,7 @@ export class Session implements IHasSessionEventListener {
    * Completes the login process by processing the information provided by the
    * Solid identity provider through redirect.
    *
-   * @param options See {@see IHandleIncomingRedirectOptions}.
+   * @param options See {@link IHandleIncomingRedirectOptions}.
    */
   handleIncomingRedirect = async (
     inputOptions: string | IHandleIncomingRedirectOptions = {},

--- a/packages/browser/src/Session.ts
+++ b/packages/browser/src/Session.ts
@@ -70,25 +70,6 @@ export interface IHandleIncomingRedirectOptions {
   restorePreviousSession?: boolean;
 
   /**
-   * Inrupt's Enterprise Solid Server can set a cookie to allow the browser to
-   * access private resources on a Pod. In order to mitigate the logout-on-refresh
-   * issue on the short term, the server also implemented a session endpoint
-   * enabling the client app to know whether the cookie is set. When a user
-   * logs in to a server that has that capability enabled, applications that set
-   * this option to `true` will be able to make use of it.
-   *
-   * If your app supports the newest session restore approach, and `restorePreviousSession`
-   * is set to true, this option is automatically set to false, but your app will
-   * not be logged out when reloaded.
-   *
-   * `useEssSession` defaults to false and will be removed in the future; to
-   * preserve sessions across page reloads, use of `restorePreviousSession` is
-   * recommended.
-   *
-   * @deprecated unreleased
-   */
-  useEssSession?: boolean;
-  /**
    * The URL of the page handling the redirect, including the query
    * parameters — these contain the information to process the login.
    * Note: as a convenience, if no URL value is specified here, we default to

--- a/packages/browser/src/Session.ts
+++ b/packages/browser/src/Session.ts
@@ -66,7 +66,7 @@ export interface IHandleIncomingRedirectOptions {
    * successfully, a `sessionRestore` event will be fired with the URL the user
    * was at before they were redirected to their Solid Identity Provider.
    * See {@link ISessionEventListener}: a callback can be registered to
-   * `session.events.on(SESSION_RESTORED, callback).
+   * `session.events.on(SESSION_RESTORED, callback)`.
    */
   restorePreviousSession?: boolean;
 

--- a/packages/browser/src/Session.ts
+++ b/packages/browser/src/Session.ts
@@ -30,7 +30,7 @@ import type {
   ISessionEventListener,
   ILogoutOptions,
 } from "@inrupt/solid-client-authn-core";
-import { EVENTS, buildProxyHandler } from "@inrupt/solid-client-authn-core";
+import { EVENTS } from "@inrupt/solid-client-authn-core";
 import { v4 } from "uuid";
 import EventEmitter from "events";
 import type ClientAuthentication from "./ClientAuthentication";

--- a/packages/browser/src/defaultSession.spec.ts
+++ b/packages/browser/src/defaultSession.spec.ts
@@ -27,9 +27,6 @@ import {
   handleIncomingRedirect,
   login,
   logout,
-  onLogin,
-  onSessionRestore,
-  onLogout,
   events,
 } from "./defaultSession";
 import * as SessionModule from "./Session";
@@ -72,9 +69,6 @@ it("all functions pass on their arguments to the default session", () => {
   const handleIncomingRedirectSpy = jest.fn();
   defaultSession.handleIncomingRedirect =
     handleIncomingRedirectSpy as typeof defaultSession.handleIncomingRedirect;
-  const onLoginSpy = jest.spyOn(defaultSession, "onLogin");
-  const onLogoutSpy = jest.spyOn(defaultSession, "onLogout");
-  const onSessionRestoreSpy = jest.spyOn(defaultSession, "onSessionRestore");
   const eventsOnSpy = jest.spyOn(defaultSession.events, "on");
 
   expect(fetchSpy).not.toHaveBeenCalled();
@@ -102,16 +96,4 @@ it("all functions pass on their arguments to the default session", () => {
   expect(eventsOnSpy).not.toHaveBeenCalled();
   events().on(EVENTS.LOGIN, jest.fn());
   expect(eventsOnSpy).toHaveBeenCalledTimes(1);
-
-  expect(onLoginSpy).not.toHaveBeenCalled();
-  onLogin(jest.fn());
-  expect(onLoginSpy).toHaveBeenCalledTimes(1);
-
-  expect(onSessionRestoreSpy).not.toHaveBeenCalled();
-  onSessionRestore(jest.fn());
-  expect(onSessionRestoreSpy).toHaveBeenCalledTimes(1);
-
-  expect(onLogoutSpy).not.toHaveBeenCalled();
-  onLogout(jest.fn());
-  expect(onLogoutSpy).toHaveBeenCalledTimes(1);
 });

--- a/packages/browser/src/defaultSession.ts
+++ b/packages/browser/src/defaultSession.ts
@@ -94,46 +94,6 @@ export const handleIncomingRedirect: Session["handleIncomingRedirect"] = (
 };
 
 /**
- * Register a callback function to be called when a user completes login.
- *
- * The callback is called when {@link handleIncomingRedirect} completes successfully.
- * @since 1.3.0
- *
- * @param callback The function called when a user completes login.
- * @deprecated Prefer events.on(EVENTS.LOGIN, callback)
-
- */
-export const onLogin: Session["onLogin"] = (...args) => {
-  const session = getDefaultSession();
-  return session.onLogin(...args);
-};
-
-/**
- * Register a callback function to be called when a user logs out:
- *
- * @param callback The function called when a user completes logout.
- * @since 1.3.0
- * @deprecated Prefer events.on(EVENTS.LOGOUT, callback)
- *
- */
-export const onLogout: Session["onLogout"] = (...args) => {
-  const session = getDefaultSession();
-  return session.onLogout(...args);
-};
-
-/**
- * Register a callback function to be called when a session is restored:
- *
- * @param callback The function called when a session is restored.
- * @since 1.3.0
- * @deprecated Prefer events.on(EVENTS.SESSION_RESTORED, callback)
- */
-export const onSessionRestore: Session["onSessionRestore"] = (...args) => {
-  const session = getDefaultSession();
-  return session.onSessionRestore(...args);
-};
-
-/**
  * {@link SessionEventEmitter} instance to subscribe to events by the default session.
  *
  * @since 1.14.0

--- a/packages/browser/src/dependencies.ts
+++ b/packages/browser/src/dependencies.ts
@@ -48,9 +48,8 @@ import { ErrorOidcHandler } from "./login/oidc/incomingRedirectHandler/ErrorOidc
 import TokenRefresher from "./login/oidc/refresh/TokenRefresher";
 
 /**
- *
  * @param dependencies
- * @deprecated This function will be removed from the external API in an upcoming release.
+ * @hidden
  */
 export function getClientAuthenticationWithDependencies(dependencies: {
   secureStorage?: IStorage;

--- a/packages/browser/src/index.spec.ts
+++ b/packages/browser/src/index.spec.ts
@@ -21,9 +21,8 @@
 
 import { it, expect } from "@jest/globals";
 
-import { Session, getClientAuthenticationWithDependencies } from "./index";
+import { Session } from "./index";
 
 it("exports the public API from the entrypoint", () => {
   expect(Session).toBeDefined();
-  expect(getClientAuthenticationWithDependencies).toBeDefined();
 });

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -39,5 +39,6 @@ export {
   IHasSessionEventListener,
   ISessionEventListener,
   IEndSessionOptions,
+  ILogoutOptions,
   EVENTS,
 } from "@inrupt/solid-client-authn-core";

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -21,8 +21,6 @@
 
 export { Session, ISessionOptions } from "./Session";
 
-export { getClientAuthenticationWithDependencies } from "./dependencies";
-
 export * from "./defaultSession";
 
 // Re-export of types defined in the core module and produced/consumed by our API

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -19,7 +19,11 @@
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-export { Session, ISessionOptions } from "./Session";
+export {
+  Session,
+  ISessionOptions,
+  IHandleIncomingRedirectOptions,
+} from "./Session";
 
 export * from "./defaultSession";
 
@@ -32,5 +36,6 @@ export {
   NotImplementedError,
   ConfigurationError,
   InMemoryStorage,
+  IHasSessionEventListener,
   EVENTS,
 } from "@inrupt/solid-client-authn-core";

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -37,5 +37,7 @@ export {
   ConfigurationError,
   InMemoryStorage,
   IHasSessionEventListener,
+  ISessionEventListener,
+  IEndSessionOptions,
   EVENTS,
 } from "@inrupt/solid-client-authn-core";

--- a/packages/core/src/SessionEventListener.ts
+++ b/packages/core/src/SessionEventListener.ts
@@ -474,28 +474,3 @@ export interface ISessionEventListener extends EventEmitter {
    */
   emit(eventName: never, ...args: never): boolean;
 }
-
-/**
- * Temporary internal builder for safe proxying.
- */
-export const buildProxyHandler = (
-  // The class to be excluded needs to be injected, because it is defined in a
-  // dependency.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  toExclude: any,
-  errorMessage: string,
-) => ({
-  // This proxy is only a temporary measure until Session no longer extends
-  // SessionEventEmitter, and the proxying is no longer necessary.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  get(target: any, prop: any, receiver: any) {
-    // Reject any calls to the proxy that isn't specific to the EventEmitter API
-    if (
-      !Object.getOwnPropertyNames(EventEmitter).includes(prop) &&
-      Object.getOwnPropertyNames(toExclude).includes(prop)
-    ) {
-      throw new Error(`${errorMessage}: [${prop}] is not supported`);
-    }
-    return Reflect.get(target, prop, receiver);
-  },
-});

--- a/packages/core/src/SessionEventListener.ts
+++ b/packages/core/src/SessionEventListener.ts
@@ -18,7 +18,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-import { EventEmitter } from "events";
+import type { EventEmitter } from "events";
 import type { EVENTS } from "./constant";
 
 export interface IHasSessionEventListener {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -24,7 +24,6 @@ export * from "./constant";
 export {
   IHasSessionEventListener,
   ISessionEventListener,
-  buildProxyHandler,
 } from "./SessionEventListener";
 
 export { default as ILoginInputOptions } from "./ILoginInputOptions";

--- a/packages/node/src/ClientAuthentication.spec.ts
+++ b/packages/node/src/ClientAuthentication.spec.ts
@@ -243,7 +243,7 @@ describe("ClientAuthentication", () => {
       const session = new Session();
       const url =
         "https://coolapp.com/redirect?state=userId&id_token=idToken&access_token=accessToken";
-      await clientAuthn.handleIncomingRedirect(url, session);
+      await clientAuthn.handleIncomingRedirect(url, session.events);
 
       // Calling the redirect handler should give us an authenticated fetch.
       expect(clientAuthn.fetch).not.toBe(unauthFetch);
@@ -333,14 +333,14 @@ describe("ClientAuthentication", () => {
         "https://coolapp.com/redirect?state=userId&id_token=idToken&access_token=accessToken";
       const redirectInfo = await clientAuthn.handleIncomingRedirect(
         url,
-        session,
+        session.events,
       );
       expect(redirectInfo).toEqual({
         ...SessionCreatorCreateResponse,
       });
       expect(defaultMocks.redirectHandler.handle).toHaveBeenCalledWith(
         url,
-        session,
+        session.events,
       );
 
       // Calling the redirect handler should have updated the fetch.
@@ -355,14 +355,14 @@ describe("ClientAuthentication", () => {
         "https://coolapp.com/redirect?state=userId&id_token=idToken&access_token=accessToken";
       const redirectInfo = await clientAuthn.handleIncomingRedirect(
         url,
-        session,
+        session.events,
       );
       expect(redirectInfo).toEqual({
         ...SessionCreatorCreateResponse,
       });
       expect(defaultMocks.redirectHandler.handle).toHaveBeenCalledWith(
         url,
-        session,
+        session.events,
       );
 
       // Calling the redirect handler should have updated the fetch.

--- a/packages/node/src/Session.spec.ts
+++ b/packages/node/src/Session.spec.ts
@@ -136,20 +136,6 @@ describe("Session", () => {
       expect(mySession.info.webId).toBe("https://some.webid");
     });
 
-    it("accepts legacy token rotation callback", () => {
-      const legacyTokenRotationCallback = jest.fn();
-      const mySession = new Session({
-        onNewRefreshToken: legacyTokenRotationCallback,
-      });
-      (mySession.events as EventEmitter).emit(
-        EVENTS.NEW_REFRESH_TOKEN,
-        "some refresh token",
-      );
-      expect(legacyTokenRotationCallback).toHaveBeenCalledWith(
-        "some refresh token",
-      );
-    });
-
     it("listens on the timeout event", () => {
       const mySession = new Session();
       (mySession.events as EventEmitter).emit(EVENTS.TIMEOUT_SET, 0);

--- a/packages/node/src/Session.spec.ts
+++ b/packages/node/src/Session.spec.ts
@@ -377,98 +377,6 @@ describe("Session", () => {
     });
   });
 
-  describe("legacy events handlers", () => {
-    describe("onLogin", () => {
-      it("calls the registered callback on login", async () => {
-        const myCallback = jest.fn();
-        const clientAuthentication = mockClientAuthentication();
-        clientAuthentication.handleIncomingRedirect = jest.fn(
-          async (_url: string) => {
-            return {
-              isLoggedIn: true,
-              sessionId: "a session ID",
-              webId: "https://some.webid#them",
-            };
-          },
-        );
-        const mySession = new Session({ clientAuthentication });
-        mySession.onLogin(myCallback);
-        await mySession.handleIncomingRedirect("https://some.url");
-        expect(myCallback).toHaveBeenCalled();
-      });
-
-      it("does not call the registered callback if login isn't successful", async () => {
-        const failCallback = (): void => {
-          throw new Error(
-            "Should *NOT* call callback - this means test has failed!",
-          );
-        };
-        const clientAuthentication = mockClientAuthentication();
-        clientAuthentication.handleIncomingRedirect = jest.fn(
-          async (_url: string) => {
-            return {
-              isLoggedIn: false,
-              sessionId: "a session ID",
-              webId: "https://some.webid#them",
-            };
-          },
-        );
-        const mySession = new Session({ clientAuthentication });
-        mySession.onLogin(failCallback);
-        await expect(
-          mySession.handleIncomingRedirect("https://some.url"),
-        ).resolves.not.toThrow();
-      });
-
-      it("sets the appropriate information before calling the callback", async () => {
-        const clientAuthentication = mockClientAuthentication();
-        clientAuthentication.handleIncomingRedirect = jest.fn(
-          async (_url: string) => {
-            return {
-              isLoggedIn: true,
-              sessionId: "a session ID",
-              webId: "https://some.webid#them",
-            };
-          },
-        );
-        const mySession = new Session({ clientAuthentication });
-        const myCallback = jest.fn((): void => {
-          expect(mySession.info.webId).toBe("https://some.webid#them");
-        });
-        mySession.onLogin(myCallback);
-        await mySession.handleIncomingRedirect("https://some.url");
-        expect(myCallback).toHaveBeenCalled();
-        // Verify that the conditional assertion has been called
-        expect.assertions(2);
-      });
-    });
-
-    describe("onLogout", () => {
-      it("calls the registered callback on logout", async () => {
-        const myCallback = jest.fn();
-        const mySession = new Session({
-          clientAuthentication: mockClientAuthentication(),
-        });
-        mySession.onLogout(myCallback);
-        await mySession.logout();
-        expect(myCallback).toHaveBeenCalled();
-      });
-    });
-
-    describe("onNewRefreshToken", () => {
-      it("calls the registered callback on the newREfreshToken event", async () => {
-        const myCallback = jest.fn();
-        const mySession = new Session();
-        mySession.events.on(EVENTS.NEW_REFRESH_TOKEN, myCallback);
-        (mySession.events as EventEmitter).emit(
-          "newRefreshToken",
-          "some new refresh token",
-        );
-        expect(myCallback).toHaveBeenCalledWith("some new refresh token");
-      });
-    });
-  });
-
   describe("events.on", () => {
     describe("login", () => {
       it("calls the registered callback on login", async () => {
@@ -559,25 +467,6 @@ describe("Session", () => {
         );
         expect(myCallback).toHaveBeenCalledWith("some new refresh token");
       });
-    });
-  });
-
-  describe("proxies events to the session", () => {
-    // This describe block is only required as long as Session extends the EventEmitter
-    // class.
-    it("proxies the EventEmitter calls from events to the session object", () => {
-      const mySession = new Session();
-      const spiedOn = jest.spyOn(mySession, "on");
-      mySession.events.on("login", jest.fn());
-      expect(spiedOn).toHaveBeenCalled();
-    });
-
-    it("throws on calls from events which aren't part of the EventEmitter interface", () => {
-      const mySession = new Session();
-      // @ts-expect-error onLogin is a function on Session, and not SessionEventEmitter
-      expect(() => mySession.events.onLogin(jest.fn())).toThrow(
-        "[onLogin] is not supported",
-      );
     });
   });
 });

--- a/packages/node/src/Session.ts
+++ b/packages/node/src/Session.ts
@@ -30,11 +30,7 @@ import type {
   IHasSessionEventListener,
   ILogoutOptions,
 } from "@inrupt/solid-client-authn-core";
-import {
-  InMemoryStorage,
-  EVENTS,
-  buildProxyHandler,
-} from "@inrupt/solid-client-authn-core";
+import { InMemoryStorage, EVENTS } from "@inrupt/solid-client-authn-core";
 import { v4 } from "uuid";
 import EventEmitter from "events";
 import type ClientAuthentication from "./ClientAuthentication";

--- a/packages/node/src/Session.ts
+++ b/packages/node/src/Session.ts
@@ -89,7 +89,7 @@ export const defaultStorage = new InMemoryStorage();
 /**
  * A {@link Session} object represents a user's session on an application. The session holds state, as it stores information enabling acces to private resources after login for instance.
  */
-export class Session extends EventEmitter implements IHasSessionEventListener {
+export class Session implements IHasSessionEventListener {
   /**
    * Information regarding the current session.
    */
@@ -129,18 +129,7 @@ export class Session extends EventEmitter implements IHasSessionEventListener {
     sessionOptions: Partial<ISessionOptions> = {},
     sessionId: string | undefined = undefined,
   ) {
-    super();
-    // Until Session no longer implements EventEmitter, this.events is just a proxy
-    // to this (with some interface filtering). When we make the breaking change,
-    // this.events will be a regular SessionEventsEmitter.
-    // this.events = new EventEmitter();
-    this.events = new Proxy(
-      this,
-      buildProxyHandler(
-        Session.prototype,
-        "events only implements ISessionEventListener",
-      ),
-    );
+    this.events = new EventEmitter();
     if (sessionOptions.clientAuthentication) {
       this.clientAuthentication = sessionOptions.clientAuthentication;
     } else if (sessionOptions.storage) {
@@ -323,37 +312,4 @@ export class Session extends EventEmitter implements IHasSessionEventListener {
     }
     return sessionInfo;
   };
-
-  /**
-   * Register a callback function to be called when a user completes login.
-   *
-   * The callback is called when {@link handleIncomingRedirect} completes successfully.
-   *
-   * @param callback The function called when a user completes login.
-   * @deprecated Prefer session.events.on(EVENTS.LOGIN, callback)
-   */
-  onLogin(callback: () => unknown): void {
-    this.events.on(EVENTS.LOGIN, callback);
-  }
-
-  /**
-   * Register a callback function to be called when a user logs out:
-   *
-   * @param callback The function called when a user completes logout.
-   * @deprecated Prefer session.events.on(EVENTS.LOGOUT, callback)
-   */
-  onLogout(callback: () => unknown): void {
-    this.events.on(EVENTS.LOGOUT, callback);
-  }
-
-  /**
-   * Register a callback function to be called when a new Refresh Token is issued
-   * for the session. This helps keeping track of refresh token rotation.
-   *
-   * @param callback The function called when a new refresh token is issued.
-   * @deprecated Prefer session.events.on(EVENTS.NEW_REFRESH_TOKEN, callback)
-   */
-  onNewRefreshToken(callback: (newToken: string) => unknown): void {
-    this.events.on(EVENTS.NEW_REFRESH_TOKEN, callback);
-  }
 }

--- a/packages/node/src/Session.ts
+++ b/packages/node/src/Session.ts
@@ -74,11 +74,6 @@ export interface ISessionOptions {
    * An instance of the library core. Typically obtained using `getClientAuthenticationWithDependencies`.
    */
   clientAuthentication: ClientAuthentication;
-  /**
-   * A callback that gets invoked whenever a new refresh token is obtained.
-   * @deprecated Prefer calling Session::onNewRefreshToken instead.
-   */
-  onNewRefreshToken?: (newToken: string) => unknown;
 }
 
 /**
@@ -160,12 +155,6 @@ export class Session implements IHasSessionEventListener {
         sessionId: sessionId ?? v4(),
         isLoggedIn: false,
       };
-    }
-    if (sessionOptions.onNewRefreshToken !== undefined) {
-      this.events.on(
-        EVENTS.NEW_REFRESH_TOKEN,
-        sessionOptions.onNewRefreshToken,
-      );
     }
     // Keeps track of the latest timeout handle in order to clean up on logout
     // and not leave open timeouts.

--- a/packages/node/src/dependencies.ts
+++ b/packages/node/src/dependencies.ts
@@ -102,7 +102,7 @@ export const buildRedirectHandler = (
 /**
  *
  * @param dependencies
- * @deprecated This function will be removed from the external API in an upcoming release.
+ * @hidden
  */
 export function getClientAuthenticationWithDependencies(dependencies: {
   secureStorage?: IStorage;

--- a/packages/node/src/multiSession.ts
+++ b/packages/node/src/multiSession.ts
@@ -19,7 +19,7 @@
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-import type { IStorage } from "@inrupt/solid-client-authn-core";
+import { EVENTS, type IStorage } from "@inrupt/solid-client-authn-core";
 import type ClientAuthentication from "./ClientAuthentication";
 import { getClientAuthenticationWithDependencies } from "./dependencies";
 import { defaultStorage, Session } from "./Session";
@@ -62,8 +62,10 @@ export async function getSessionFromStorage(
   const session = new Session({
     sessionInfo,
     clientAuthentication: clientAuth,
-    onNewRefreshToken,
   });
+  if (onNewRefreshToken !== undefined) {
+    session.events.on(EVENTS.NEW_REFRESH_TOKEN, onNewRefreshToken);
+  }
   if (sessionInfo.refreshToken) {
     await session.login({
       oidcIssuer: sessionInfo.issuer,


### PR DESCRIPTION
This removes APIs marked for deprecation: 
- `EventEmitter` extended by `Session`, and related Session constructor parameter.
- Remove `useEssSession` from type signature
- Make `getClientAuthenticationWithDependencies` private