### PR TITLE
Improve SessionEventListener types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The following changes have been implemented but not released yet:
 #### browser and node
 
 - Fix the `Session` error listener typing by adding `Error` to the `errorDescription` type so that it reflects the actual behavior.
+  Thanks to @NoelDeMartin for fixing this issue. 
 
 ## [2.3.0](https://github.com/inrupt/solid-client-authn-js/releases/tag/v2.3.0) - 2024-11-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ The following changes have been implemented but not released yet:
 #### browser and node
 
 - Fix the `Session` error listener typing by adding `Error` to the `errorDescription` type so that it reflects the actual behavior.
-  Thanks to @NoelDeMartin for fixing this issue. 
+  Thanks to @NoelDeMartin for fixing this issue.
 
 ## [2.3.0](https://github.com/inrupt/solid-client-authn-js/releases/tag/v2.3.0) - 2024-11-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,6 @@ within this mono-repo.
 
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased
-
-The following changes have been implemented but not released yet:
-
 ## Deprecation notice
 
 - A new signature was introduced for `getSessionFromStorage` in release 2.3.0. The legacy signature is
@@ -29,6 +25,16 @@ const session = await getSessionFromStorage(sessionId, {
   refresh,
 });
 ```
+
+## Unreleased
+
+The following changes have been implemented but not released yet:
+
+### Bugfix
+
+#### browser and node
+
+- Fix the `Session` error listener typing by adding `Error` to the `errorDescription` type so that it reflects the actual behavior.
 
 ## [2.3.0](https://github.com/inrupt/solid-client-authn-js/releases/tag/v2.3.0) - 2024-11-14
 

--- a/packages/core/src/SessionEventListener.ts
+++ b/packages/core/src/SessionEventListener.ts
@@ -38,7 +38,10 @@ type SESSION_RESTORED_ARGS = {
 };
 type ERROR_ARGS = {
   eventName: typeof EVENTS.ERROR;
-  listener: (error: string | null, errorDescription?: string | Error | null) => unknown;
+  listener: (
+    error: string | null,
+    errorDescription?: string | Error | null,
+  ) => unknown;
 };
 type SESSION_EXTENDED_ARGS = {
   eventName: typeof EVENTS.SESSION_EXTENDED;

--- a/packages/core/src/SessionEventListener.ts
+++ b/packages/core/src/SessionEventListener.ts
@@ -38,7 +38,7 @@ type SESSION_RESTORED_ARGS = {
 };
 type ERROR_ARGS = {
   eventName: typeof EVENTS.ERROR;
-  listener: (error: string | null, errorDescription?: string | null) => unknown;
+  listener: (error: string | null, errorDescription?: string | Error | null) => unknown;
 };
 type SESSION_EXTENDED_ARGS = {
   eventName: typeof EVENTS.SESSION_EXTENDED;


### PR DESCRIPTION
Reapplies #3750 for CI

There are some scenarios where an Error is thrown rather than a string, for example within ClientAuthentication.