### PR TITLE
Prevent uploaded artifact naming conflicts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: ${{ matrix.node-version == '20.x' }}
         with:
-          name: code-coverage-ubuntu-latest-${{matrix.node-version}}
+          name: code-coverage-${{ matrix.os }}-${{matrix.node-version}}
           path: coverage/
 
   sonar-scan:


### PR DESCRIPTION
The previous naming scheme didn't account for OS, creating conflicting artifact names. This became apparent when upgrading to upload action v4, where naming conflicts cause a 409 error.
