### PR TITLE
Remove hard-coded secrets from test suite

### DIFF
--- a/packages/browser/src/login/oidc/OidcLoginHandler.spec.ts
+++ b/packages/browser/src/login/oidc/OidcLoginHandler.spec.ts
@@ -26,6 +26,7 @@ import {
   StorageUtilityMock,
   mockStorage,
 } from "@inrupt/solid-client-authn-core/mocks";
+import { randomUUID } from "crypto";
 
 import { OidcHandlerMock } from "./__mocks__/IOidcHandler";
 import {
@@ -108,8 +109,8 @@ describe("OidcLoginHandler", () => {
   it("should lookup client ID if not provided, if not found do DCR", async () => {
     const mockedOidcModule = jest.requireMock("@inrupt/oidc-client-ext") as any;
     mockedOidcModule.registerClient = (jest.fn() as any).mockResolvedValue({
-      clientId: "some dynamically registered ID",
-      clientSecret: "some dynamically registered secret",
+      clientId: randomUUID(),
+      clientSecret: randomUUID(),
     });
 
     const mockedEmptyStorage = new StorageUtility(
@@ -135,10 +136,11 @@ describe("OidcLoginHandler", () => {
   });
 
   it("should perform DCR if a client WebID is provided, but the target IdP does not support Solid-OIDC", async () => {
+    const clientId = randomUUID();
     const mockedOidcModule = jest.requireMock("@inrupt/oidc-client-ext") as any;
     mockedOidcModule.registerClient = (jest.fn() as any).mockResolvedValue({
-      clientId: "some dynamically registered ID",
-      clientSecret: "some dynamically registered secret",
+      clientId,
+      clientSecret: randomUUID(),
     });
 
     const mockedEmptyStorage = new StorageUtility(
@@ -165,7 +167,7 @@ describe("OidcLoginHandler", () => {
     });
 
     const calledWith = actualHandler.handle.mock.calls[0][0];
-    expect(calledWith.client.clientId).toBe("some dynamically registered ID");
+    expect(calledWith.client.clientId).toBe(clientId);
   });
 
   it("should save statically registered client ID if given one as an input option", async () => {

--- a/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.spec.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/ClientCredentialsOidcHandler.spec.ts
@@ -26,6 +26,7 @@ import type * as SolidClientAuthnCore from "@inrupt/solid-client-authn-core";
 import { jest, it, describe, expect } from "@jest/globals";
 import type * as OpenidClient from "openid-client";
 import type { JWK } from "jose";
+import { randomUUID } from "crypto";
 import { mockDefaultTokenRefresher } from "../refresh/__mocks__/TokenRefresher";
 import { standardOidcOptions } from "../__mocks__/IOidcOptions";
 import ClientCredentialsOidcHandler from "./ClientCredentialsOidcHandler";
@@ -182,8 +183,8 @@ describe("ClientCredentialsOidcHandler", () => {
         clientCredentialsOidcHandler.canHandle({
           ...standardOidcOptions,
           client: {
-            clientId: "some client ID",
-            clientSecret: "some client secret",
+            clientId: randomUUID(),
+            clientSecret: randomUUID(),
             clientType: "static",
           },
         }),
@@ -198,8 +199,8 @@ describe("ClientCredentialsOidcHandler", () => {
         clientCredentialsOidcHandler.canHandle({
           ...standardOidcOptions,
           client: {
-            clientId: "some client ID",
-            clientSecret: "some secret",
+            clientId: randomUUID(),
+            clientSecret: randomUUID(),
             clientType: "dynamic",
           },
         }),
@@ -214,8 +215,8 @@ describe("ClientCredentialsOidcHandler", () => {
         clientCredentialsOidcHandler.canHandle({
           ...standardOidcOptions,
           client: {
-            clientId: "some client ID",
-            clientSecret: "some client secret",
+            clientId: randomUUID(),
+            clientSecret: randomUUID(),
             clientType: "static",
           },
           redirectUrl: undefined,
@@ -231,8 +232,8 @@ describe("ClientCredentialsOidcHandler", () => {
         clientCredentialsOidcHandler.canHandle({
           ...standardOidcOptions,
           client: {
-            clientId: "some client ID",
-            clientSecret: "some client secret",
+            clientId: randomUUID(),
+            clientSecret: randomUUID(),
             clientType: "static",
           },
         }),
@@ -253,8 +254,8 @@ describe("handle", () => {
       clientCredentialsOidcHandler.handle({
         ...standardOidcOptions,
         client: {
-          clientId: "some client ID",
-          clientSecret: "some client secret",
+          clientId: randomUUID(),
+          clientSecret: randomUUID(),
           clientType: "static",
         },
       }),
@@ -278,8 +279,8 @@ describe("handle", () => {
     const sessionInfo = await clientCredentialsOidcHandler.handle({
       ...standardOidcOptions,
       client: {
-        clientId: "some client ID",
-        clientSecret: "some client secret",
+        clientId: randomUUID(),
+        clientSecret: randomUUID(),
         clientType: "static",
       },
     });
@@ -311,8 +312,8 @@ describe("handle", () => {
       clientCredentialsOidcHandler.handle({
         ...standardOidcOptions,
         client: {
-          clientId: "some client ID",
-          clientSecret: "some client secret",
+          clientId: randomUUID(),
+          clientSecret: randomUUID(),
           clientType: "static",
         },
       }),
@@ -330,8 +331,8 @@ describe("handle", () => {
       ...standardOidcOptions,
       dpop: true,
       client: {
-        clientId: "some client ID",
-        clientSecret: "some client secret",
+        clientId: randomUUID(),
+        clientSecret: randomUUID(),
         clientType: "static",
       },
     });
@@ -359,8 +360,8 @@ describe("handle", () => {
       ...standardOidcOptions,
       dpop: false,
       client: {
-        clientId: "some client ID",
-        clientSecret: "some client secret",
+        clientId: randomUUID(),
+        clientSecret: randomUUID(),
         clientType: "static",
       },
     });
@@ -397,8 +398,8 @@ describe("handle", () => {
       ...standardOidcOptions,
       dpop: true,
       client: {
-        clientId: "some client ID",
-        clientSecret: "some client secret",
+        clientId: randomUUID(),
+        clientSecret: randomUUID(),
         clientType: "static",
       },
     });
@@ -434,8 +435,8 @@ describe("handle", () => {
       ...standardOidcOptions,
       dpop: true,
       client: {
-        clientId: "some client ID",
-        clientSecret: "some client secret",
+        clientId: randomUUID(),
+        clientSecret: randomUUID(),
         clientType: "static",
       },
     });
@@ -459,8 +460,8 @@ describe("handle", () => {
       ...standardOidcOptions,
       dpop: true,
       client: {
-        clientId: "some client ID",
-        clientSecret: "some client secret",
+        clientId: randomUUID(),
+        clientSecret: randomUUID(),
         clientType: "static",
       },
     });
@@ -484,8 +485,8 @@ describe("handle", () => {
       ...standardOidcOptions,
       dpop: true,
       client: {
-        clientId: "some client ID",
-        clientSecret: "some client secret",
+        clientId: randomUUID(),
+        clientSecret: randomUUID(),
         clientType: "static",
       },
     });

--- a/packages/node/src/login/oidc/oidcHandlers/RefreshTokenOidcHandler.spec.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/RefreshTokenOidcHandler.spec.ts
@@ -31,6 +31,7 @@ import {
   USER_SESSION_PREFIX,
 } from "@inrupt/solid-client-authn-core";
 import type * as SolidClientAuthnCore from "@inrupt/solid-client-authn-core";
+import { randomUUID } from "crypto";
 import { jwtVerify, exportJWK } from "jose";
 import { EventEmitter } from "events";
 import {
@@ -48,6 +49,8 @@ const mockedFetch = jest
   .spyOn(globalThis, "fetch")
   .mockResolvedValue(new Response());
 
+const EXAMPLE_CLIENT_ID = "d788f39d-c1e4-4c06-b68d-133149d26001";
+
 jest.mock("@inrupt/solid-client-authn-core", () => {
   const actualCoreModule = jest.requireActual(
     "@inrupt/solid-client-authn-core",
@@ -58,7 +61,7 @@ jest.mock("@inrupt/solid-client-authn-core", () => {
     getWebidFromTokenPayload: jest.fn(() =>
       Promise.resolve({
         webId: "https://my.webid/",
-        clientId: "some client id",
+        clientId: EXAMPLE_CLIENT_ID,
       }),
     ),
   };
@@ -77,8 +80,8 @@ describe("RefreshTokenOidcHandler", () => {
           mockOidcOptions({
             refreshToken: undefined,
             client: {
-              clientId: "some client id",
-              clientSecret: "some client secret",
+              clientId: randomUUID(),
+              clientSecret: randomUUID(),
               clientType: "dynamic",
             },
           }),
@@ -100,7 +103,7 @@ describe("RefreshTokenOidcHandler", () => {
               // eslint-disable-next-line @typescript-eslint/ban-ts-comment
               // @ts-ignore
               clientId: undefined,
-              clientSecret: "some client secret",
+              clientSecret: randomUUID(),
               clientType: "dynamic",
             },
           }),
@@ -120,8 +123,8 @@ describe("RefreshTokenOidcHandler", () => {
           mockOidcOptions({
             refreshToken: undefined,
             client: {
-              clientId: "some client id",
-              clientSecret: "some client secret",
+              clientId: randomUUID(),
+              clientSecret: randomUUID(),
               clientType: "dynamic",
             },
           }),
@@ -142,8 +145,8 @@ describe("RefreshTokenOidcHandler", () => {
         mockOidcOptions({
           refreshToken: "some refresh token",
           client: {
-            clientId: "some client id",
-            clientSecret: "some client secret",
+            clientId: randomUUID(),
+            clientSecret: randomUUID(),
             clientType: "dynamic",
           },
         }),
@@ -171,8 +174,8 @@ describe("RefreshTokenOidcHandler", () => {
         mockOidcOptions({
           refreshToken: "some refresh token",
           client: {
-            clientId: "some client id",
-            clientSecret: "some client secret",
+            clientId: randomUUID(),
+            clientSecret: randomUUID(),
             clientType: "dynamic",
           },
         }),
@@ -210,8 +213,8 @@ describe("RefreshTokenOidcHandler", () => {
         mockOidcOptions({
           refreshToken: "some refresh token",
           client: {
-            clientId: "some client id",
-            clientSecret: "some client secret",
+            clientId: randomUUID(),
+            clientSecret: randomUUID(),
             clientType: "dynamic",
           },
         }),
@@ -242,8 +245,8 @@ describe("RefreshTokenOidcHandler", () => {
         mockOidcOptions({
           refreshToken: "some refresh token",
           client: {
-            clientId: "some client id",
-            clientSecret: "some client secret",
+            clientId: randomUUID(),
+            clientSecret: randomUUID(),
             clientType: "dynamic",
           },
           dpop: false,
@@ -264,6 +267,8 @@ describe("RefreshTokenOidcHandler", () => {
     });
 
     it("stores OIDC context in storage so that refreshing the token succeeds later", async () => {
+      const exampleClientSecret = randomUUID();
+
       const mockedStorage = mockStorageUtility({});
       const refreshTokenOidcHandler = new RefreshTokenOidcHandler(
         mockDefaultTokenRefresher(),
@@ -273,8 +278,8 @@ describe("RefreshTokenOidcHandler", () => {
         mockOidcOptions({
           refreshToken: "some refresh token",
           client: {
-            clientId: "some client id",
-            clientSecret: "some client secret",
+            clientId: EXAMPLE_CLIENT_ID,
+            clientSecret: exampleClientSecret,
             clientName: "some client name",
             clientType: "dynamic",
           },
@@ -285,13 +290,13 @@ describe("RefreshTokenOidcHandler", () => {
           mockDefaultOidcOptions().sessionId,
           "clientId",
         ),
-      ).resolves.toBe("some client id");
+      ).resolves.toBe(EXAMPLE_CLIENT_ID);
       await expect(
         mockedStorage.getForUser(
           mockDefaultOidcOptions().sessionId,
           "clientSecret",
         ),
-      ).resolves.toBe("some client secret");
+      ).resolves.toBe(exampleClientSecret);
       await expect(
         mockedStorage.getForUser(
           mockDefaultOidcOptions().sessionId,
@@ -335,8 +340,8 @@ describe("RefreshTokenOidcHandler", () => {
       mockOidcOptions({
         refreshToken: "some refresh token",
         client: {
-          clientId: "some client id",
-          clientSecret: "some client secret",
+          clientId: randomUUID(),
+          clientSecret: randomUUID(),
           clientType: "dynamic",
         },
       }),
@@ -367,14 +372,14 @@ describe("RefreshTokenOidcHandler", () => {
       mockOidcOptions({
         refreshToken: "some refresh token",
         client: {
-          clientId: "some client id",
-          clientSecret: "some client secret",
+          clientId: EXAMPLE_CLIENT_ID,
+          clientSecret: randomUUID(),
           clientType: "dynamic",
         },
       }),
     );
     expect(result?.webId).toBe("https://my.webid/");
-    expect(result?.clientAppId).toBe("some client id");
+    expect(result?.clientAppId).toBe(EXAMPLE_CLIENT_ID);
 
     expect(mockAuthenticatedFetchBuild).toHaveBeenCalledWith(
       expect.anything(),
@@ -403,8 +408,8 @@ describe("RefreshTokenOidcHandler", () => {
       mockOidcOptions({
         refreshToken: "some refresh token",
         client: {
-          clientId: "some client id",
-          clientSecret: "some client secret",
+          clientId: randomUUID(),
+          clientSecret: randomUUID(),
           clientType: "dynamic",
         },
         eventEmitter: mockEmitter,
@@ -433,8 +438,8 @@ describe("RefreshTokenOidcHandler", () => {
       mockOidcOptions({
         refreshToken: "some refresh token",
         client: {
-          clientId: "some client id",
-          clientSecret: "some client secret",
+          clientId: randomUUID(),
+          clientSecret: randomUUID(),
           clientType: "dynamic",
         },
       }),


### PR DESCRIPTION
The test suite currently uses many hard-coded id/secret combinations. This changes those values to random UUIDs.

In most cases, the value of the IDs and secrets are irrelevant. In those cases where the value is important, the value is stored for later comparison. In the case where a mocked refresh token is rotated, I have added a statically defined UUID.