### PR TITLE
Refresh tokens in NodeJS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,9 +49,10 @@ The following changes have been implemented but not released yet:
 
 #### node
 
-- Added a `EVENTS.NEW_TOKENS` event to be emitted by the `Session` when it receives new tokens when a session is initially
+- Added a `EVENTS.NEW_TOKENS` (`newTokens`) event to be emitted by the `Session` when it receives new tokens when a session is initially
   logged in or refreshed. This event is more useful than `EVENTS.NEW_REFRESH_TOKEN` which is being deprecated.
 - Added a static `Session.fromTokens(tokens, sessionId)` method that creates a new authenticated session directly from a token set, without requiring a full login flow.
+- Added a new function `refreshTokens` to refresh tokens obtained via the `newTokens` event after the Access Token expired.
 
 ## [2.3.0](https://github.com/inrupt/solid-client-authn-js/releases/tag/v2.3.0) - 2024-11-14
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1795,7 +1795,6 @@
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/@bergos/jsonparse/-/jsonparse-1.4.2.tgz",
       "integrity": "sha512-qUt0QNJjvg4s1zk+AuLM6s/zcsQ8MvGn7+1f0vPuxvpCYa08YtTryuDInngbEyW5fNGGYe2znKt61RMGd5HnXg==",
-      "dev": true,
       "engines": [
         "node >= 0.2.0"
       ],
@@ -3159,7 +3158,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@inrupt/solid-client/-/solid-client-2.1.2.tgz",
       "integrity": "sha512-JCqWe2Kl0fVjBpd+Ntdjrd1rhv4v9NkiQI/PXE0wOhfmj/zNd45/qu8nGbpojfnUqopmBZSN2BU4dUpGy795nQ==",
-      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@inrupt/solid-client-errors": "^0.0.2",
         "@rdfjs/dataset": "^1.1.1",
@@ -3197,7 +3196,6 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/@inrupt/solid-client-errors/-/solid-client-errors-0.0.2.tgz",
       "integrity": "sha512-Nhq39DJMKDMc35/VFT168v9JwuKzfzCHPN4fYYAE/Q0ECtM6PuBGT7nu0gZ06+S0pZQasHDyTkOGXRIx+zkvJA==",
-      "dev": true,
       "engines": {
         "node": "^18.0.0 || ^20.0.0 || ^22.0.0"
       }
@@ -3206,7 +3204,6 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
       "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -5834,7 +5831,6 @@
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/@rdfjs/data-model/-/data-model-1.3.4.tgz",
       "integrity": "sha512-iKzNcKvJotgbFDdti7GTQDCYmL7GsGldkYStiP0K8EYtN7deJu5t7U11rKTz+nR7RtesUggT+lriZ7BakFv8QQ==",
-      "dev": true,
       "dependencies": {
         "@rdfjs/types": ">=1.0.1"
       },
@@ -5846,7 +5842,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@rdfjs/dataset/-/dataset-1.1.1.tgz",
       "integrity": "sha512-BNwCSvG0cz0srsG5esq6CQKJc1m8g/M0DZpLuiEp0MMpfwguXX7VeS8TCg4UUG3DV/DqEvhy83ZKSEjdsYseeA==",
-      "dev": true,
       "dependencies": {
         "@rdfjs/data-model": "^1.2.0"
       },
@@ -5858,7 +5853,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.0.tgz",
       "integrity": "sha512-5zm8bN2/CC634dTcn/0AhTRLaQRjXDZs3QfcAsQKNturHT7XVWcKy/8p3P5gXl+YkZTAmy7T5M/LyiT/jbkENw==",
-      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -6641,7 +6635,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/@types/http-link-header/-/http-link-header-1.0.7.tgz",
       "integrity": "sha512-snm5oLckop0K3cTDAiBnZDy6ncx9DJ3mCRDvs42C884MbVYPP74Tiq2hFsSDRTyjK6RyDYDIulPiW23ge+g5Lw==",
-      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -6794,7 +6787,6 @@
       "version": "4.0.16",
       "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.16.tgz",
       "integrity": "sha512-Fvp+8OcU8PyV90KTk5tR/rI8OjD3MP5NUow5rjOsZo+9zxf4p4soJtK9j4V6yeG30TH6rZxqRaP4JLa8lNNTNQ==",
-      "dev": true,
       "dependencies": {
         "@types/node": "*",
         "safe-buffer": "~5.1.1"
@@ -6803,8 +6795,7 @@
     "node_modules/@types/readable-stream/node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/@types/resolve": {
       "version": "1.20.2",
@@ -7429,7 +7420,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
       "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "dev": true,
       "dependencies": {
         "event-target-shim": "^5.0.0"
       },
@@ -8435,7 +8425,6 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
       "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -8625,8 +8614,7 @@
     "node_modules/canonicalize": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-1.0.8.tgz",
-      "integrity": "sha512-0CNTVCLZggSh7bc5VkX5WWPWO+cyZbNd07IHIsSXLia/eAq+r836hgk+8BKoEh7949Mda87VUOitx5OddVj64A==",
-      "dev": true
+      "integrity": "sha512-0CNTVCLZggSh7bc5VkX5WWPWO+cyZbNd07IHIsSXLia/eAq+r836hgk+8BKoEh7949Mda87VUOitx5OddVj64A=="
     },
     "node_modules/chalk": {
       "version": "2.4.2",
@@ -11247,7 +11235,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -12737,7 +12724,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/http-link-header/-/http-link-header-1.1.3.tgz",
       "integrity": "sha512-3cZ0SRL8fb9MUlU3mKM61FcQvPfXx2dBrZW3Vbg5CXa8jFlK8OaEpePenLe1oEXQduhz8b0QjsqfS59QP4AJDQ==",
-      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -12815,7 +12801,6 @@
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -15684,7 +15669,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/jsonld-context-parser/-/jsonld-context-parser-3.0.0.tgz",
       "integrity": "sha512-Kg6TVtBUdIm057ht/8WNhM9BROt+BeYaDGXbzrKaa3xA99csee+CsD8IMCTizRgzoO8PIzvzcxxCoRvpq1xNQw==",
-      "dev": true,
       "dependencies": {
         "@types/http-link-header": "^1.0.1",
         "@types/node": "^18.0.0",
@@ -15699,7 +15683,6 @@
       "version": "18.19.59",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.59.tgz",
       "integrity": "sha512-vizm2EqwV/7Zay+A6J3tGl9Lhr7CjZe2HmWS988sefiEmsyP9CeXEleho6i4hJk/8UtZAo0bWN4QPZZr83RxvQ==",
-      "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -15708,7 +15691,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/jsonld-streaming-parser/-/jsonld-streaming-parser-4.0.1.tgz",
       "integrity": "sha512-6M4y9YGgADk3nXJebbRrxEdMVBJ9bnz+peAvjTXUievopqaE8sg/qml/I6Sp1ln7rpOKffsNZWSre6B7N76szw==",
-      "dev": true,
       "dependencies": {
         "@bergos/jsonparse": "^1.4.0",
         "@rdfjs/types": "*",
@@ -17439,7 +17421,6 @@
       "version": "1.17.2",
       "resolved": "https://registry.npmjs.org/n3/-/n3-1.17.2.tgz",
       "integrity": "sha512-BxSM52wYFqXrbQQT5WUEzKUn6qpYV+2L4XZLfn3Gblz2kwZ09S+QxC33WNdVEQy2djenFL8SNkrjejEKlvI6+Q==",
-      "dev": true,
       "dependencies": {
         "queue-microtask": "^1.1.2",
         "readable-stream": "^4.0.0"
@@ -19227,7 +19208,6 @@
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
       "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
-      "dev": true,
       "engines": {
         "node": ">= 0.6.0"
       }
@@ -19440,7 +19420,6 @@
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -19499,7 +19478,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.2.tgz",
       "integrity": "sha512-TfQD63Lokabd09ES1jAtKK8AA6rkr9rwyUBGo6olOt1CE0Um36CUQIqytyf0am2ouBPR0l7SaHxCiMcPGHkt1A==",
-      "dev": true,
       "dependencies": {
         "@rdfjs/types": "*"
       }
@@ -19866,7 +19844,6 @@
       "version": "4.5.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
       "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
-      "dev": true,
       "dependencies": {
         "abort-controller": "^3.0.0",
         "buffer": "^6.0.3",
@@ -20067,8 +20044,7 @@
     "node_modules/relative-to-absolute-iri": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/relative-to-absolute-iri/-/relative-to-absolute-iri-1.0.7.tgz",
-      "integrity": "sha512-Xjyl4HmIzg2jzK/Un2gELqbcE8Fxy85A/aLSHE6PE/3+OGsFwmKVA1vRyGaz6vLWSqLDMHA+5rjD/xbibSQN1Q==",
-      "dev": true
+      "integrity": "sha512-Xjyl4HmIzg2jzK/Un2gELqbcE8Fxy85A/aLSHE6PE/3+OGsFwmKVA1vRyGaz6vLWSqLDMHA+5rjD/xbibSQN1Q=="
     },
     "node_modules/renderkid": {
       "version": "3.0.0",
@@ -21260,7 +21236,6 @@
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
@@ -22426,8 +22401,7 @@
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.1",
@@ -24007,6 +23981,7 @@
       "version": "2.3.0",
       "license": "MIT",
       "dependencies": {
+        "@inrupt/solid-client": "^2.1.2",
         "@inrupt/solid-client-authn-node": "^2.3.0",
         "cookie-session": "^2.1.0",
         "express": "^4.21.2"

--- a/packages/core/src/sessionInfo/ISessionInfo.ts
+++ b/packages/core/src/sessionInfo/ISessionInfo.ts
@@ -91,6 +91,18 @@ export interface ISessionInternalInfo {
    * @since 2.2.0
    */
   keepAlive?: boolean;
+
+  /**
+   * Private part of the DPoP key.
+   * @since unreleased
+   */
+  privateKey?: string;
+
+    /**
+   * Public part of the DPoP key.
+   * @since unreleased
+   */
+  publicKey?: string;
 }
 
 export function isSupportedTokenType(

--- a/packages/core/src/sessionInfo/ISessionInfo.ts
+++ b/packages/core/src/sessionInfo/ISessionInfo.ts
@@ -98,7 +98,7 @@ export interface ISessionInternalInfo {
    */
   privateKey?: string;
 
-    /**
+  /**
    * Public part of the DPoP key.
    * @since unreleased
    */

--- a/packages/node/examples/multiSession/.env.example
+++ b/packages/node/examples/multiSession/.env.example
@@ -1,0 +1,6 @@
+PORT=3001
+OPENID_PROVIDER="https://login.inrupt.com/"
+# Endpoint whenre the app receives the redirection from the OpenID Provider
+REDIRECT_URL="http://localhost:3001/redirect"
+# Solid-OIDC Client identifier for the application.
+CLIENT_ID="https://storage.inrupt.com/d70fd154-de71-4627-89f3-9f9515950f7a/client_ids/ca999ecd-7951-4982-b7eb-d4376985f978"

--- a/packages/node/examples/multiSession/package.json
+++ b/packages/node/examples/multiSession/package.json
@@ -15,6 +15,7 @@
   },
   "homepage": "https://github.com/inrupt/solid-client-authn-js#readme",
   "dependencies": {
+    "@inrupt/solid-client": "^2.1.2",
     "@inrupt/solid-client-authn-node": "^2.3.0",
     "cookie-session": "^2.1.0",
     "express": "^4.21.2"

--- a/packages/node/src/Session.ts
+++ b/packages/node/src/Session.ts
@@ -45,6 +45,7 @@ import type ClientAuthentication from "./ClientAuthentication";
 import { getClientAuthenticationWithDependencies } from "./dependencies";
 import IssuerConfigFetcher from "./login/oidc/IssuerConfigFetcher";
 import StorageUtilityNode from "./storage/StorageUtility";
+
 export interface ISessionOptions {
   /**
    * A private storage, unreachable to other scripts on the page. Typically in-memory.
@@ -180,14 +181,14 @@ export class Session implements IHasSessionEventListener {
       refreshToken: sessionTokenSet.refreshToken,
       issuer: sessionTokenSet.issuer,
       tokenType: sessionTokenSet.dpopKey === undefined ? "Bearer" : "DPoP",
-      publicKey: sessionTokenSet.dpopKey?.publicKey !== undefined 
-        ? JSON.stringify(sessionTokenSet.dpopKey?.publicKey)
-        : undefined,
-      privateKey: sessionTokenSet.dpopKey?.privateKey !== undefined 
-        ? JSON.stringify(
-            await exportJWK(sessionTokenSet.dpopKey?.privateKey),
-          )
-        : undefined,
+      publicKey:
+        sessionTokenSet.dpopKey?.publicKey !== undefined
+          ? JSON.stringify(sessionTokenSet.dpopKey?.publicKey)
+          : undefined,
+      privateKey:
+        sessionTokenSet.dpopKey?.privateKey !== undefined
+          ? JSON.stringify(await exportJWK(sessionTokenSet.dpopKey?.privateKey))
+          : undefined,
     });
 
     const sessionInfo = await clientAuth.getSessionInfo(finalSessionId);

--- a/packages/node/src/Session.ts
+++ b/packages/node/src/Session.ts
@@ -40,11 +40,11 @@ import {
 } from "@inrupt/solid-client-authn-core";
 import { v4 } from "uuid";
 import EventEmitter from "events";
+import { exportJWK } from "jose";
 import type ClientAuthentication from "./ClientAuthentication";
 import { getClientAuthenticationWithDependencies } from "./dependencies";
 import IssuerConfigFetcher from "./login/oidc/IssuerConfigFetcher";
 import StorageUtilityNode from "./storage/StorageUtility";
-
 export interface ISessionOptions {
   /**
    * A private storage, unreachable to other scripts on the page. Typically in-memory.
@@ -180,6 +180,14 @@ export class Session implements IHasSessionEventListener {
       refreshToken: sessionTokenSet.refreshToken,
       issuer: sessionTokenSet.issuer,
       tokenType: sessionTokenSet.dpopKey === undefined ? "Bearer" : "DPoP",
+      publicKey: sessionTokenSet.dpopKey?.publicKey === undefined 
+        ? JSON.stringify(sessionTokenSet.dpopKey?.publicKey)
+        : undefined,
+      privateKey: sessionTokenSet.dpopKey?.privateKey !== undefined 
+        ? JSON.stringify(
+            await exportJWK(sessionTokenSet.dpopKey?.privateKey),
+          )
+        : undefined,
     });
 
     const sessionInfo = await clientAuth.getSessionInfo(finalSessionId);

--- a/packages/node/src/Session.ts
+++ b/packages/node/src/Session.ts
@@ -180,7 +180,7 @@ export class Session implements IHasSessionEventListener {
       refreshToken: sessionTokenSet.refreshToken,
       issuer: sessionTokenSet.issuer,
       tokenType: sessionTokenSet.dpopKey === undefined ? "Bearer" : "DPoP",
-      publicKey: sessionTokenSet.dpopKey?.publicKey === undefined 
+      publicKey: sessionTokenSet.dpopKey?.publicKey !== undefined 
         ? JSON.stringify(sessionTokenSet.dpopKey?.publicKey)
         : undefined,
       privateKey: sessionTokenSet.dpopKey?.privateKey !== undefined 

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -26,6 +26,7 @@ export {
   getSessionIdFromStorageAll,
   clearSessionFromStorageAll,
   refreshSession,
+  refreshTokens,
 } from "./multiSession";
 
 // Re-export of types defined in the core module and produced/consumed by our API

--- a/packages/node/src/login/oidc/oidcHandlers/RefreshTokenOidcHandler.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/RefreshTokenOidcHandler.ts
@@ -79,7 +79,7 @@ async function refreshAccess(
   try {
     let dpopKey: KeyPair | undefined;
     if (dpop) {
-      dpopKey = refreshBindingKey || (await generateDpopKeyPair());
+      dpopKey = refreshBindingKey ?? (await generateDpopKeyPair());
       // The alg property isn't set by exportJWK, so set it manually.
       [dpopKey.publicKey.alg] = PREFERRED_SIGNING_ALG;
     }

--- a/packages/node/src/multiSession.ts
+++ b/packages/node/src/multiSession.ts
@@ -99,7 +99,7 @@ export async function refreshSession(
 /**
  * Refresh the Access Token and ID Token using the Refresh Token.
  * The tokens may not be expired in order to be refreshed.
- * 
+ *
  * @param tokenSet the tokens to refresh
  * @returns a new set of tokens
  * @since unreleased

--- a/packages/node/src/multiSession.ts
+++ b/packages/node/src/multiSession.ts
@@ -19,7 +19,7 @@
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-import {
+import type {
   SessionTokenSet,
   EVENTS,
   type IStorage,
@@ -99,12 +99,12 @@ export async function refreshSession(
 export async function refreshTokens(tokenSet: SessionTokenSet) {
   const session = await Session.fromTokens(tokenSet);
   // Replace with Promise.withResolvers when minimal node is 22.
-  let tokenResolve: (tokenSet: SessionTokenSet) => void;
+  let tokenResolve: (tokens: SessionTokenSet) => void;
   const tokenPromise = new Promise<SessionTokenSet>((resolve) => {
     tokenResolve = resolve;
   });
-  session.events.on("newTokens", (tokenSet) => {
-    tokenResolve(tokenSet);
+  session.events.on("newTokens", (tokens) => {
+    tokenResolve(tokens);
   });
   await session.login({
     oidcIssuer: tokenSet.issuer,

--- a/packages/node/src/multiSession.ts
+++ b/packages/node/src/multiSession.ts
@@ -21,9 +21,9 @@
 
 import type {
   SessionTokenSet,
-  EVENTS,
-  type IStorage,
+  IStorage,
 } from "@inrupt/solid-client-authn-core";
+import { EVENTS } from "@inrupt/solid-client-authn-core";
 import type ClientAuthentication from "./ClientAuthentication";
 import { getClientAuthenticationWithDependencies } from "./dependencies";
 import { defaultStorage, Session } from "./Session";

--- a/packages/node/src/multiSession.ts
+++ b/packages/node/src/multiSession.ts
@@ -96,6 +96,19 @@ export async function refreshSession(
   }
 }
 
+/**
+ * Refresh the Access Token and ID Token using the Refresh Token.
+ * The tokens may not be expired in order to be refreshed.
+ * 
+ * @param tokenSet the tokens to refresh
+ * @returns a new set of tokens
+ * @since unreleased
+ * @example
+ * ```
+ * const refreshedTokens = await refreshTokens(previousTokenSet);
+ * const session = await Session.fromTokens(refreshedTokens, sessionId);
+ * ```
+ */
 export async function refreshTokens(tokenSet: SessionTokenSet) {
   const session = await Session.fromTokens(tokenSet);
   // Replace with Promise.withResolvers when minimal node is 22.
@@ -103,6 +116,7 @@ export async function refreshTokens(tokenSet: SessionTokenSet) {
   const tokenPromise = new Promise<SessionTokenSet>((resolve) => {
     tokenResolve = resolve;
   });
+  // FIXME: if the refresh flow fails, the promise should reject.
   session.events.on("newTokens", (tokens) => {
     tokenResolve(tokens);
   });

--- a/packages/node/src/sessionInfo/SessionInfoManager.ts
+++ b/packages/node/src/sessionInfo/SessionInfoManager.ts
@@ -66,6 +66,8 @@ export class SessionInfoManager
       clientAppSecret: sessionInfo.clientAppSecret,
       dpop: sessionInfo.tokenType === "DPoP",
       keepAlive: sessionInfo.keepAlive,
+      privateKey: sessionInfo.privateKey,
+      publicKey: sessionInfo.publicKey,
     };
 
     const definedFields: Record<string, string> = Object.entries(fieldsToStore)
@@ -94,6 +96,8 @@ export class SessionInfoManager
       clientAppSecret,
       dpop,
       keepAlive,
+      publicKey,
+      privateKey,
     ] = await Promise.all([
       // ISessionInfo
       this.storageUtility.getForUser(sessionId, "webId"),
@@ -107,6 +111,8 @@ export class SessionInfoManager
       this.storageUtility.getForUser(sessionId, "clientAppSecret"),
       this.storageUtility.getForUser(sessionId, "dpop"),
       this.storageUtility.getForUser(sessionId, "keepAlive"),
+      this.storageUtility.getForUser(sessionId, "publicKey"),
+      this.storageUtility.getForUser(sessionId, "privateKey"),
     ]);
 
     if (issuer !== undefined) {
@@ -126,6 +132,8 @@ export class SessionInfoManager
         redirectUrl,
         tokenType: dpop === "true" ? "DPoP" : "Bearer",
         keepAlive: keepAlive === "true",
+        publicKey,
+        privateKey,
       };
     }
 


### PR DESCRIPTION
# New feature description

This adds a function to the `multisession` module to be able to refresh
a `SessionTokenSet`. It also fixes the internal session info to keep
track of the DPoP keys.

# Checklist

- [X] All acceptance criteria are met.
- [] Relevant documentation, if any, has been written/updated.
- [X] The changelog has been updated, if applicable.
- [X] New functions/types have been exported in `index.ts`, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).