### PR TITLE
Allow to disable session background refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ The following changes have been implemented but not released yet:
   parameter is added to the constructor: `Session({ keepAlive: false })`. This prevents
   the `Session` setting a callback to refresh the Access Token before it expires, which
   could cause a memory leak in the case of a server-side application with many users, in
-  addition to unnecessary requests sent to the OpenID Provider. 
+  addition to unnecessary requests sent to the OpenID Provider.
 
 ## [2.1.0](https://github.com/inrupt/solid-client-authn-js/releases/tag/v2.1.0) - 2024-03-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,11 @@ The following changes have been implemented but not released yet:
 
 #### node
 
-- It is now possible to prevent a `Session` to self-refresh in NodeJS. To do so, a new
+- It is now possible to prevent a `Session` self-refreshing in NodeJS. To do so, a new
   parameter is added to the constructor: `Session({ keepAlive: false })`. This prevents
   the `Session` setting a callback to refresh the Access Token before it expires, which
-  could cause a memory leak in the case of a server-side application with many users, in
-  addition to unnecessary requests sent to the OpenID Provider.
+  could cause a memory leak in the case of a server-side application with many users.
+  It also avoids unnecessary requests being sent to the OpenID Provider.
 
 ## [2.1.0](https://github.com/inrupt/solid-client-authn-js/releases/tag/v2.1.0) - 2024-03-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 The following changes have been implemented but not released yet:
 
+### New Feature
+
+#### node
+
+- It is now possible to prevent a `Session` to self-refresh in NodeJS. To do so, a new
+  parameter is added to the constructor: `Session({ keepAlive: false })`. This prevents
+  the `Session` setting a callback to refresh the Access Token before it expires, which
+  could cause a memory leak in the case of a server-side application with many users, in
+  addition to unnecessary requests sent to the OpenID Provider. 
+
 ## [2.1.0](https://github.com/inrupt/solid-client-authn-js/releases/tag/v2.1.0) - 2024-03-13
 
 ### New Feature

--- a/e2e/node/server/e2e-app-test.spec.ts
+++ b/e2e/node/server/e2e-app-test.spec.ts
@@ -18,73 +18,49 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-import { CognitoPage, OpenIdPage } from "@inrupt/internal-playwright-helpers";
+import {CognitoPage, OpenIdPage} from "@inrupt/internal-playwright-helpers";
 import {
-  getBrowserTestingEnvironment,
-  getNodeTestingEnvironment,
+    getBrowserTestingEnvironment,
+    getNodeTestingEnvironment,
 } from "@inrupt/internal-test-env";
 import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  jest,
+    afterEach,
+    beforeEach,
+    describe,
+    expect,
+    it,
+    jest,
 } from "@jest/globals";
-import { firefox } from "@playwright/test";
-import { custom } from "openid-client";
-import type { Server } from "http";
+import {firefox} from "@playwright/test";
+import {custom} from "openid-client";
+import type {Server} from "http";
 import {
-  type ISeedPodResponse,
-  seedPod,
-  tearDownPod,
+    type ISeedPodResponse,
+    seedPod,
+    tearDownPod,
 } from "../../browser/solid-client-authn-browser/test/fixtures";
-import { createApp } from "./express";
+import {createApp} from "./express";
 // Extensions are required for JSON-LD imports.
 // eslint-disable-next-line import/extensions
 import CONSTANTS from "../../../playwright.client-authn.constants.json";
 
 custom.setHttpOptionsDefaults({
-  timeout: 15000,
+    timeout: 15000,
 });
 
 if (process.env.CI === "true") {
-  // Tests running in the CI runners tend to be more flaky.
-  jest.retryTimes(3, { logErrorsBeforeRetry: true });
+    // Tests running in the CI runners tend to be more flaky.
+    jest.retryTimes(3, {logErrorsBeforeRetry: true});
 }
 
 const ENV = getNodeTestingEnvironment();
 const BROWSER_ENV = getBrowserTestingEnvironment();
 
-describe("Testing against express app", () => {
-  let app: Server;
-  let seedInfo: ISeedPodResponse;
-  let clientId: string;
-  let clientResourceUrl: string;
-  let clientResourceContent: string;
-
-  beforeEach(async () => {
-    seedInfo = await seedPod(ENV);
-    clientId = seedInfo.clientId;
-    clientResourceUrl = seedInfo.clientResourceUrl;
-    clientResourceContent = seedInfo.clientResourceContent;
-    await new Promise<void>((res) => {
-      app = createApp(res);
-    });
-  }, 30_000);
-
-  afterEach(async () => {
-    await tearDownPod(seedInfo);
-    await new Promise<void>((res) => {
-      app.close(() => res());
-    });
-  }, 30_000);
-
-  it("Should be able to properly login and out with idp logout", async () => {
+async function performTest(clientId: string, clientResourceUrl: string, clientResourceContent: string) {
     const browser = await firefox.launch();
     const page = await browser.newPage();
     const url = new URL(
-      `http://localhost:${CONSTANTS.CLIENT_AUTHN_TEST_PORT}/login`,
+        `http://localhost:${CONSTANTS.CLIENT_AUTHN_TEST_PORT}/login`,
     );
     url.searchParams.append("oidcIssuer", ENV.idp);
     url.searchParams.append("clientId", clientId);
@@ -97,39 +73,39 @@ describe("Testing against express app", () => {
 
     const cognitoPage = new CognitoPage(page);
     await cognitoPage.login(
-      BROWSER_ENV.clientCredentials.owner.login,
-      BROWSER_ENV.clientCredentials.owner.password,
+        BROWSER_ENV.clientCredentials.owner.login,
+        BROWSER_ENV.clientCredentials.owner.password,
     );
     const openidPage = new OpenIdPage(page);
     try {
-      await openidPage.allow();
+        await openidPage.allow();
     } catch (e) {
-      // Ignore allow error for now
+        // Ignore allow error for now
     }
 
     await page.waitForURL(
-      `http://localhost:${CONSTANTS.CLIENT_AUTHN_TEST_PORT}/`,
+        `http://localhost:${CONSTANTS.CLIENT_AUTHN_TEST_PORT}/`,
     );
 
     // Fetching a protected resource once logged in
     const resourceUrl = new URL(
-      `http://localhost:${CONSTANTS.CLIENT_AUTHN_TEST_PORT}/fetch`,
+        `http://localhost:${CONSTANTS.CLIENT_AUTHN_TEST_PORT}/fetch`,
     );
     resourceUrl.searchParams.append("resource", clientResourceUrl);
     await page.goto(resourceUrl.toString());
     await expect(page.content()).resolves.toBe(
-      `<html><head></head><body>${clientResourceContent}</body></html>`,
+        `<html><head></head><body>${clientResourceContent}</body></html>`,
     );
 
     // Performing idp logout and being redirected to the postLogoutUrl after doing so
     await page.goto(
-      `http://localhost:${CONSTANTS.CLIENT_AUTHN_TEST_PORT}/idplogout`,
+        `http://localhost:${CONSTANTS.CLIENT_AUTHN_TEST_PORT}/idplogout`,
     );
     await page.waitForURL(
-      `http://localhost:${CONSTANTS.CLIENT_AUTHN_TEST_PORT}/postLogoutUrl`,
+        `http://localhost:${CONSTANTS.CLIENT_AUTHN_TEST_PORT}/postLogoutUrl`,
     );
     await expect(page.content()).resolves.toBe(
-      `<html><head></head><body>successfully at post logout</body></html>`,
+        `<html><head></head><body>successfully at post logout</body></html>`,
     );
 
     // Should not be able to retrieve the protected resource after logout
@@ -142,15 +118,72 @@ describe("Testing against express app", () => {
     // It should go back to the cognito page when we try to log back in
     // rather than skipping straight to the consent page
     await page.waitForURL((navigationUrl) => {
-      const u1 = new URL(navigationUrl);
-      u1.searchParams.delete("state");
+        const u1 = new URL(navigationUrl);
+        u1.searchParams.delete("state");
 
-      const u2 = new URL(cognitoPageUrl);
-      u2.searchParams.delete("state");
+        const u2 = new URL(cognitoPageUrl);
+        u2.searchParams.delete("state");
 
-      return u1.toString() === u2.toString();
+        return u1.toString() === u2.toString();
     });
 
     await browser.close();
-  }, 120_000);
+}
+
+describe("Testing against express app with default session", () => {
+    let app: Server;
+    let seedInfo: ISeedPodResponse;
+    let clientId: string;
+    let clientResourceUrl: string;
+    let clientResourceContent: string;
+
+    beforeEach(async () => {
+        seedInfo = await seedPod(ENV);
+        clientId = seedInfo.clientId;
+        clientResourceUrl = seedInfo.clientResourceUrl;
+        clientResourceContent = seedInfo.clientResourceContent;
+        await new Promise<void>((res) => {
+            app = createApp({}, res);
+        });
+    }, 30_000);
+
+    afterEach(async () => {
+        await tearDownPod(seedInfo);
+        await new Promise<void>((res) => {
+            app.close(() => res());
+        });
+    }, 30_000);
+
+    it("Should be able to properly login and out with idp logout", async () => {
+        await performTest(clientId, clientResourceUrl, clientResourceContent);
+    }, 120_000);
+});
+
+describe("Testing against express app with session keep alive off", () => {
+    let app: Server;
+    let seedInfo: ISeedPodResponse;
+    let clientId: string;
+    let clientResourceUrl: string;
+    let clientResourceContent: string;
+
+    beforeEach(async () => {
+        seedInfo = await seedPod(ENV);
+        clientId = seedInfo.clientId;
+        clientResourceUrl = seedInfo.clientResourceUrl;
+        clientResourceContent = seedInfo.clientResourceContent;
+        await new Promise<void>((res) => {
+            app = createApp({ keepAlive: false }, res);
+        });
+    }, 30_000);
+
+    afterEach(async () => {
+        await tearDownPod(seedInfo);
+        await new Promise<void>((res) => {
+            app.close(() => res());
+        });
+    }, 30_000);
+
+    it("Should be able to properly login and out with idp logout", async () => {
+        await performTest(clientId, clientResourceUrl, clientResourceContent);
+    }, 120_000);
 });

--- a/e2e/node/server/e2e-app-test.spec.ts
+++ b/e2e/node/server/e2e-app-test.spec.ts
@@ -137,7 +137,7 @@ describe("Testing against express app with default session", () => {
   beforeEach(async () => {
     seedInfo = await seedPod(ENV);
     await new Promise<void>((res) => {
-      app = createApp({}, res);
+      app = createApp(res, {});
     });
   }, 30_000);
 

--- a/e2e/node/server/e2e-app-test.spec.ts
+++ b/e2e/node/server/e2e-app-test.spec.ts
@@ -18,160 +18,160 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-import {CognitoPage, OpenIdPage} from "@inrupt/internal-playwright-helpers";
+import { CognitoPage, OpenIdPage } from "@inrupt/internal-playwright-helpers";
 import {
-    getBrowserTestingEnvironment,
-    getNodeTestingEnvironment,
+  getBrowserTestingEnvironment,
+  getNodeTestingEnvironment,
 } from "@inrupt/internal-test-env";
 import {
-    afterEach,
-    beforeEach,
-    describe,
-    expect,
-    it,
-    jest,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
 } from "@jest/globals";
-import {firefox} from "@playwright/test";
-import {custom} from "openid-client";
-import type {Server} from "http";
+import { firefox } from "@playwright/test";
+import { custom } from "openid-client";
+import type { Server } from "http";
 import {
-    type ISeedPodResponse,
-    seedPod,
-    tearDownPod,
+  type ISeedPodResponse,
+  seedPod,
+  tearDownPod,
 } from "../../browser/solid-client-authn-browser/test/fixtures";
-import {createApp} from "./express";
+import { createApp } from "./express";
 // Extensions are required for JSON-LD imports.
 // eslint-disable-next-line import/extensions
 import CONSTANTS from "../../../playwright.client-authn.constants.json";
 
 custom.setHttpOptionsDefaults({
-    timeout: 15000,
+  timeout: 15000,
 });
 
 if (process.env.CI === "true") {
-    // Tests running in the CI runners tend to be more flaky.
-    jest.retryTimes(3, {logErrorsBeforeRetry: true});
+  // Tests running in the CI runners tend to be more flaky.
+  jest.retryTimes(3, { logErrorsBeforeRetry: true });
 }
 
 const ENV = getNodeTestingEnvironment();
 const BROWSER_ENV = getBrowserTestingEnvironment();
 
 async function performTest(seedInfo: ISeedPodResponse) {
-    const browser = await firefox.launch();
-    const page = await browser.newPage();
-    const url = new URL(
-        `http://localhost:${CONSTANTS.CLIENT_AUTHN_TEST_PORT}/login`,
-    );
-    url.searchParams.append("oidcIssuer", ENV.idp);
-    url.searchParams.append("clientId", seedInfo.clientId);
+  const browser = await firefox.launch();
+  const page = await browser.newPage();
+  const url = new URL(
+    `http://localhost:${CONSTANTS.CLIENT_AUTHN_TEST_PORT}/login`,
+  );
+  url.searchParams.append("oidcIssuer", ENV.idp);
+  url.searchParams.append("clientId", seedInfo.clientId);
 
-    await page.goto(url.toString());
+  await page.goto(url.toString());
 
-    // Wait for navigation outside the localhost session
-    await page.waitForURL(/^https/);
-    const cognitoPageUrl = page.url();
+  // Wait for navigation outside the localhost session
+  await page.waitForURL(/^https/);
+  const cognitoPageUrl = page.url();
 
-    const cognitoPage = new CognitoPage(page);
-    await cognitoPage.login(
-        BROWSER_ENV.clientCredentials.owner.login,
-        BROWSER_ENV.clientCredentials.owner.password,
-    );
-    const openidPage = new OpenIdPage(page);
-    try {
-        await openidPage.allow();
-    } catch (e) {
-        // Ignore allow error for now
-    }
+  const cognitoPage = new CognitoPage(page);
+  await cognitoPage.login(
+    BROWSER_ENV.clientCredentials.owner.login,
+    BROWSER_ENV.clientCredentials.owner.password,
+  );
+  const openidPage = new OpenIdPage(page);
+  try {
+    await openidPage.allow();
+  } catch (e) {
+    // Ignore allow error for now
+  }
 
-    await page.waitForURL(
-        `http://localhost:${CONSTANTS.CLIENT_AUTHN_TEST_PORT}/`,
-    );
+  await page.waitForURL(
+    `http://localhost:${CONSTANTS.CLIENT_AUTHN_TEST_PORT}/`,
+  );
 
-    // Fetching a protected resource once logged in
-    const resourceUrl = new URL(
-        `http://localhost:${CONSTANTS.CLIENT_AUTHN_TEST_PORT}/fetch`,
-    );
-    resourceUrl.searchParams.append("resource", seedInfo.clientResourceUrl);
-    await page.goto(resourceUrl.toString());
-    await expect(page.content()).resolves.toBe(
-        `<html><head></head><body>${seedInfo.clientResourceContent}</body></html>`,
-    );
+  // Fetching a protected resource once logged in
+  const resourceUrl = new URL(
+    `http://localhost:${CONSTANTS.CLIENT_AUTHN_TEST_PORT}/fetch`,
+  );
+  resourceUrl.searchParams.append("resource", seedInfo.clientResourceUrl);
+  await page.goto(resourceUrl.toString());
+  await expect(page.content()).resolves.toBe(
+    `<html><head></head><body>${seedInfo.clientResourceContent}</body></html>`,
+  );
 
-    // Performing idp logout and being redirected to the postLogoutUrl after doing so
-    await page.goto(
-        `http://localhost:${CONSTANTS.CLIENT_AUTHN_TEST_PORT}/idplogout`,
-    );
-    await page.waitForURL(
-        `http://localhost:${CONSTANTS.CLIENT_AUTHN_TEST_PORT}/postLogoutUrl`,
-    );
-    await expect(page.content()).resolves.toBe(
-        `<html><head></head><body>successfully at post logout</body></html>`,
-    );
+  // Performing idp logout and being redirected to the postLogoutUrl after doing so
+  await page.goto(
+    `http://localhost:${CONSTANTS.CLIENT_AUTHN_TEST_PORT}/idplogout`,
+  );
+  await page.waitForURL(
+    `http://localhost:${CONSTANTS.CLIENT_AUTHN_TEST_PORT}/postLogoutUrl`,
+  );
+  await expect(page.content()).resolves.toBe(
+    `<html><head></head><body>successfully at post logout</body></html>`,
+  );
 
-    // Should not be able to retrieve the protected resource after logout
-    await page.goto(resourceUrl.toString());
-    await expect(page.content()).resolves.toMatch("Unauthorized");
+  // Should not be able to retrieve the protected resource after logout
+  await page.goto(resourceUrl.toString());
+  await expect(page.content()).resolves.toMatch("Unauthorized");
 
-    // Testing what happens if we try to log back in again after logging out
-    await page.goto(url.toString());
+  // Testing what happens if we try to log back in again after logging out
+  await page.goto(url.toString());
 
-    // It should go back to the cognito page when we try to log back in
-    // rather than skipping straight to the consent page
-    await page.waitForURL((navigationUrl) => {
-        const u1 = new URL(navigationUrl);
-        u1.searchParams.delete("state");
+  // It should go back to the cognito page when we try to log back in
+  // rather than skipping straight to the consent page
+  await page.waitForURL((navigationUrl) => {
+    const u1 = new URL(navigationUrl);
+    u1.searchParams.delete("state");
 
-        const u2 = new URL(cognitoPageUrl);
-        u2.searchParams.delete("state");
+    const u2 = new URL(cognitoPageUrl);
+    u2.searchParams.delete("state");
 
-        return u1.toString() === u2.toString();
-    });
+    return u1.toString() === u2.toString();
+  });
 
-    await browser.close();
+  await browser.close();
 }
 
 describe("Testing against express app with default session", () => {
-    let app: Server;
-    let seedInfo: ISeedPodResponse;
+  let app: Server;
+  let seedInfo: ISeedPodResponse;
 
-    beforeEach(async () => {
-        seedInfo = await seedPod(ENV);
-        await new Promise<void>((res) => {
-            app = createApp({}, res);
-        });
-    }, 30_000);
+  beforeEach(async () => {
+    seedInfo = await seedPod(ENV);
+    await new Promise<void>((res) => {
+      app = createApp({}, res);
+    });
+  }, 30_000);
 
-    afterEach(async () => {
-        await tearDownPod(seedInfo);
-        await new Promise<void>((res) => {
-            app.close(() => res());
-        });
-    }, 30_000);
+  afterEach(async () => {
+    await tearDownPod(seedInfo);
+    await new Promise<void>((res) => {
+      app.close(() => res());
+    });
+  }, 30_000);
 
-    it("Should be able to properly login and out with idp logout", async () => {
-        await performTest(seedInfo);
-    }, 120_000);
+  it("Should be able to properly login and out with idp logout", async () => {
+    await performTest(seedInfo);
+  }, 120_000);
 });
 
 describe("Testing against express app with session keep alive off", () => {
-    let app: Server;
-    let seedInfo: ISeedPodResponse;
+  let app: Server;
+  let seedInfo: ISeedPodResponse;
 
-    beforeEach(async () => {
-        seedInfo = await seedPod(ENV);
-        await new Promise<void>((res) => {
-            app = createApp({ keepAlive: false }, res);
-        });
-    }, 30_000);
+  beforeEach(async () => {
+    seedInfo = await seedPod(ENV);
+    await new Promise<void>((res) => {
+      app = createApp({ keepAlive: false }, res);
+    });
+  }, 30_000);
 
-    afterEach(async () => {
-        await tearDownPod(seedInfo);
-        await new Promise<void>((res) => {
-            app.close(() => res());
-        });
-    }, 30_000);
+  afterEach(async () => {
+    await tearDownPod(seedInfo);
+    await new Promise<void>((res) => {
+      app.close(() => res());
+    });
+  }, 30_000);
 
-    it("Should be able to properly login and out with idp logout", async () => {
-        await performTest(seedInfo);
-    }, 120_000);
+  it("Should be able to properly login and out with idp logout", async () => {
+    await performTest(seedInfo);
+  }, 120_000);
 });

--- a/e2e/node/server/e2e-app-test.spec.ts
+++ b/e2e/node/server/e2e-app-test.spec.ts
@@ -160,7 +160,7 @@ describe("Testing against express app with session keep alive off", () => {
   beforeEach(async () => {
     seedInfo = await seedPod(ENV);
     await new Promise<void>((res) => {
-      app = createApp({ keepAlive: false }, res);
+      app = createApp(res, { keepAlive: false });
     });
   }, 30_000);
 

--- a/e2e/node/server/e2e-app-test.spec.ts
+++ b/e2e/node/server/e2e-app-test.spec.ts
@@ -137,7 +137,7 @@ describe("Testing against express app with default session", () => {
   beforeEach(async () => {
     seedInfo = await seedPod(ENV);
     await new Promise<void>((res) => {
-      app = createApp(res, {});
+      app = createApp(res, { keepAlive: true });
     });
   }, 30_000);
 

--- a/e2e/node/server/express.ts
+++ b/e2e/node/server/express.ts
@@ -22,14 +22,14 @@ import log from "loglevel";
 import express from "express";
 // Here we want to test how the local code behaves, not the already published one.
 // eslint-disable-next-line import/no-relative-packages
-import { Session } from "../../../packages/node/src/index";
+import {ISessionOptions, Session} from "../../../packages/node/src/index";
 // Extensions are required for JSON-LD imports.
 // eslint-disable-next-line import/extensions
 import CONSTANTS from "../../../playwright.client-authn.constants.json";
 
 log.setLevel("TRACE");
 
-export function createApp(onStart: () => void) {
+export function createApp(sessionOptions: Partial<ISessionOptions> = {}, onStart: (value: (PromiseLike<void> | void)) => void) {
   const app = express();
 
   // Initialised when the server comes up and is running...
@@ -111,7 +111,7 @@ export function createApp(onStart: () => void) {
   });
 
   return app.listen(CONSTANTS.CLIENT_AUTHN_TEST_PORT, async () => {
-    session = new Session();
+    session = new Session(sessionOptions);
 
     onStart();
   });

--- a/e2e/node/server/express.ts
+++ b/e2e/node/server/express.ts
@@ -22,14 +22,18 @@ import log from "loglevel";
 import express from "express";
 // Here we want to test how the local code behaves, not the already published one.
 // eslint-disable-next-line import/no-relative-packages
-import {ISessionOptions, Session} from "../../../packages/node/src/index";
+import { Session } from "@inrupt/solid-client-authn-node/src/index";
+import type { ISessionOptions } from "@inrupt/solid-client-authn-node/src/index";
 // Extensions are required for JSON-LD imports.
 // eslint-disable-next-line import/extensions
 import CONSTANTS from "../../../playwright.client-authn.constants.json";
 
 log.setLevel("TRACE");
 
-export function createApp(sessionOptions: Partial<ISessionOptions> = {}, onStart: (value: (PromiseLike<void> | void)) => void) {
+export function createApp(
+  sessionOptions: Partial<ISessionOptions> = {},
+  onStart: (value: PromiseLike<void> | void) => void,
+) {
   const app = express();
 
   // Initialised when the server comes up and is running...

--- a/e2e/node/server/express.ts
+++ b/e2e/node/server/express.ts
@@ -31,8 +31,8 @@ import CONSTANTS from "../../../playwright.client-authn.constants.json";
 log.setLevel("TRACE");
 
 export function createApp(
-  sessionOptions: Partial<ISessionOptions> = {},
   onStart: (value: PromiseLike<void> | void) => void,
+  sessionOptions: Partial<ISessionOptions> = {},
 ) {
   const app = express();
 

--- a/e2e/node/server/express.ts
+++ b/e2e/node/server/express.ts
@@ -22,8 +22,8 @@ import log from "loglevel";
 import express from "express";
 // Here we want to test how the local code behaves, not the already published one.
 // eslint-disable-next-line import/no-relative-packages
-import { Session } from "@inrupt/solid-client-authn-node/src/index";
-import type { ISessionOptions } from "@inrupt/solid-client-authn-node/src/index";
+import { Session } from "../../../packages/node/src/index";
+import type { ISessionOptions } from "../../../packages/node/src/index";
 // Extensions are required for JSON-LD imports.
 // eslint-disable-next-line import/extensions
 import CONSTANTS from "../../../playwright.client-authn.constants.json";

--- a/e2e/node/server/express.ts
+++ b/e2e/node/server/express.ts
@@ -22,8 +22,8 @@ import log from "loglevel";
 import express from "express";
 // Here we want to test how the local code behaves, not the already published one.
 // eslint-disable-next-line import/no-relative-packages
-import { Session } from "../../../packages/node/src/index";
-import type { ISessionOptions } from "../../../packages/node/src/index";
+import type { ISessionOptions } from "@inrupt/solid-client-authn-node/src/index";
+import { Session } from "@inrupt/solid-client-authn-node/src/index";
 // Extensions are required for JSON-LD imports.
 // eslint-disable-next-line import/extensions
 import CONSTANTS from "../../../playwright.client-authn.constants.json";

--- a/e2e/node/server/express.ts
+++ b/e2e/node/server/express.ts
@@ -22,8 +22,9 @@ import log from "loglevel";
 import express from "express";
 // Here we want to test how the local code behaves, not the already published one.
 // eslint-disable-next-line import/no-relative-packages
-import type { ISessionOptions } from "@inrupt/solid-client-authn-node/src/index";
-import { Session } from "@inrupt/solid-client-authn-node/src/index";
+import type { ISessionOptions } from "../../../packages/node/src/index";
+// eslint-disable-next-line import/no-relative-packages
+import { Session } from "../../../packages/node/src/index";
 // Extensions are required for JSON-LD imports.
 // eslint-disable-next-line import/extensions
 import CONSTANTS from "../../../playwright.client-authn.constants.json";

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test:unit:node": "jest --coverage --verbose --selectProjects node",
     "test:unit:browser": "jest --coverage --verbose --selectProjects browser",
     "test:unit:core": "jest --coverage --verbose --selectProjects core",
-    "test:unit:oidc-node": "jest --coverage --verbose --selectProjects oidc-node",
+    "test:unit:oidc-browser": "jest --coverage --verbose --selectProjects oidc-browser",
     "test:e2e:node:all": "jest --selectProjects e2e-node-script e2e-node-server --collectCoverage false",
     "test:e2e:node": "jest --selectProjects e2e-node-script --collectCoverage false",
     "test:e2e:node:script": "jest --selectProjects e2e-node-script --collectCoverage false",

--- a/packages/browser/src/ClientAuthentication.spec.ts
+++ b/packages/browser/src/ClientAuthentication.spec.ts
@@ -424,6 +424,7 @@ describe("ClientAuthentication", () => {
       expect(defaultMocks.redirectHandler.handle).toHaveBeenCalledWith(
         url,
         mockEmitter,
+        undefined,
       );
 
       // Calling the redirect handler should have updated the fetch.

--- a/packages/browser/src/ClientAuthentication.ts
+++ b/packages/browser/src/ClientAuthentication.ts
@@ -101,7 +101,11 @@ export default class ClientAuthentication extends ClientAuthenticationBase {
     eventEmitter: EventEmitter,
   ): Promise<ISessionInfo | undefined> => {
     try {
-      const redirectInfo = await this.redirectHandler.handle(url, eventEmitter, undefined);
+      const redirectInfo = await this.redirectHandler.handle(
+        url,
+        eventEmitter,
+        undefined,
+      );
       // The `FallbackRedirectHandler` directly returns the global `fetch` for
       // his value, so we should ensure it's bound to `window` rather than to
       // ClientAuthentication, to avoid the following error:

--- a/packages/browser/src/ClientAuthentication.ts
+++ b/packages/browser/src/ClientAuthentication.ts
@@ -101,7 +101,7 @@ export default class ClientAuthentication extends ClientAuthenticationBase {
     eventEmitter: EventEmitter,
   ): Promise<ISessionInfo | undefined> => {
     try {
-      const redirectInfo = await this.redirectHandler.handle(url, eventEmitter);
+      const redirectInfo = await this.redirectHandler.handle(url, eventEmitter, undefined);
       // The `FallbackRedirectHandler` directly returns the global `fetch` for
       // his value, so we should ensure it's bound to `window` rather than to
       // ClientAuthentication, to avoid the following error:

--- a/packages/browser/src/Session.ts
+++ b/packages/browser/src/Session.ts
@@ -115,7 +115,7 @@ function isLoggedIn(
 }
 
 /**
- * A {@link Session} object represents a user's session on an application. The session holds state, as it stores information enabling acces to private resources after login for instance.
+ * A {@link Session} object represents a user's session on an application. The session holds state, as it stores information enabling access to private resources after login for instance.
  */
 export class Session implements IHasSessionEventListener {
   /**

--- a/packages/core/src/Session.ts
+++ b/packages/core/src/Session.ts
@@ -1,0 +1,24 @@
+//
+// Copyright Inrupt Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+// Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+export type SessionConfig = {
+  keepAlive: boolean;
+};

--- a/packages/core/src/SessionEventListener.ts
+++ b/packages/core/src/SessionEventListener.ts
@@ -54,7 +54,7 @@ type NEW_REFRESH_TOKEN_ARGS = {
 };
 type FALLBACK_ARGS = {
   eventName: Parameters<InstanceType<typeof EventEmitter>["on"]>[0];
-  // Prevents from using a SessionEventEmitter as an aritrary EventEmitter.
+  // Prevents from using a SessionEventEmitter as an arbitrary EventEmitter.
   listener: never;
 };
 

--- a/packages/core/src/authenticatedFetch/fetchFactory.ts
+++ b/packages/core/src/authenticatedFetch/fetchFactory.ts
@@ -191,7 +191,7 @@ export async function buildAuthenticatedFetch(
         if (refreshToken !== undefined) {
           currentRefreshOptions.refreshToken = refreshToken;
         }
-        // Each time the access token is refreshed, we must plan fo the next
+        // Each time the access token is refreshed, we must plan for the next
         // refresh iteration.
         clearTimeout(latestTimeout);
         latestTimeout = setTimeout(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -131,6 +131,8 @@ export {
   TokenEndpointResponse,
 } from "./login/oidc/refresh/ITokenRefresher";
 
+export type { SessionConfig } from "./Session";
+
 // Mocks.
 /**
  * @deprecated

--- a/packages/core/src/login/ILoginOptions.ts
+++ b/packages/core/src/login/ILoginOptions.ts
@@ -53,4 +53,6 @@ export default interface ILoginOptions extends ILoginInputOptions {
    * Event emitter enabling calling user-specified callbacks.
    */
   eventEmitter?: EventEmitter;
+
+  keepAlive?: boolean;
 }

--- a/packages/core/src/login/oidc/IIncomingRedirectHandler.ts
+++ b/packages/core/src/login/oidc/IIncomingRedirectHandler.ts
@@ -29,12 +29,16 @@ import type { EventEmitter } from "events";
 import type IHandleable from "../../util/handlerPattern/IHandleable";
 import type { ISessionInfo } from "../../sessionInfo/ISessionInfo";
 import type { IRpLogoutOptions } from "../../logout/ILogoutHandler";
-import {SessionConfig} from "../../Session";
+import type { SessionConfig } from "../../Session";
 
 export type IncomingRedirectResult = ISessionInfo & { fetch: typeof fetch } & {
   getLogoutUrl?: (options: IRpLogoutOptions) => string;
 };
-export type IncomingRedirectInput = [string, EventEmitter | undefined, SessionConfig | undefined];
+export type IncomingRedirectInput = [
+  string,
+  EventEmitter | undefined,
+  SessionConfig | undefined,
+];
 
 /**
  * @hidden

--- a/packages/core/src/login/oidc/IIncomingRedirectHandler.ts
+++ b/packages/core/src/login/oidc/IIncomingRedirectHandler.ts
@@ -29,11 +29,12 @@ import type { EventEmitter } from "events";
 import type IHandleable from "../../util/handlerPattern/IHandleable";
 import type { ISessionInfo } from "../../sessionInfo/ISessionInfo";
 import type { IRpLogoutOptions } from "../../logout/ILogoutHandler";
+import {SessionConfig} from "../../Session";
 
 export type IncomingRedirectResult = ISessionInfo & { fetch: typeof fetch } & {
   getLogoutUrl?: (options: IRpLogoutOptions) => string;
 };
-export type IncomingRedirectInput = [string, EventEmitter | undefined];
+export type IncomingRedirectInput = [string, EventEmitter | undefined, SessionConfig | undefined];
 
 /**
  * @hidden

--- a/packages/core/src/login/oidc/IOidcOptions.ts
+++ b/packages/core/src/login/oidc/IOidcOptions.ts
@@ -66,7 +66,7 @@ export interface IOidcOptions {
   handleRedirect?: (url: string) => unknown;
   eventEmitter?: EventEmitter;
   /**
-   * Should the resulting session be refreshed in the background? This is persisted prior redirection.
+   * Should the resulting session be refreshed in the background? This is persisted prior to redirection.
    * Defaults to true.
    */
   keepAlive?: boolean;

--- a/packages/core/src/login/oidc/IOidcOptions.ts
+++ b/packages/core/src/login/oidc/IOidcOptions.ts
@@ -65,6 +65,11 @@ export interface IOidcOptions {
   redirectUrl?: string;
   handleRedirect?: (url: string) => unknown;
   eventEmitter?: EventEmitter;
+  /**
+   * Should the resulting session be refreshed in the background? This is persisted prior redirection.
+   * Defaults to true.
+   */
+  keepAlive?: boolean;
 }
 
 export default IOidcOptions;

--- a/packages/core/src/login/oidc/oidcHandlers/AuthorizationCodeWithPkceOidcHandler.ts
+++ b/packages/core/src/login/oidc/oidcHandlers/AuthorizationCodeWithPkceOidcHandler.ts
@@ -27,6 +27,16 @@ import type { IRedirector } from "../IRedirector";
  * @packageDocumentation
  */
 
+function booleanWithFallback(
+  value: boolean | undefined,
+  fallback: boolean,
+): boolean {
+  if (typeof value === "boolean") {
+    return Boolean(value);
+  }
+  return Boolean(fallback);
+}
+
 /**
  * @hidden
  * Authorization code flow spec: https://openid.net/specs/openid-connect-core-1_0.html#CodeFlowAuth
@@ -94,7 +104,11 @@ export default abstract class AuthorizationCodeWithPkceOidcHandlerBase {
         issuer: oidcLoginOptions.issuer.toString(),
         // The redirect URL is read after redirect, so it must be stored now.
         redirectUrl: oidcLoginOptions.redirectUrl,
-        dpop: oidcLoginOptions.dpop ? "true" : "false",
+        dpop: Boolean(oidcLoginOptions.dpop).toString(),
+        keepAlive: booleanWithFallback(
+          oidcLoginOptions.keepAlive,
+          true,
+        ).toString(),
       }),
     ]);
 

--- a/packages/core/src/sessionInfo/ISessionInfo.ts
+++ b/packages/core/src/sessionInfo/ISessionInfo.ts
@@ -85,6 +85,11 @@ export interface ISessionInternalInfo {
    * The token type used by the session
    */
   tokenType?: "DPoP" | "Bearer";
+
+  /**
+   * Whether the session is refreshed in the background or not.
+   */
+  keepAlive?: boolean;
 }
 
 export function isSupportedTokenType(

--- a/packages/core/src/storage/StorageUtility.spec.ts
+++ b/packages/core/src/storage/StorageUtility.spec.ts
@@ -436,6 +436,7 @@ describe("loadOidcContextFromStorage", () => {
       codeVerifier: "some code verifier",
       redirectUrl: "https://my.app/redirect",
       dpop: true,
+      keepAlive: true,
     });
   });
 

--- a/packages/node/examples/multiSession/src/serverSideApp.mjs
+++ b/packages/node/examples/multiSession/src/serverSideApp.mjs
@@ -69,7 +69,7 @@ app.get("/", async (req, res, next) => {
 });
 
 app.get("/login", async (req, res, next) => {
-  const session = new Session();
+  const session = new Session({ keepAlive: false });
   req.session.sessionId = session.info.sessionId;
   await session.login({
     redirectUrl: REDIRECT_URL,
@@ -93,6 +93,7 @@ app.get("/redirect", async (req, res) => {
   } else {
     await session.handleIncomingRedirect(getRequestFullUrl(req));
     if (session.info.isLoggedIn) {
+      session.events.on("sessionExtended", () => { console.log("Extended session.")})
       res.send(
         `<p>Logged in as [<strong>${session.info.webId}</strong>] after redirect</p>`,
       );

--- a/packages/node/src/ClientAuthentication.spec.ts
+++ b/packages/node/src/ClientAuthentication.spec.ts
@@ -228,14 +228,14 @@ describe("ClientAuthentication", () => {
     it("turn off keeping the session alive", async () => {
       const clientAuthn = getClientAuthentication();
       await clientAuthn.login(
-          "mySession",
-          {
-            clientId: "coolApp",
-            redirectUrl: "https://coolapp.com/redirect",
-            oidcIssuer: "https://idp.com",
-          },
-          mockEmitter,
-          { keepAlive: false },
+        "mySession",
+        {
+          clientId: "coolApp",
+          redirectUrl: "https://coolapp.com/redirect",
+          oidcIssuer: "https://idp.com",
+        },
+        mockEmitter,
+        { keepAlive: false },
       );
       expect(defaultMocks.loginHandler.handle).toHaveBeenCalledWith({
         sessionId: "mySession",

--- a/packages/node/src/ClientAuthentication.spec.ts
+++ b/packages/node/src/ClientAuthentication.spec.ts
@@ -275,7 +275,11 @@ describe("ClientAuthentication", () => {
       });
       const session = await clientAuthn.getSessionInfo("mySession");
       // isLoggedIn is stored as a string under the hood, but deserialized as a boolean
-      expect(session).toEqual({ ...sessionInfo, isLoggedIn: true, keepAlive: true });
+      expect(session).toEqual({
+        ...sessionInfo,
+        isLoggedIn: true,
+        keepAlive: true,
+      });
     });
   });
 

--- a/packages/node/src/ClientAuthentication.spec.ts
+++ b/packages/node/src/ClientAuthentication.spec.ts
@@ -86,6 +86,7 @@ describe("ClientAuthentication", () => {
         tokenType: "DPoP",
         eventEmitter: mockEmitter,
         refreshToken: undefined,
+        keepAlive: true,
       });
     });
 
@@ -220,6 +221,7 @@ describe("ClientAuthentication", () => {
         handleRedirect: undefined,
         tokenType: "Bearer",
         eventEmitter: mockEmitter,
+        keepAlive: true,
       });
     });
   });
@@ -262,6 +264,7 @@ describe("ClientAuthentication", () => {
         sessionId: "mySession",
         webId: "https://pod.com/profile/card#me",
         issuer: "https://some.idp",
+        keepAlive: "true",
       };
       const clientAuthn = getClientAuthentication({
         sessionInfoManager: mockSessionInfoManager(
@@ -272,7 +275,7 @@ describe("ClientAuthentication", () => {
       });
       const session = await clientAuthn.getSessionInfo("mySession");
       // isLoggedIn is stored as a string under the hood, but deserialized as a boolean
-      expect(session).toEqual({ ...sessionInfo, isLoggedIn: true });
+      expect(session).toEqual({ ...sessionInfo, isLoggedIn: true, keepAlive: true });
     });
   });
 
@@ -341,6 +344,7 @@ describe("ClientAuthentication", () => {
       expect(defaultMocks.redirectHandler.handle).toHaveBeenCalledWith(
         url,
         session.events,
+        { keepAlive: true },
       );
 
       // Calling the redirect handler should have updated the fetch.
@@ -363,6 +367,7 @@ describe("ClientAuthentication", () => {
       expect(defaultMocks.redirectHandler.handle).toHaveBeenCalledWith(
         url,
         session.events,
+        { keepAlive: true },
       );
 
       // Calling the redirect handler should have updated the fetch.

--- a/packages/node/src/ClientAuthentication.spec.ts
+++ b/packages/node/src/ClientAuthentication.spec.ts
@@ -63,7 +63,7 @@ describe("ClientAuthentication", () => {
 
   describe("login", () => {
     const mockEmitter = new EventEmitter();
-    it("calls login, and defaults to a DPoP token", async () => {
+    it("calls login, and defaults to a DPoP token and keep session alive on", async () => {
       const clientAuthn = getClientAuthentication();
       await clientAuthn.login(
         "mySession",
@@ -222,6 +222,33 @@ describe("ClientAuthentication", () => {
         tokenType: "Bearer",
         eventEmitter: mockEmitter,
         keepAlive: true,
+      });
+    });
+
+    it("turn off keeping the session alive", async () => {
+      const clientAuthn = getClientAuthentication();
+      await clientAuthn.login(
+          "mySession",
+          {
+            clientId: "coolApp",
+            redirectUrl: "https://coolapp.com/redirect",
+            oidcIssuer: "https://idp.com",
+          },
+          mockEmitter,
+          { keepAlive: false },
+      );
+      expect(defaultMocks.loginHandler.handle).toHaveBeenCalledWith({
+        sessionId: "mySession",
+        clientId: "coolApp",
+        redirectUrl: "https://coolapp.com/redirect",
+        oidcIssuer: "https://idp.com",
+        clientName: "coolApp",
+        clientSecret: undefined,
+        handleRedirect: undefined,
+        tokenType: "DPoP",
+        eventEmitter: mockEmitter,
+        refreshToken: undefined,
+        keepAlive: false,
       });
     });
   });

--- a/packages/node/src/ClientAuthentication.ts
+++ b/packages/node/src/ClientAuthentication.ts
@@ -31,6 +31,7 @@ import {
 import type {
   ILoginInputOptions,
   ISessionInfo,
+  SessionConfig
 } from "@inrupt/solid-client-authn-core";
 import type { EventEmitter } from "events";
 
@@ -44,6 +45,7 @@ export default class ClientAuthentication extends ClientAuthenticationBase {
     sessionId: string,
     options: ILoginInputOptions,
     eventEmitter: EventEmitter,
+    config: SessionConfig,
   ): Promise<ISessionInfo | undefined> => {
     // Keep track of the session ID
     await this.sessionInfoManager.register(sessionId);
@@ -67,6 +69,7 @@ export default class ClientAuthentication extends ClientAuthenticationBase {
       // Defaults to DPoP
       tokenType: options.tokenType ?? "DPoP",
       eventEmitter,
+      keepAlive: config.keepAlive,
     });
 
     if (loginReturn !== undefined) {
@@ -94,8 +97,9 @@ export default class ClientAuthentication extends ClientAuthenticationBase {
   handleIncomingRedirect = async (
     url: string,
     eventEmitter: EventEmitter,
+    config: SessionConfig
   ): Promise<ISessionInfo | undefined> => {
-    const redirectInfo = await this.redirectHandler.handle(url, eventEmitter);
+    const redirectInfo = await this.redirectHandler.handle(url, eventEmitter, config);
 
     this.fetch = redirectInfo.fetch;
     this.boundLogout = redirectInfo.getLogoutUrl;

--- a/packages/node/src/ClientAuthentication.ts
+++ b/packages/node/src/ClientAuthentication.ts
@@ -45,7 +45,7 @@ export default class ClientAuthentication extends ClientAuthenticationBase {
     sessionId: string,
     options: ILoginInputOptions,
     eventEmitter: EventEmitter,
-    config: SessionConfig,
+    config: SessionConfig = { keepAlive: true },
   ): Promise<ISessionInfo | undefined> => {
     // Keep track of the session ID
     await this.sessionInfoManager.register(sessionId);
@@ -97,7 +97,7 @@ export default class ClientAuthentication extends ClientAuthenticationBase {
   handleIncomingRedirect = async (
     url: string,
     eventEmitter: EventEmitter,
-    config: SessionConfig,
+    config: SessionConfig = { keepAlive: true },
   ): Promise<ISessionInfo | undefined> => {
     const redirectInfo = await this.redirectHandler.handle(
       url,

--- a/packages/node/src/ClientAuthentication.ts
+++ b/packages/node/src/ClientAuthentication.ts
@@ -31,7 +31,7 @@ import {
 import type {
   ILoginInputOptions,
   ISessionInfo,
-  SessionConfig
+  SessionConfig,
 } from "@inrupt/solid-client-authn-core";
 import type { EventEmitter } from "events";
 
@@ -97,9 +97,13 @@ export default class ClientAuthentication extends ClientAuthenticationBase {
   handleIncomingRedirect = async (
     url: string,
     eventEmitter: EventEmitter,
-    config: SessionConfig
+    config: SessionConfig,
   ): Promise<ISessionInfo | undefined> => {
-    const redirectInfo = await this.redirectHandler.handle(url, eventEmitter, config);
+    const redirectInfo = await this.redirectHandler.handle(
+      url,
+      eventEmitter,
+      config,
+    );
 
     this.fetch = redirectInfo.fetch;
     this.boundLogout = redirectInfo.getLogoutUrl;

--- a/packages/node/src/Session.ts
+++ b/packages/node/src/Session.ts
@@ -29,6 +29,7 @@ import type {
   ISessionEventListener,
   IHasSessionEventListener,
   ILogoutOptions,
+  SessionConfig,
 } from "@inrupt/solid-client-authn-core";
 import { InMemoryStorage, EVENTS } from "@inrupt/solid-client-authn-core";
 import { v4 } from "uuid";
@@ -70,6 +71,10 @@ export interface ISessionOptions {
    * An instance of the library core. Typically obtained using `getClientAuthenticationWithDependencies`.
    */
   clientAuthentication: ClientAuthentication;
+  /**
+   * A boolean flag indicating whether a session should be constantly kept alive in the background.
+   */
+  keepAlive: boolean;
 }
 
 /**
@@ -98,6 +103,8 @@ export class Session implements IHasSessionEventListener {
   private tokenRequestInProgress = false;
 
   private lastTimeoutHandle = 0;
+
+  private config: SessionConfig;
 
   /**
    * Session object constructor. Typically called as follows:
@@ -152,6 +159,10 @@ export class Session implements IHasSessionEventListener {
         isLoggedIn: false,
       };
     }
+    this.config = {
+      // Default to true for backwards compatibility.
+      keepAlive: sessionOptions.keepAlive ?? true,
+    };
     // Keeps track of the latest timeout handle in order to clean up on logout
     // and not leave open timeouts.
     this.events.on(EVENTS.TIMEOUT_SET, (timeoutHandle: number) => {
@@ -177,6 +188,7 @@ export class Session implements IHasSessionEventListener {
         ...options,
       },
       this.events,
+      this.config,
     );
     if (loginInfo !== undefined) {
       this.info.isLoggedIn = loginInfo.isLoggedIn;
@@ -279,6 +291,7 @@ export class Session implements IHasSessionEventListener {
         sessionInfo = await this.clientAuthentication.handleIncomingRedirect(
           url,
           this.events,
+          this.config,
         );
 
         if (sessionInfo) {

--- a/packages/node/src/Session.ts
+++ b/packages/node/src/Session.ts
@@ -83,7 +83,7 @@ export interface ISessionOptions {
 export const defaultStorage = new InMemoryStorage();
 
 /**
- * A {@link Session} object represents a user's session on an application. The session holds state, as it stores information enabling acces to private resources after login for instance.
+ * A {@link Session} object represents a user's session on an application. The session holds state, as it stores information enabling access to private resources after login for instance.
  */
 export class Session implements IHasSessionEventListener {
   /**

--- a/packages/node/src/login/oidc/AggregateIncomingRedirectHandler.ts
+++ b/packages/node/src/login/oidc/AggregateIncomingRedirectHandler.ts
@@ -29,7 +29,8 @@
  */
 import type {
   IIncomingRedirectHandler,
-  ISessionInfo, SessionConfig,
+  ISessionInfo,
+  SessionConfig,
 } from "@inrupt/solid-client-authn-core";
 import { AggregateHandler } from "@inrupt/solid-client-authn-core";
 import type { EventEmitter } from "events";

--- a/packages/node/src/login/oidc/AggregateIncomingRedirectHandler.ts
+++ b/packages/node/src/login/oidc/AggregateIncomingRedirectHandler.ts
@@ -29,7 +29,7 @@
  */
 import type {
   IIncomingRedirectHandler,
-  ISessionInfo,
+  ISessionInfo, SessionConfig,
 } from "@inrupt/solid-client-authn-core";
 import { AggregateHandler } from "@inrupt/solid-client-authn-core";
 import type { EventEmitter } from "events";
@@ -39,7 +39,7 @@ import type { EventEmitter } from "events";
  */
 export default class AggregateIncomingRedirectHandler
   extends AggregateHandler<
-    [string, EventEmitter],
+    [string, EventEmitter, SessionConfig],
     ISessionInfo & { fetch: typeof fetch }
   >
   implements IIncomingRedirectHandler

--- a/packages/node/src/login/oidc/OidcLoginHandler.spec.ts
+++ b/packages/node/src/login/oidc/OidcLoginHandler.spec.ts
@@ -357,7 +357,7 @@ describe("OidcLoginHandler", () => {
       });
       const clientRegistrar = mockDefaultClientRegistrar();
       clientRegistrar.getClient = (jest.fn() as any).mockResolvedValueOnce(
-          mockDefaultClient(),
+        mockDefaultClient(),
       );
       const handler = getInitialisedHandler({
         oidcHandler,
@@ -372,9 +372,9 @@ describe("OidcLoginHandler", () => {
         keepAlive: false,
       });
       expect(oidcHandler.handle).toHaveBeenCalledWith(
-          expect.objectContaining({
-            keepAlive: false,
-          }),
+        expect.objectContaining({
+          keepAlive: false,
+        }),
       );
     });
   });

--- a/packages/node/src/login/oidc/OidcLoginHandler.spec.ts
+++ b/packages/node/src/login/oidc/OidcLoginHandler.spec.ts
@@ -348,5 +348,34 @@ describe("OidcLoginHandler", () => {
         }),
       );
     });
+
+    it("passes keep alive session through to OIDC Handler", async () => {
+      const { oidcHandler } = defaultMocks;
+      const mockedStorage = mockStorageUtility({});
+      await mockedStorage.setForUser("mySession", {
+        refreshToken: "some token",
+      });
+      const clientRegistrar = mockDefaultClientRegistrar();
+      clientRegistrar.getClient = (jest.fn() as any).mockResolvedValueOnce(
+          mockDefaultClient(),
+      );
+      const handler = getInitialisedHandler({
+        oidcHandler,
+        clientRegistrar,
+        storageUtility: mockedStorage,
+      });
+      await handler.handle({
+        sessionId: "mySession",
+        oidcIssuer: "https://arbitrary.url",
+        redirectUrl: "https://app.com/redirect",
+        tokenType: "DPoP",
+        keepAlive: false,
+      });
+      expect(oidcHandler.handle).toHaveBeenCalledWith(
+          expect.objectContaining({
+            keepAlive: false,
+          }),
+      );
+    });
   });
 });

--- a/packages/node/src/login/oidc/OidcLoginHandler.ts
+++ b/packages/node/src/login/oidc/OidcLoginHandler.ts
@@ -123,6 +123,7 @@ export default class OidcLoginHandler implements ILoginHandler {
         )),
       handleRedirect: options.handleRedirect,
       eventEmitter: options.eventEmitter,
+      keepAlive: options.keepAlive,
     };
     // Call proper OIDC Handler
     return this.oidcHandler.handle(oidcOptions);

--- a/packages/node/src/login/oidc/incomingRedirectHandler/AuthCodeRedirectHandler.ts
+++ b/packages/node/src/login/oidc/incomingRedirectHandler/AuthCodeRedirectHandler.ts
@@ -35,6 +35,7 @@ import type {
   RefreshOptions,
   ITokenRefresher,
   IncomingRedirectResult,
+  SessionConfig,
 } from "@inrupt/solid-client-authn-core";
 import {
   loadOidcContextFromStorage,
@@ -169,7 +170,7 @@ export class AuthCodeRedirectHandler implements IIncomingRedirectHandler {
     }
     const authFetch = await buildAuthenticatedFetch(tokenSet.access_token, {
       dpopKey,
-      refreshOptions,
+      refreshOptions: oidcContext.keepAlive ? refreshOptions : undefined,
       eventEmitter,
       expiresIn: tokenSet.expires_in,
     });

--- a/packages/node/src/login/oidc/incomingRedirectHandler/AuthCodeRedirectHandler.ts
+++ b/packages/node/src/login/oidc/incomingRedirectHandler/AuthCodeRedirectHandler.ts
@@ -35,7 +35,6 @@ import type {
   RefreshOptions,
   ITokenRefresher,
   IncomingRedirectResult,
-  SessionConfig,
 } from "@inrupt/solid-client-authn-core";
 import {
   loadOidcContextFromStorage,

--- a/packages/node/src/login/oidc/oidcHandlers/RefreshTokenOidcHandler.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/RefreshTokenOidcHandler.ts
@@ -71,6 +71,7 @@ function validateOptions(
 async function refreshAccess(
   refreshOptions: RefreshOptions,
   dpop: boolean,
+  keepAlive: boolean,
   refreshBindingKey?: KeyPair,
   eventEmitter?: EventEmitter,
 ): Promise<TokenEndpointResponse & { fetch: typeof fetch }> {
@@ -93,7 +94,7 @@ async function refreshAccess(
     };
     const authFetch = await buildAuthenticatedFetch(tokens.accessToken, {
       dpopKey,
-      refreshOptions: rotatedRefreshOptions,
+      refreshOptions: keepAlive ? rotatedRefreshOptions : undefined,
       eventEmitter,
     });
     return Object.assign(tokens, {
@@ -179,6 +180,7 @@ export default class RefreshTokenOidcHandler implements IOidcHandler {
     const accessInfo = await refreshAccess(
       refreshOptions,
       oidcLoginOptions.dpop,
+      oidcLoginOptions.keepAlive ?? true,
       keyPair,
     );
 

--- a/packages/node/src/multiSession.ts
+++ b/packages/node/src/multiSession.ts
@@ -62,6 +62,7 @@ export async function getSessionFromStorage(
   const session = new Session({
     sessionInfo,
     clientAuthentication: clientAuth,
+    keepAlive: sessionInfo.keepAlive,
   });
   if (onNewRefreshToken !== undefined) {
     session.events.on(EVENTS.NEW_REFRESH_TOKEN, onNewRefreshToken);

--- a/packages/node/src/sessionInfo/SessionInfoManager.ts
+++ b/packages/node/src/sessionInfo/SessionInfoManager.ts
@@ -47,16 +47,14 @@ export class SessionInfoManager
   async get(
     sessionId: string,
   ): Promise<(ISessionInfo & ISessionInternalInfo) | undefined> {
-    const webId = await this.storageUtility.getForUser(sessionId, "webId");
-    const isLoggedIn = await this.storageUtility.getForUser(
-      sessionId,
-      "isLoggedIn",
-    );
-    const refreshToken = await this.storageUtility.getForUser(
-      sessionId,
-      "refreshToken",
-    );
-    const issuer = await this.storageUtility.getForUser(sessionId, "issuer");
+    const [webId, isLoggedIn, refreshToken, issuer, keepAlive] =
+      await Promise.all([
+        this.storageUtility.getForUser(sessionId, "webId"),
+        this.storageUtility.getForUser(sessionId, "isLoggedIn"),
+        this.storageUtility.getForUser(sessionId, "refreshToken"),
+        this.storageUtility.getForUser(sessionId, "issuer"),
+        this.storageUtility.getForUser(sessionId, "keepAlive"),
+      ]);
 
     if (issuer !== undefined) {
       return {
@@ -65,6 +63,7 @@ export class SessionInfoManager
         isLoggedIn: isLoggedIn === "true",
         refreshToken,
         issuer,
+        keepAlive: keepAlive === "true",
       };
     }
 


### PR DESCRIPTION
# New feature description

In a server-side scenario, one may not want sessions to proactively refresh to keep their access token active. Instead, the session si logged in using the refresh token when loaded from storage, but it will only be active during the lifetime of its Access Token.

When building a Session, a new option "keepAlive" is supported. It defaults to 'true' for backwards compatibility. If set to 'false', the refresh token of the session will not be used to proactively refresh the access token. `keepAlive` is persisted in storage with the session state so that it is used after the authorization request during the token request in the authorization code flow.

The default value is set in multiple places, which is a bad thing. This can be fixed later.

# Checklist

- [ ] All acceptance criteria are met.
- [ ] Relevant documentation, if any, has been written/updated.
- [ ] The changelog has been updated, if applicable.
- [ ] New functions/types have been exported in `index.ts`, if applicable.
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).