### PR TITLE
Align repository URLs with other libraries

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -8,7 +8,8 @@
   "module": "dist/index.mjs",
   "bundle": "dist/solid-client-authn.bundle.js",
   "repository": {
-    "url": "https://github.com/inrupt/solid-client-authn"
+    "type": "git",
+    "url": "https://github.com/inrupt/solid-client-authn.git"
   },
   "exports": {
     ".": {

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -9,7 +9,7 @@
   "bundle": "dist/solid-client-authn.bundle.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/inrupt/solid-client-authn.git"
+    "url": "https://github.com/inrupt/solid-client-authn-js.git"
   },
   "exports": {
     ".": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,7 +26,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/inrupt/solid-client-authn.git"
+    "url": "https://github.com/inrupt/solid-client-authn-js.git"
   },
   "scripts": {
     "prepublishOnly": "npm run build",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,7 +25,8 @@
     }
   },
   "repository": {
-    "url": "https://github.com/inrupt/solid-client-authn"
+    "type": "git",
+    "url": "https://github.com/inrupt/solid-client-authn.git"
   },
   "scripts": {
     "prepublishOnly": "npm run build",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -7,7 +7,7 @@
   "module": "dist/index.mjs",
   "repository": {
     "type": "git",
-    "url": "https://github.com/inrupt/solid-client-authn.git"
+    "url": "https://github.com/inrupt/solid-client-authn-js.git"
   },
   "exports": {
     ".": {

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -6,7 +6,8 @@
   "types": "dist/index.d.ts",
   "module": "dist/index.mjs",
   "repository": {
-    "url": "https://github.com/inrupt/solid-client-authn"
+    "type": "git",
+    "url": "https://github.com/inrupt/solid-client-authn.git"
   },
   "exports": {
     ".": {

--- a/packages/oidc-browser/package.json
+++ b/packages/oidc-browser/package.json
@@ -10,7 +10,7 @@
   "sideEffects": false,
   "repository": {
     "type": "git",
-    "url": "https://github.com/inrupt/solid-client-authn.git"
+    "url": "https://github.com/inrupt/solid-client-authn-js.git"
   },
   "scripts": {
     "prepublishOnly": "npm run build",

--- a/packages/oidc-browser/package.json
+++ b/packages/oidc-browser/package.json
@@ -8,6 +8,10 @@
   "module": "dist/index.es.js",
   "types": "dist/index.d.ts",
   "sideEffects": false,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/inrupt/solid-client-authn.git"
+  },
   "scripts": {
     "prepublishOnly": "npm run build",
     "build": "rollup --config rollup.config.mjs",


### PR DESCRIPTION
As of 2024-09-18, a change in NPM (?) results in `npm view @inrupt/solid-client-authn repository.url` not showing the `git+...` URL of the repo, but shows `https://...` instead. This is an attempt at making this command consistent accross all of our repositories.