### PR TITLE
Fix IdP logout in node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@ The following changes have been implemented but not released yet:
   storage (using `getSessionFromStorage`), which is the typical way server-side
   sessions are retrieved.
 
-
 ## [2.2.6](https://github.com/inrupt/solid-client-authn-js/releases/tag/v2.2.6) - 2024-09-18
 
 ### Bugfix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 The following changes have been implemented but not released yet:
 
+### Bugfix
+
+#### node
+
+- The IdP logout no longer fails in Node if the session was restored from
+  storage (using `getSessionFromStorage`), which is the typical way server-side
+  sessions are retrieved.
+
+
 ## [2.2.6](https://github.com/inrupt/solid-client-authn-js/releases/tag/v2.2.6) - 2024-09-18
 
 ### Bugfix

--- a/packages/core/src/logout/endSessionUrl.ts
+++ b/packages/core/src/logout/endSessionUrl.ts
@@ -66,7 +66,6 @@ export function maybeBuildRpInitiatedLogout({
   endSessionEndpoint,
   idTokenHint,
 }: Partial<Omit<IEndSessionOptions, keyof IRpLogoutOptions>>) {
-  console.log(`EndSessionEndpoint: ${endSessionEndpoint}`);
   if (endSessionEndpoint === undefined) return undefined;
 
   return function logout({ state, postLogoutUrl }: IRpLogoutOptions) {

--- a/packages/core/src/logout/endSessionUrl.ts
+++ b/packages/core/src/logout/endSessionUrl.ts
@@ -66,6 +66,7 @@ export function maybeBuildRpInitiatedLogout({
   endSessionEndpoint,
   idTokenHint,
 }: Partial<Omit<IEndSessionOptions, keyof IRpLogoutOptions>>) {
+  console.log(`EndSessionEndpoint: ${endSessionEndpoint}`);
   if (endSessionEndpoint === undefined) return undefined;
 
   return function logout({ state, postLogoutUrl }: IRpLogoutOptions) {

--- a/packages/node/examples/multiSession/src/serverSideApp.mjs
+++ b/packages/node/examples/multiSession/src/serverSideApp.mjs
@@ -126,8 +126,10 @@ app.get("/logout", async (req, res, next) => {
   const session = await getSessionFromStorage(req.session.sessionId);
   if (session) {
     const { webId } = session.info;
-    session.logout();
-    res.send(`<p>Logged out of session with WebID [${webId}]</p>`);
+    await session.logout({
+      logoutType: "idp",
+      handleRedirect: (redirectUrl) => { res.redirect(redirectUrl) }
+    });
   } else {
     res.status(400).send(`<p>No active session to log out</p>`);
   }

--- a/packages/node/src/ClientAuthentication.ts
+++ b/packages/node/src/ClientAuthentication.ts
@@ -74,6 +74,7 @@ export default class ClientAuthentication extends ClientAuthenticationBase {
 
     if (loginReturn !== undefined) {
       this.fetch = loginReturn.fetch;
+      this.boundLogout = loginReturn.getLogoutUrl;
       return loginReturn;
     }
 

--- a/packages/node/src/login/oidc/__mocks__/IOidcOptions.ts
+++ b/packages/node/src/login/oidc/__mocks__/IOidcOptions.ts
@@ -38,7 +38,7 @@ export const standardOidcOptions: IOidcOptions = {
     claimsSupported: [],
     scopesSupported: ["openid"],
     grantTypesSupported: ["authorization_code"],
-    endSessionEndpoint: "https://example.com/end-session"
+    endSessionEndpoint: "https://example.com/end-session",
   },
   client: {
     clientId: "coolApp",

--- a/packages/node/src/login/oidc/__mocks__/IOidcOptions.ts
+++ b/packages/node/src/login/oidc/__mocks__/IOidcOptions.ts
@@ -38,6 +38,7 @@ export const standardOidcOptions: IOidcOptions = {
     claimsSupported: [],
     scopesSupported: ["openid"],
     grantTypesSupported: ["authorization_code"],
+    endSessionEndpoint: "https://example.com/end-session"
   },
   client: {
     clientId: "coolApp",

--- a/packages/node/src/login/oidc/oidcHandlers/RefreshTokenOidcHandler.spec.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/RefreshTokenOidcHandler.spec.ts
@@ -181,6 +181,7 @@ describe("RefreshTokenOidcHandler", () => {
         }),
       )) as SolidClientAuthnCore.LoginResult;
       expect(result).toBeDefined();
+      expect(result?.getLogoutUrl).toBeDefined();
       expect(result?.webId).toBe("https://my.webid/");
       expect(result?.expirationDate).toBeGreaterThan(Date.now());
 

--- a/packages/node/src/login/oidc/oidcHandlers/RefreshTokenOidcHandler.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/RefreshTokenOidcHandler.ts
@@ -44,7 +44,7 @@ import {
   generateDpopKeyPair,
   PREFERRED_SIGNING_ALG,
   buildAuthenticatedFetch,
-  maybeBuildRpInitiatedLogout
+  maybeBuildRpInitiatedLogout,
 } from "@inrupt/solid-client-authn-core";
 import type { JWK } from "jose";
 import { importJWK } from "jose";
@@ -225,8 +225,9 @@ export default class RefreshTokenOidcHandler implements IOidcHandler {
       fetch: accessInfo.fetch,
       getLogoutUrl: maybeBuildRpInitiatedLogout({
         idTokenHint: accessInfo.idToken,
-        endSessionEndpoint: oidcLoginOptions.issuerConfiguration.endSessionEndpoint,
-      })
+        endSessionEndpoint:
+          oidcLoginOptions.issuerConfiguration.endSessionEndpoint,
+      }),
     });
   }
 }

--- a/packages/node/src/login/oidc/oidcHandlers/RefreshTokenOidcHandler.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/RefreshTokenOidcHandler.ts
@@ -44,6 +44,7 @@ import {
   generateDpopKeyPair,
   PREFERRED_SIGNING_ALG,
   buildAuthenticatedFetch,
+  maybeBuildRpInitiatedLogout
 } from "@inrupt/solid-client-authn-core";
 import type { JWK } from "jose";
 import { importJWK } from "jose";
@@ -222,6 +223,10 @@ export default class RefreshTokenOidcHandler implements IOidcHandler {
 
     return Object.assign(sessionInfo, {
       fetch: accessInfo.fetch,
+      getLogoutUrl: maybeBuildRpInitiatedLogout({
+        idTokenHint: accessInfo.idToken,
+        endSessionEndpoint: oidcLoginOptions.issuerConfiguration.endSessionEndpoint,
+      })
     });
   }
 }


### PR DESCRIPTION
The IdP logout no longer fails in Node if the session was restored from storage (using `getSessionFromStorage`), which is the typical use case of how the session should be retrieved.

- [X] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).