### PR TITLE
Fix/sdk 3270/bearer token browser session

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
           name: code-coverage-ubuntu-latest-20.x
           path: coverage/
       - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@v1.9
+        uses: SonarSource/sonarcloud-github-action@v2.1.1
         if: ${{ github.actor != 'dependabot[bot]' }}
         with:
           projectBaseDir: ${{ matrix.project-root }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 The following changes have been implemented but not released yet:
 
+### Bugfix
+
+#### browser
+
+- Fix non-DPoP bound tokens support in browser: a bug in the handling of non-DPoP-bound tokens was
+  preventing the auth code grant to complete, with a 401 to the OpenId Provider Token Endpoint
+  observed on redirect after the user authenticated. It is now possible to do 
+  `session.login({/*...*/, tokenType: "Bearer"})` and get a successful result.
+
 ## [2.0.0](https://github.com/inrupt/solid-client-authn-js/releases/tag/v2.0.0) - 2023-12-20
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The following changes have been implemented but not released yet:
 
 - Fix non-DPoP bound tokens support in browser: a bug in the handling of non-DPoP-bound tokens was
   preventing the auth code grant to complete, with a 401 to the OpenId Provider Token Endpoint
-  observed on redirect after the user authenticated. It is now possible to do 
+  observed on redirect after the user authenticated. It is now possible to do
   `session.login({/*...*/, tokenType: "Bearer"})` and get a successful result.
 
 ## [2.0.0](https://github.com/inrupt/solid-client-authn-js/releases/tag/v2.0.0) - 2023-12-20

--- a/e2e/browser/solid-client-authn-browser/test/fixtures.ts
+++ b/e2e/browser/solid-client-authn-browser/test/fixtures.ts
@@ -43,8 +43,6 @@ import {
   saveSolidDatasetAt,
   getThing,
   getUrlAll,
-  access_v1,
-  access_v2,
   deleteFile,
   createContainerInContainer,
   overwriteFile,
@@ -452,8 +450,7 @@ export const test = base.extend<Fixtures>({
       session,
     });
 
-    const { setPublicAccess, setAgentAccess } =
-      setupEnvironment.environment === "ESS PodSpaces" ? access_v1 : access_v2;
+    const { setPublicAccess, setAgentAccess } = universalAccess;
 
     await setPublicAccess(
       publicFileUrl,

--- a/packages/browser/src/login/oidc/incomingRedirectHandler/AuthCodeRedirectHandler.ts
+++ b/packages/browser/src/login/oidc/incomingRedirectHandler/AuthCodeRedirectHandler.ts
@@ -39,7 +39,6 @@ import {
   loadOidcContextFromStorage,
   maybeBuildRpInitiatedLogout,
 } from "@inrupt/solid-client-authn-core";
-import type { CodeExchangeResult } from "@inrupt/oidc-client-ext";
 import { getTokens } from "@inrupt/oidc-client-ext";
 import type { EventEmitter } from "events";
 

--- a/packages/oidc-browser/src/dpop/tokenExchange.spec.ts
+++ b/packages/oidc-browser/src/dpop/tokenExchange.spec.ts
@@ -396,134 +396,24 @@ describe("getTokens", () => {
     );
     expect(result?.webId).toBe("https://some.webid#me");
   });
-});
 
-// describe("getDpopToken", () => {
-//   it("requests a key-bound token, and returns the appropriate key with the token", async () => {
-//     const myFetch = mockFetch(JSON.stringify(mockDpopTokens()), 200);
-//     /* eslint-disable @typescript-eslint/no-explicit-any */
-//     const core = jest.requireMock("@inrupt/solid-client-authn-core") as any;
-//     core.createDpopHeader = jest.fn(() => Promise.resolve("some DPoP header"));
-//     core.generateDpopKeyPair = jest.fn(() => Promise.resolve("some DPoP keys"));
-//     const tokens = await getDpopToken(
-//       mockIssuer(),
-//       mockClient(),
-//       mockEndpointInput(),
-//     );
-//     expect(myFetch.mock.calls[0][0]).toBe(
-//       mockIssuer().tokenEndpoint.toString(),
-//     );
-//     const headers = myFetch.mock.calls[0][1]?.headers as Record<string, string>;
-//     expect(headers.DPoP).toBe("some DPoP header");
-//     expect(tokens.dpopKey).toBe("some DPoP keys");
-//   });
-// });
-
-jest.mock("@inrupt/oidc-client");
-
-const defaultOidcClient = {
-  metadata: {
-    jwks_uri: "https://some.jwks",
-    issuer: "https://some.issuer",
-  },
-  client_id: "some client id",
-};
-const mockOidcClient = (clientSettings: any = defaultOidcClient) => {
-  /* eslint-disable @typescript-eslint/no-explicit-any */
-  const { processSigninResponse } = jest.requireActual(
-    "@inrupt/oidc-client",
-  ) as any;
-  /* eslint-disable @typescript-eslint/no-explicit-any */
-  const oidcModule = jest.requireMock("@inrupt/oidc-client") as any;
-  oidcModule.OidcClient = jest.fn().mockImplementation(() => {
-    return {
-      processSigninResponse: async (
-        redirectUrl: string,
-      ): Promise<ReturnType<typeof processSigninResponse>> => {
-        if (redirectUrl === "https://invalid.url") {
-          throw new Error("Dummy error");
-        }
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore Ignore because we don't need to mock out all data fields.
-        return Promise.resolve({
-          access_token: mockBearerAccessToken(),
-          id_token: mockIdToken(),
-        });
-      },
-      settings: clientSettings,
-    };
+  it("requests a key-bound token, and returns the appropriate key with the token", async () => {
+    const myFetch = mockFetch(JSON.stringify(mockDpopTokens()), 200);
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    const core = jest.requireMock("@inrupt/solid-client-authn-core") as any;
+    core.createDpopHeader = jest.fn(() => Promise.resolve("some DPoP header"));
+    core.generateDpopKeyPair = jest.fn(() => Promise.resolve("some DPoP keys"));
+    const tokens = await getTokens(
+      mockIssuer(),
+      mockClient(),
+      mockEndpointInput(),
+      true,
+    );
+    expect(myFetch.mock.calls[0][0]).toBe(
+      mockIssuer().tokenEndpoint.toString(),
+    );
+    const headers = myFetch.mock.calls[0][1]?.headers as Record<string, string>;
+    expect(headers.DPoP).toBe("some DPoP header");
+    expect(tokens.dpopKey).toBe("some DPoP keys");
   });
-};
-
-// describe("getBearerToken", () => {
-//   it("returns the tokens returned by the endpoint", async () => {
-//     mockOidcClient();
-//     mockFetch(JSON.stringify(mockBearerTokens()), 200);
-//     const tokens = await getBearerToken("https://my.app/redirect");
-//     expect(tokens.accessToken).toEqual(mockBearerAccessToken());
-//     expect(tokens.idToken).toEqual(mockIdToken());
-//     expect(tokens.dpopKey).toBeUndefined();
-//   });
-
-//   it("throws if client metadata are undefined", async () => {
-//     mockOidcClient({
-//       metadata: undefined,
-//       client_id: "some client id",
-//     });
-//     mockFetch(JSON.stringify(mockBearerTokens()), 200);
-//     await expect(getBearerToken("https://my.app/redirect")).rejects.toThrow(
-//       "Cannot retrieve issuer metadata from client information in storage.",
-//     );
-//   });
-
-//   it("throws if client metadata don't include a JWKS URI", async () => {
-//     mockOidcClient({
-//       metadata: {
-//         jwks_uri: undefined,
-//         issuer: "https://some.issuer",
-//       },
-//       client_id: "some client id",
-//     });
-//     mockFetch(JSON.stringify(mockBearerTokens()), 200);
-//     await expect(getBearerToken("https://my.app/redirect")).rejects.toThrow(
-//       "Missing some issuer metadata from client information in storage: 'jwks_uri' is undefined",
-//     );
-//   });
-
-//   it("throws if client metadata don't include an issuer URI", async () => {
-//     mockOidcClient({
-//       metadata: {
-//         jwks_uri: "https://some.jwks",
-//         issuer: undefined,
-//       },
-//       client_id: "some client id",
-//     });
-//     mockFetch(JSON.stringify(mockBearerTokens()), 200);
-//     await expect(getBearerToken("https://my.app/redirect")).rejects.toThrow(
-//       "Missing some issuer metadata from client information in storage: 'issuer' is undefined",
-//     );
-//   });
-
-//   it("throws if client metadata don't include a client ID", async () => {
-//     mockOidcClient({
-//       metadata: {
-//         jwks_uri: "https://some.jwks",
-//         issuer: "https://some.jwks",
-//       },
-//       client_id: undefined,
-//     });
-//     mockFetch(JSON.stringify(mockBearerTokens()), 200);
-//     await expect(getBearerToken("https://my.app/redirect")).rejects.toThrow(
-//       "Missing some client information in storage: 'client_id' is undefined",
-//     );
-//   });
-
-//   it("wraps oidc-client errors", async () => {
-//     mockOidcClient();
-//     mockFetch("", 200);
-//     const tokenRequest = getBearerToken("https://invalid.url");
-//     await expect(tokenRequest).rejects.toThrow(
-//       `Problem handling Auth Code Grant (Flow) redirect - URL [https://invalid.url]: Error: Dummy error`,
-//     );
-//   });
-// });
+});

--- a/packages/oidc-browser/src/dpop/tokenExchange.spec.ts
+++ b/packages/oidc-browser/src/dpop/tokenExchange.spec.ts
@@ -22,12 +22,7 @@
 import { jest, it, describe, expect } from "@jest/globals";
 import type { IIssuerConfig } from "@inrupt/solid-client-authn-core";
 
-import {
-  // getBearerToken,
-  // getDpopToken,
-  getTokens,
-  validateTokenEndpointResponse,
-} from "./tokenExchange";
+import { getTokens, validateTokenEndpointResponse } from "./tokenExchange";
 import {
   mockBearerAccessToken,
   mockBearerTokens,

--- a/packages/oidc-browser/src/dpop/tokenExchange.spec.ts
+++ b/packages/oidc-browser/src/dpop/tokenExchange.spec.ts
@@ -23,8 +23,8 @@ import { jest, it, describe, expect } from "@jest/globals";
 import type { IIssuerConfig } from "@inrupt/solid-client-authn-core";
 
 import {
-  getBearerToken,
-  getDpopToken,
+  // getBearerToken,
+  // getDpopToken,
   getTokens,
   validateTokenEndpointResponse,
 } from "./tokenExchange";
@@ -398,26 +398,26 @@ describe("getTokens", () => {
   });
 });
 
-describe("getDpopToken", () => {
-  it("requests a key-bound token, and returns the appropriate key with the token", async () => {
-    const myFetch = mockFetch(JSON.stringify(mockDpopTokens()), 200);
-    /* eslint-disable @typescript-eslint/no-explicit-any */
-    const core = jest.requireMock("@inrupt/solid-client-authn-core") as any;
-    core.createDpopHeader = jest.fn(() => Promise.resolve("some DPoP header"));
-    core.generateDpopKeyPair = jest.fn(() => Promise.resolve("some DPoP keys"));
-    const tokens = await getDpopToken(
-      mockIssuer(),
-      mockClient(),
-      mockEndpointInput(),
-    );
-    expect(myFetch.mock.calls[0][0]).toBe(
-      mockIssuer().tokenEndpoint.toString(),
-    );
-    const headers = myFetch.mock.calls[0][1]?.headers as Record<string, string>;
-    expect(headers.DPoP).toBe("some DPoP header");
-    expect(tokens.dpopKey).toBe("some DPoP keys");
-  });
-});
+// describe("getDpopToken", () => {
+//   it("requests a key-bound token, and returns the appropriate key with the token", async () => {
+//     const myFetch = mockFetch(JSON.stringify(mockDpopTokens()), 200);
+//     /* eslint-disable @typescript-eslint/no-explicit-any */
+//     const core = jest.requireMock("@inrupt/solid-client-authn-core") as any;
+//     core.createDpopHeader = jest.fn(() => Promise.resolve("some DPoP header"));
+//     core.generateDpopKeyPair = jest.fn(() => Promise.resolve("some DPoP keys"));
+//     const tokens = await getDpopToken(
+//       mockIssuer(),
+//       mockClient(),
+//       mockEndpointInput(),
+//     );
+//     expect(myFetch.mock.calls[0][0]).toBe(
+//       mockIssuer().tokenEndpoint.toString(),
+//     );
+//     const headers = myFetch.mock.calls[0][1]?.headers as Record<string, string>;
+//     expect(headers.DPoP).toBe("some DPoP header");
+//     expect(tokens.dpopKey).toBe("some DPoP keys");
+//   });
+// });
 
 jest.mock("@inrupt/oidc-client");
 
@@ -455,75 +455,75 @@ const mockOidcClient = (clientSettings: any = defaultOidcClient) => {
   });
 };
 
-describe("getBearerToken", () => {
-  it("returns the tokens returned by the endpoint", async () => {
-    mockOidcClient();
-    mockFetch(JSON.stringify(mockBearerTokens()), 200);
-    const tokens = await getBearerToken("https://my.app/redirect");
-    expect(tokens.accessToken).toEqual(mockBearerAccessToken());
-    expect(tokens.idToken).toEqual(mockIdToken());
-    expect(tokens.dpopKey).toBeUndefined();
-  });
+// describe("getBearerToken", () => {
+//   it("returns the tokens returned by the endpoint", async () => {
+//     mockOidcClient();
+//     mockFetch(JSON.stringify(mockBearerTokens()), 200);
+//     const tokens = await getBearerToken("https://my.app/redirect");
+//     expect(tokens.accessToken).toEqual(mockBearerAccessToken());
+//     expect(tokens.idToken).toEqual(mockIdToken());
+//     expect(tokens.dpopKey).toBeUndefined();
+//   });
 
-  it("throws if client metadata are undefined", async () => {
-    mockOidcClient({
-      metadata: undefined,
-      client_id: "some client id",
-    });
-    mockFetch(JSON.stringify(mockBearerTokens()), 200);
-    await expect(getBearerToken("https://my.app/redirect")).rejects.toThrow(
-      "Cannot retrieve issuer metadata from client information in storage.",
-    );
-  });
+//   it("throws if client metadata are undefined", async () => {
+//     mockOidcClient({
+//       metadata: undefined,
+//       client_id: "some client id",
+//     });
+//     mockFetch(JSON.stringify(mockBearerTokens()), 200);
+//     await expect(getBearerToken("https://my.app/redirect")).rejects.toThrow(
+//       "Cannot retrieve issuer metadata from client information in storage.",
+//     );
+//   });
 
-  it("throws if client metadata don't include a JWKS URI", async () => {
-    mockOidcClient({
-      metadata: {
-        jwks_uri: undefined,
-        issuer: "https://some.issuer",
-      },
-      client_id: "some client id",
-    });
-    mockFetch(JSON.stringify(mockBearerTokens()), 200);
-    await expect(getBearerToken("https://my.app/redirect")).rejects.toThrow(
-      "Missing some issuer metadata from client information in storage: 'jwks_uri' is undefined",
-    );
-  });
+//   it("throws if client metadata don't include a JWKS URI", async () => {
+//     mockOidcClient({
+//       metadata: {
+//         jwks_uri: undefined,
+//         issuer: "https://some.issuer",
+//       },
+//       client_id: "some client id",
+//     });
+//     mockFetch(JSON.stringify(mockBearerTokens()), 200);
+//     await expect(getBearerToken("https://my.app/redirect")).rejects.toThrow(
+//       "Missing some issuer metadata from client information in storage: 'jwks_uri' is undefined",
+//     );
+//   });
 
-  it("throws if client metadata don't include an issuer URI", async () => {
-    mockOidcClient({
-      metadata: {
-        jwks_uri: "https://some.jwks",
-        issuer: undefined,
-      },
-      client_id: "some client id",
-    });
-    mockFetch(JSON.stringify(mockBearerTokens()), 200);
-    await expect(getBearerToken("https://my.app/redirect")).rejects.toThrow(
-      "Missing some issuer metadata from client information in storage: 'issuer' is undefined",
-    );
-  });
+//   it("throws if client metadata don't include an issuer URI", async () => {
+//     mockOidcClient({
+//       metadata: {
+//         jwks_uri: "https://some.jwks",
+//         issuer: undefined,
+//       },
+//       client_id: "some client id",
+//     });
+//     mockFetch(JSON.stringify(mockBearerTokens()), 200);
+//     await expect(getBearerToken("https://my.app/redirect")).rejects.toThrow(
+//       "Missing some issuer metadata from client information in storage: 'issuer' is undefined",
+//     );
+//   });
 
-  it("throws if client metadata don't include a client ID", async () => {
-    mockOidcClient({
-      metadata: {
-        jwks_uri: "https://some.jwks",
-        issuer: "https://some.jwks",
-      },
-      client_id: undefined,
-    });
-    mockFetch(JSON.stringify(mockBearerTokens()), 200);
-    await expect(getBearerToken("https://my.app/redirect")).rejects.toThrow(
-      "Missing some client information in storage: 'client_id' is undefined",
-    );
-  });
+//   it("throws if client metadata don't include a client ID", async () => {
+//     mockOidcClient({
+//       metadata: {
+//         jwks_uri: "https://some.jwks",
+//         issuer: "https://some.jwks",
+//       },
+//       client_id: undefined,
+//     });
+//     mockFetch(JSON.stringify(mockBearerTokens()), 200);
+//     await expect(getBearerToken("https://my.app/redirect")).rejects.toThrow(
+//       "Missing some client information in storage: 'client_id' is undefined",
+//     );
+//   });
 
-  it("wraps oidc-client errors", async () => {
-    mockOidcClient();
-    mockFetch("", 200);
-    const tokenRequest = getBearerToken("https://invalid.url");
-    await expect(tokenRequest).rejects.toThrow(
-      `Problem handling Auth Code Grant (Flow) redirect - URL [https://invalid.url]: Error: Dummy error`,
-    );
-  });
-});
+//   it("wraps oidc-client errors", async () => {
+//     mockOidcClient();
+//     mockFetch("", 200);
+//     const tokenRequest = getBearerToken("https://invalid.url");
+//     await expect(tokenRequest).rejects.toThrow(
+//       `Problem handling Auth Code Grant (Flow) redirect - URL [https://invalid.url]: Error: Dummy error`,
+//     );
+//   });
+// });

--- a/packages/oidc-browser/src/dpop/tokenExchange.ts
+++ b/packages/oidc-browser/src/dpop/tokenExchange.ts
@@ -188,18 +188,6 @@ export async function getTokens(
   issuer: IIssuerConfig,
   client: IClient,
   data: TokenEndpointInput,
-  dpop: true,
-): Promise<CodeExchangeResult>;
-export async function getTokens(
-  issuer: IIssuerConfig,
-  client: IClient,
-  data: TokenEndpointInput,
-  dpop: false,
-): Promise<CodeExchangeResult>;
-export async function getTokens(
-  issuer: IIssuerConfig,
-  client: IClient,
-  data: TokenEndpointInput,
   dpop: boolean,
 ): Promise<CodeExchangeResult> {
   validatePreconditions(issuer, data);
@@ -267,94 +255,4 @@ export async function getTokens(
     dpopKey,
     expiresIn: tokenResponse.expires_in,
   };
-}
-
-/**
- * This function exchanges an authorization code for a bearer token.
- * Note that it is based on oidc-client-js, and assumes that the same client has
- * been used to issue the initial redirect.
- * @param redirectUrl The URL to which the user has been redirected
- */
-export async function getBearerToken(
-  redirectUrl: string,
-): Promise<CodeExchangeResult> {
-  let signinResponse;
-  try {
-    const client = new OidcClient({
-      // TODO: We should look at the various interfaces being used for storage,
-      //  i.e. between oidc-client-js (WebStorageStoreState), localStorage
-      //  (which has an interface Storage), and our own proprietary interface
-      //  IStorage - i.e. we should really just be using the browser Web Storage
-      //  API, e.g. "stateStore: window.localStorage,".
-
-      // We are instantiating a new instance here, so the only value we need to
-      // explicitly provide is the response mode (default otherwise will look
-      // for a hash '#' fragment!).
-      // eslint-disable-next-line camelcase
-      response_mode: "query",
-      // The userinfo endpoint on NSS fails, so disable this for now
-      // Note that in Solid, information should be retrieved from the
-      // profile referenced by the WebId.
-      // TODO: Note that this is heavy-handed, and that this userinfo check
-      //  verifies that the `sub` claim in the id token you get along with the
-      //  access token matches the sub claim associated with the access token at
-      //  the userinfo endpoint.
-      // That is a useful check, and in the future it should be only disabled
-      // against NSS, and not in general.
-      // Issue tracker: https://github.com/solid/node-solid-server/issues/1490
-      loadUserInfo: false,
-    });
-    signinResponse = await client.processSigninResponse(redirectUrl);
-    if (client.settings.metadata === undefined) {
-      throw new Error(
-        "Cannot retrieve issuer metadata from client information in storage.",
-      );
-    }
-    if (client.settings.metadata.jwks_uri === undefined) {
-      throw new Error(
-        "Missing some issuer metadata from client information in storage: 'jwks_uri' is undefined",
-      );
-    }
-    if (client.settings.metadata.issuer === undefined) {
-      throw new Error(
-        "Missing some issuer metadata from client information in storage: 'issuer' is undefined",
-      );
-    }
-    if (client.settings.client_id === undefined) {
-      throw new Error(
-        "Missing some client information in storage: 'client_id' is undefined",
-      );
-    }
-    const webId = await getWebidFromTokenPayload(
-      signinResponse.id_token,
-      client.settings.metadata.jwks_uri,
-      client.settings.metadata.issuer,
-      client.settings.client_id,
-    );
-    return {
-      accessToken: signinResponse.access_token,
-      idToken: signinResponse.id_token,
-      webId,
-      // Although not a field in the TypeScript response interface, the refresh
-      // token (which can optionally come back with the access token (if, as per
-      // the OAuth2 spec, we requested one using the scope of 'offline_access')
-      // will be included in the signin response object.
-      // eslint-disable-next-line camelcase
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      refreshToken: signinResponse.refresh_token,
-    };
-  } catch (err) {
-    throw new Error(
-      `Problem handling Auth Code Grant (Flow) redirect - URL [${redirectUrl}]: ${err}`,
-    );
-  }
-}
-
-export async function getDpopToken(
-  issuer: IIssuerConfig,
-  client: IClient,
-  data: TokenEndpointInput,
-): Promise<CodeExchangeResult> {
-  return getTokens(issuer, client, data, true);
 }

--- a/packages/oidc-browser/src/dpop/tokenExchange.ts
+++ b/packages/oidc-browser/src/dpop/tokenExchange.ts
@@ -19,7 +19,6 @@
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-import { OidcClient } from "@inrupt/oidc-client";
 import type {
   IClient,
   IIssuerConfig,
@@ -204,7 +203,9 @@ export async function getTokens(
     );
   }
 
-  // TODO: Find out where this is specified.
+  // Note: this defaults to client_secret_basic. client_secret_post
+  // is currently not supported. See https://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication
+  // for details.
   if (client.clientSecret) {
     headers.Authorization = `Basic ${btoa(
       `${client.clientId}:${client.clientSecret}`,

--- a/packages/oidc-browser/src/index.ts
+++ b/packages/oidc-browser/src/index.ts
@@ -43,8 +43,7 @@ export {
 
 export { registerClient } from "./dcr/clientRegistrar";
 export {
-  getDpopToken,
-  getBearerToken,
+  getTokens,
   TokenEndpointInput,
   CodeExchangeResult,
 } from "./dpop/tokenExchange";


### PR DESCRIPTION
The current implementation relied on `oidc-client` in the browser to
perform part of the authorization grant. However, a bug caused the
RP authentication method to the OP token endpoint to default to
"client_secret_post", instead of "client_secret_basic", which is the
default used during dynamic client registration. This mismatch was
preventing the auth code grant to complete.

- [x] I've added a unit test to test for potential regressions of this bug.
- [X] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/)