### PR TITLE
Prevent automatic refresh of the session

### DIFF
--- a/packages/node/src/Session.ts
+++ b/packages/node/src/Session.ts
@@ -197,6 +197,7 @@ export class Session implements IHasSessionEventListener {
     const session = new Session({
       sessionInfo,
       clientAuthentication: clientAuth,
+      keepAlive: false,
     });
 
     if (


### PR DESCRIPTION
In the case of a session built from `Session.fromTokens` being used inside of `refreshTokens`, the default behavior of the session automatically rotating the refresh tokens was not disabled.