### PR TITLE
Expose prompt option

### DIFF
--- a/packages/browser/src/login/oidc/oidcHandlers/AuthorizationCodeWithPkceOidcHandler.ts
+++ b/packages/browser/src/login/oidc/oidcHandlers/AuthorizationCodeWithPkceOidcHandler.ts
@@ -62,7 +62,7 @@ export default class AuthorizationCodeWithPkceOidcHandler
       // profile referenced by the WebId.
       loadUserInfo: false,
       code_verifier: true,
-      prompt: oidcLoginOptions.prompt ?? "consent",
+      prompt: 'prompt' in oidcLoginOptions ? oidcLoginOptions.prompt : "consent",
     };
     /* eslint-enable camelcase */
 

--- a/packages/core/src/ILoginInputOptions.ts
+++ b/packages/core/src/ILoginInputOptions.ts
@@ -55,4 +55,11 @@ export default interface ILoginInputOptions {
    * secret to authenticate.
    */
   refreshToken?: string;
+  /**
+   * Specify whether the Solid Identity Provider may, or may not, interact with the user (for example,
+   * the normal login process **_requires_** human interaction for them to enter their credentials,
+   * but if a user simply refreshes the current page in their browser, we'll want to log them in again
+   * automatically, i.e., without prompting them to manually provide their credentials again).
+   */
+  prompt?: string;
 }

--- a/packages/core/src/login/ILoginOptions.ts
+++ b/packages/core/src/login/ILoginOptions.ts
@@ -39,13 +39,6 @@ export default interface ILoginOptions extends ILoginInputOptions {
   // 'bundling' into this options interface), but it wouldn't be a significant
   // improvement really...
   sessionId: string;
-  /**
-   * Specify whether the Solid Identity Provider may, or may not, interact with the user (for example,
-   * the normal login process **_requires_** human interaction for them to enter their credentials,
-   * but if a user simply refreshes the current page in their browser, we'll want to log them in again
-   * automatically, i.e., without prompting them to manually provide their credentials again).
-   */
-  prompt?: string;
   // Force the token type to be required (i.e. no longer optional).
   tokenType: "DPoP" | "Bearer";
 


### PR DESCRIPTION
This PR is mostly a feature request, but I figured I'd open a PR with the changes to propose a solution.

The feature request is basically to expose the `prompt` option in the login. I always thought that working with various Solid PODs was annoying because they asked for confirmation in every page reload, but recently I realized it's actually the expected behaviour because this library sends the "consent" prompt parameter during the [authentication request](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest). This is done internally, so it would be nice to expose this to clients and let them decide how to behave.

Currently, this can be bypassed using the `prompt` parameter anyways, and telling Typescript to ignore the problem. But there is another issue. Eventually, [the prompt parameter is resolved using a null coalescing operator that defaults to "consent"](https://github.com/inrupt/solid-client-authn-js/blob/main/packages/browser/src/login/oidc/oidcHandlers/AuthorizationCodeWithPkceOidcHandler.ts#L65). This is a problem because in some implementations (for example, [in Laravel](https://laravel.com/docs/11.x/passport#requesting-tokens-redirecting-for-authorization)), there is a distinction between using "none" or omitting the parameter altogether. There should be a way to explicitly avoid sending the parameter, even if the default behaviour is to use "consent". 