### PR TITLE
Improve SessionEventListener types

### DIFF
--- a/packages/core/src/SessionEventListener.ts
+++ b/packages/core/src/SessionEventListener.ts
@@ -38,7 +38,7 @@ type SESSION_RESTORED_ARGS = {
 };
 type ERROR_ARGS = {
   eventName: typeof EVENTS.ERROR;
-  listener: (error: string | null, errorDescription?: string | null) => unknown;
+  listener: (error: string | null, errorDescription?: string | Error | null) => unknown;
 };
 type SESSION_EXTENDED_ARGS = {
   eventName: typeof EVENTS.SESSION_EXTENDED;


### PR DESCRIPTION
Whilst debugging some issues, I realized that I was getting an `Error` at runtime, instead of a `string` like Typescript indicates. Digging into the code, I found [a FIXME indicating that this is not the intended behaviour](https://github.com/inrupt/solid-client-authn-js/blob/main/packages/browser/src/ClientAuthentication.ts#L130..L135).

However, since that's been there for 2 years, and I'm not sure if there's any plans to fix it, I think it'd be better that the Typescript annotations actually reflect reality.