### PR TITLE
SDK-3349: keepAlive option in client cred. flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@ The following changes have been implemented but not released yet:
 
   Note that there still is a timeout being set to notify of session expiration, causing
   NodeJS to wait for the end of the session before closing a terminal. This can be avoided
-  by logging the session out explicitly: 
+  by logging the session out explicitly:
+
   ```javascript
     const session = new Session();
     await session.login({
@@ -28,7 +29,9 @@ The following changes have been implemented but not released yet:
       clientSecret: ...,
     });
   ```
+
   will hang until the session expires, while
+
   ```javascript
     const session = new Session();
     await session.login({
@@ -38,6 +41,7 @@ The following changes have been implemented but not released yet:
     });
     await session.logout();
   ```
+
   will close when logout is complete.
 
 ## [2.2.3](https://github.com/inrupt/solid-client-authn-js/releases/tag/v2.2.3) - 2024-06-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,37 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 The following changes have been implemented but not released yet:
 
+### Bugfix
+
+#### node
+
+- The `keepAlive` option (introduced in v2.2.0) is now correctly observed in a script using
+  the Client Credentials flow (i.e. using a `clientId` and a `clientSecret` to log in). It
+  previously was disregarded, and the `Session` always self-refreshed in the background.
+
+  Note that there still is a timeout being set to notify of session expiration, causing
+  NodeJS to wait for the end of the session before closing a terminal. This can be avoided
+  by logging the session out explicitly: 
+  ```javascript
+    const session = new Session();
+    await session.login({
+      oidcIssuer: ...,
+      clientId: ...,
+      clientSecret: ...,
+    });
+  ```
+  will hang until the session expires, while
+  ```javascript
+    const session = new Session();
+    await session.login({
+      oidcIssuer: ...,
+      clientId: ...,
+      clientSecret: ...,
+    });
+    await session.logout();
+  ```
+  will close when logout is complete.
+
 ## [2.2.3](https://github.com/inrupt/solid-client-authn-js/releases/tag/v2.2.3) - 2024-06-20
 
 ### Bugfix

--- a/packages/node/src/login/oidc/__mocks__/IOidcOptions.ts
+++ b/packages/node/src/login/oidc/__mocks__/IOidcOptions.ts
@@ -43,6 +43,7 @@ export const standardOidcOptions: IOidcOptions = {
     clientId: "coolApp",
     clientType: "dynamic",
   },
+  keepAlive: true,
 };
 
 export const mockDefaultOidcOptions = (): IOidcOptions => {

--- a/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.spec.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.spec.ts
@@ -507,7 +507,7 @@ describe("handle", () => {
     setupOidcClientMock(tokens);
     const mockedRefresher = mockDefaultTokenRefresher();
     const clientCredentialsOidcHandler = new ClientCredentialsOidcHandler(
-      mockedRefresher
+      mockedRefresher,
     );
     await clientCredentialsOidcHandler.handle({
       ...standardOidcOptions,

--- a/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.spec.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.spec.ts
@@ -489,7 +489,6 @@ describe("handle", () => {
         clientType: "static",
       },
     });
-
     expect(result?.isLoggedIn).toBe(true);
     expect(result?.sessionId).toBe(standardOidcOptions.sessionId);
     expect(result?.webId).toBe("https://my.webid/");
@@ -497,5 +496,32 @@ describe("handle", () => {
     expect(result?.expirationDate).toBe(
       Date.now() + DEFAULT_EXPIRATION_TIME_SECONDS * 1000,
     );
+  });
+
+  // The next test is skipped because the fake timers currently don't work
+  // with the background refresh.
+  it.skip("does not setup session refresh if keepAlive is false", async () => {
+    // Mock timers to trigger token refresh.
+    jest.useFakeTimers();
+    const tokens = mockDpopTokens();
+    setupOidcClientMock(tokens);
+    const mockedRefresher = mockDefaultTokenRefresher();
+    const clientCredentialsOidcHandler = new ClientCredentialsOidcHandler(
+      mockedRefresher
+    );
+    await clientCredentialsOidcHandler.handle({
+      ...standardOidcOptions,
+      dpop: true,
+      keepAlive: false,
+      client: {
+        clientId: "some client ID",
+        clientSecret: "some client secret",
+        clientType: "static",
+      },
+    });
+    jest.advanceTimersByTime(500000);
+    // This would pass, but simply because the timers don't work
+    // properly, so it is NOT a functional test.
+    expect(mockedRefresher.refresh).not.toHaveBeenCalled();
   });
 });

--- a/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.ts
@@ -129,7 +129,7 @@ export default class ClientCredentialsOidcHandler implements IOidcHandler {
 
     const authFetch = await buildAuthenticatedFetch(tokens.access_token, {
       dpopKey,
-      refreshOptions: tokens.refresh_token
+      refreshOptions: oidcLoginOptions.keepAlive && tokens.refresh_token
         ? {
             refreshToken: tokens.refresh_token,
             sessionId: oidcLoginOptions.sessionId,

--- a/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.ts
@@ -129,13 +129,14 @@ export default class ClientCredentialsOidcHandler implements IOidcHandler {
 
     const authFetch = await buildAuthenticatedFetch(tokens.access_token, {
       dpopKey,
-      refreshOptions: oidcLoginOptions.keepAlive && tokens.refresh_token
-        ? {
-            refreshToken: tokens.refresh_token,
-            sessionId: oidcLoginOptions.sessionId,
-            tokenRefresher: this.tokenRefresher,
-          }
-        : undefined,
+      refreshOptions:
+        oidcLoginOptions.keepAlive && tokens.refresh_token
+          ? {
+              refreshToken: tokens.refresh_token,
+              sessionId: oidcLoginOptions.sessionId,
+              tokenRefresher: this.tokenRefresher,
+            }
+          : undefined,
       eventEmitter: oidcLoginOptions.eventEmitter,
       expiresIn: tokens.expires_in,
     });


### PR DESCRIPTION
When logging in using the Client Credentials flow, the `keepAlive` option set on the Session should be enforced.

- [X] I've added a unit test to test for potential regressions of this bug. (although the test is currently skipped)
- [X] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).