### PR TITLE
Adding `clientAppId` to `ISessionInfo` object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ The following changes have been implemented but not released yet:
 
 ### Bugfix
 
+#### node and browser
+
+- Fix the initialization of `clientAppId` in `ISessionInfo` objects:  `clientAppId` property of the `ISessionInfo` interface, although present, was not being set either in the `ISessionInfo` objects returned by
+the `handleIncomingRedirect` function in `ClientAuthentication`, or in the `Session` class.
+
+### Bugfix
+
 #### node
 
 - The `keepAlive` option (introduced in v2.2.0) is now correctly observed in a script using

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@ The following changes have been implemented but not released yet:
 
 #### node and browser
 
-- Fix the initialization of `clientAppId` in `ISessionInfo` objects:  `clientAppId` property of the `ISessionInfo` interface, although present, was not being set either in the `ISessionInfo` objects returned by
-the `handleIncomingRedirect` function in `ClientAuthentication`, or in the `Session` class.
+- Fix the initialization of `clientAppId` in `ISessionInfo` objects: `clientAppId` property of the `ISessionInfo` interface, although present, was not being set either in the `ISessionInfo` objects returned by
+  the `handleIncomingRedirect` function in `ClientAuthentication`, or in the `Session` class.
 
 ### Bugfix
 

--- a/packages/browser/src/ClientAuthentication.ts
+++ b/packages/browser/src/ClientAuthentication.ts
@@ -121,6 +121,7 @@ export default class ClientAuthentication extends ClientAuthenticationBase {
         webId: redirectInfo.webId,
         sessionId: redirectInfo.sessionId,
         expirationDate: redirectInfo.expirationDate,
+        clientAppId: redirectInfo.clientAppId,
       };
     } catch (err) {
       // Strip the oauth params:

--- a/packages/browser/src/Session.ts
+++ b/packages/browser/src/Session.ts
@@ -360,6 +360,7 @@ export class Session implements IHasSessionEventListener {
     this.info.isLoggedIn = sessionInfo.isLoggedIn;
     this.info.webId = sessionInfo.webId;
     this.info.sessionId = sessionInfo.sessionId;
+    this.info.clientAppId = sessionInfo.clientAppId;
     this.info.expirationDate = sessionInfo.expirationDate;
     this.events.on(EVENTS.SESSION_EXTENDED, (expiresIn: number) => {
       this.info.expirationDate = Date.now() + expiresIn * 1000;

--- a/packages/browser/src/Session.ts
+++ b/packages/browser/src/Session.ts
@@ -170,6 +170,7 @@ export class Session implements IHasSessionEventListener {
         sessionId: sessionOptions.sessionInfo.sessionId,
         isLoggedIn: false,
         webId: sessionOptions.sessionInfo.webId,
+        clientAppId: sessionOptions.sessionInfo.clientAppId,
       };
     } else {
       this.info = {

--- a/packages/node/src/ClientAuthentication.ts
+++ b/packages/node/src/ClientAuthentication.ts
@@ -112,6 +112,7 @@ export default class ClientAuthentication extends ClientAuthenticationBase {
       isLoggedIn: redirectInfo.isLoggedIn,
       webId: redirectInfo.webId,
       sessionId: redirectInfo.sessionId,
+      clientAppId: redirectInfo.clientAppId,
     };
   };
 }

--- a/packages/node/src/Session.spec.ts
+++ b/packages/node/src/Session.spec.ts
@@ -503,6 +503,7 @@ describe("getSessionFromStorage", () => {
         isLoggedIn: true,
         issuer: "https://my.idp",
         sessionId: "mySession",
+        clientAppId: undefined,
       });
     clientAuthentication.logout = jest
       .fn<typeof clientAuthentication.logout>()
@@ -518,6 +519,7 @@ describe("getSessionFromStorage", () => {
       isLoggedIn: false,
       sessionId: "mySession",
       webId: "https://my.webid",
+      clientAppId: undefined,
     });
   });
 

--- a/packages/node/src/Session.ts
+++ b/packages/node/src/Session.ts
@@ -297,6 +297,7 @@ export class Session implements IHasSessionEventListener {
         if (sessionInfo) {
           this.info.isLoggedIn = sessionInfo.isLoggedIn;
           this.info.webId = sessionInfo.webId;
+          this.info.clientAppId = sessionInfo.clientAppId;
           this.info.sessionId = sessionInfo.sessionId;
           if (sessionInfo.isLoggedIn) {
             // The login event can only be triggered **after** the user has been

--- a/packages/node/src/Session.ts
+++ b/packages/node/src/Session.ts
@@ -152,6 +152,7 @@ export class Session implements IHasSessionEventListener {
         sessionId: sessionOptions.sessionInfo.sessionId,
         isLoggedIn: false,
         webId: sessionOptions.sessionInfo.webId,
+        clientAppId: sessionOptions.sessionInfo.clientAppId,
       };
     } else {
       this.info = {

--- a/packages/node/src/multiSession.spec.ts
+++ b/packages/node/src/multiSession.spec.ts
@@ -86,6 +86,7 @@ describe("getSessionFromStorage", () => {
         isLoggedIn: true,
         issuer: "https://my.idp",
         sessionId: "mySession",
+        clientAppId: undefined,
       });
     clientAuthentication.logout = jest
       .fn<typeof clientAuthentication.logout>()
@@ -101,6 +102,7 @@ describe("getSessionFromStorage", () => {
       isLoggedIn: false,
       sessionId: "mySession",
       webId: "https://my.webid",
+      clientAppId: undefined,
     });
   });
 


### PR DESCRIPTION
This PR fixes bug `clientAppId` not being added in `ISessionInfo` object.

- [ ] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).