### PR TITLE
3518: Do not store refresh token in local storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 The following changes have been implemented but not released yet:
 
+### Bugfix
+
+#### browser
+
+- Fix #3518: Prevent refresh token from being persisted in local storage.
+
 ## [2.2.0](https://github.com/inrupt/solid-client-authn-js/releases/tag/v2.2.0) - 2024-05-03
 
 ### New Feature

--- a/packages/browser/src/login/oidc/refresh/TokenRefresher.spec.ts
+++ b/packages/browser/src/login/oidc/refresh/TokenRefresher.spec.ts
@@ -272,5 +272,26 @@ describe("TokenRefresher", () => {
       );
       expect(result.refreshToken).toBe("Some rotated refresh token");
     });
+
+    it("does not store the rotated refresh token", async () => {
+      const mockedStorage = mockRefresherDefaultStorageUtility();
+      await mockOidcModule({
+        ...mockDpopTokens(),
+        refreshToken: "Some rotated refresh token",
+        dpopKey: await mockKeyPair(),
+        webId: mockWebId(),
+      });
+      const refresher = getTokenRefresher({
+        storageUtility: mockedStorage,
+      });
+      await refresher.refresh(
+        "mySession",
+        "some refresh token",
+        await mockKeyPair(),
+      );
+      await expect(
+        mockedStorage.getForUser("mySession", "refreshToken"),
+      ).resolves.toBeUndefined();
+    });
   });
 });

--- a/packages/browser/src/login/oidc/refresh/TokenRefresher.ts
+++ b/packages/browser/src/login/oidc/refresh/TokenRefresher.ts
@@ -97,9 +97,6 @@ export default class TokenRefresher implements ITokenRefresher {
 
     if (tokenSet.refreshToken !== undefined) {
       eventEmitter?.emit(EVENTS.NEW_REFRESH_TOKEN, tokenSet.refreshToken);
-      await this.storageUtility.setForUser(sessionId, {
-        refreshToken: tokenSet.refreshToken,
-      });
     }
     return tokenSet;
   }


### PR DESCRIPTION
The local storage is not a secure storage, and as such the refresh token should not be stored there. This issue is mitigated by the token being DPoP-bound, and the DPoP key not being available in storage.

This PR fixes bug #3518 .

- [x] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).