### PR TITLE
Multisession RP-initiated logout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,12 @@ const session = await getSessionFromStorage(sessionId, {
 
 The following changes have been implemented but not released yet:
 
+### Feature
+
+#### node
+
+- Added a `logout` function in the token management API that enables RP-initiated logout for multi-user server-side applications. This complements the `refreshTokens` function introduced in 2.4.0, allowing applications that manage tokens in external storage to both refresh tokens and perform identity provider logout without requiring a Session object. Applications can now implement complete user authentication lifecycle management using token sets stored in their own database.
+
 ## [2.4.1](https://github.com/inrupt/solid-client-authn-js/releases/tag/v2.4.1) - 2025-04-18
 
 ### Bugfix

--- a/e2e/node/server/e2e-app-test.spec.ts
+++ b/e2e/node/server/e2e-app-test.spec.ts
@@ -32,6 +32,7 @@ import {
   jest,
 } from "@jest/globals";
 import { firefox } from "@playwright/test";
+import type { Browser, Page } from "@playwright/test";
 import { custom } from "openid-client";
 import type { Server } from "http";
 import type { SessionTokenSet } from "node";
@@ -57,9 +58,17 @@ if (process.env.CI === "true") {
 const ENV = getNodeTestingEnvironment();
 const BROWSER_ENV = getBrowserTestingEnvironment();
 
-// Testing the OIDC Authorization Code flow in an express-based web application.
+type LoginFixture = {
+  browser: Browser;
+  page: Page;
+  loginUrl: string;
+  cognitoPageUrl: string;
+};
 
-async function performTest(seedInfo: ISeedPodResponse) {
+/**
+ * Helper function to log in a user and return the browser, page, and login URLs
+ */
+async function loginUser(seedInfo: ISeedPodResponse): Promise<LoginFixture> {
   const browser = await firefox.launch();
   const page = await browser.newPage();
   const url = new URL(
@@ -90,151 +99,194 @@ async function performTest(seedInfo: ISeedPodResponse) {
     `http://localhost:${CONSTANTS.CLIENT_AUTHN_TEST_PORT}/`,
   );
 
-  // Fetching a protected resource once logged in
-  const resourceUrl = new URL(
-    `http://localhost:${CONSTANTS.CLIENT_AUTHN_TEST_PORT}/fetch`,
-  );
-  resourceUrl.searchParams.append("resource", seedInfo.clientResourceUrl);
-  await page.goto(resourceUrl.toString());
-  await expect(page.content()).resolves.toBe(
-    `<html><head></head><body>${seedInfo.clientResourceContent}</body></html>`,
-  );
-
-  // Fetching a protected resource once logged in, rebuilding the session from saved tokens
-  const resourceUrl2 = new URL(
-    `http://localhost:${CONSTANTS.CLIENT_AUTHN_TEST_PORT}/fetchSessionFromTokens`,
-  );
-  resourceUrl2.searchParams.append("resource", seedInfo.clientResourceUrl);
-  await page.goto(resourceUrl.toString());
-  await expect(page.content()).resolves.toBe(
-    `<html><head></head><body>${seedInfo.clientResourceContent}</body></html>`,
-  );
-
-  // Fetching the token set returned after login
-  const tokensUrl = new URL(
-    `http://localhost:${CONSTANTS.CLIENT_AUTHN_TEST_PORT}/tokens`,
-  );
-
-  // Use page.evaluate to fetch JSON response
-  await page.goto(tokensUrl.toString());
-  const tokenSet: SessionTokenSet = await page.evaluate(() => {
-    try {
-      return JSON.parse(document.body.textContent || "{}");
-    } catch (e) {
-      return null;
-    }
-  });
-
-  expect(tokenSet).toBeDefined();
-  expect(tokenSet.accessToken).toBeDefined();
-  expect(tokenSet.idToken).toBeDefined();
-  expect(tokenSet.expiresAt).toBeDefined();
-  expect(tokenSet.dpopKey).toBeDefined();
-  expect(tokenSet.webId).toBeDefined();
-
-  // FIXME: Uncomment when the issue with external token management
-  // and IDP logout is resolved.
-  // const refreshUrl = new URL(
-  //   `http://localhost:${CONSTANTS.CLIENT_AUTHN_TEST_PORT}/refresh`,
-  // );
-
-  // Use page.evaluate to fetch JSON response
-  // await page.goto(refreshUrl.toString());
-  // const refreshedTokens: SessionTokenSet = await page.evaluate(() => {
-  //   try {
-  //     return JSON.parse(document.body.textContent || "{}");
-  //   } catch (e) {
-  //     return null;
-  //   }
-  // });
-
-  // expect(refreshedTokens).toBeDefined();
-  // // The ID Token should have been refreshed.
-  // expect(refreshedTokens.idToken).not.toBe(tokenSet.idToken);
-  // // The Refresh Token should have been rotated.
-  // expect(refreshedTokens.refreshToken).not.toBe(tokenSet.refreshToken);
-  // // The DPoP key should be unchanged.
-  // expect(refreshedTokens.dpopKey?.publicKey).toStrictEqual(
-  //   tokenSet.dpopKey?.publicKey,
-  // );
-
-  // Performing idp logout and being redirected to the postLogoutUrl after doing so
-  await page.goto(
-    `http://localhost:${CONSTANTS.CLIENT_AUTHN_TEST_PORT}/idplogout`,
-  );
-  await page.waitForURL(
-    `http://localhost:${CONSTANTS.CLIENT_AUTHN_TEST_PORT}/postLogoutUrl`,
-  );
-  await expect(page.content()).resolves.toBe(
-    `<html><head></head><body>successfully at post logout</body></html>`,
-  );
-
-  // Should not be able to retrieve the protected resource after logout
-  await page.goto(resourceUrl.toString());
-  await expect(page.content()).resolves.toMatch("Unauthorized");
-
-  // Testing what happens if we try to log back in again after logging out
-  await page.goto(url.toString());
-
-  // It should go back to the cognito page when we try to log back in
-  // rather than skipping straight to the consent page
-  await page.waitForURL((navigationUrl) => {
-    const u1 = new URL(navigationUrl);
-    u1.searchParams.delete("state");
-
-    const u2 = new URL(cognitoPageUrl);
-    u2.searchParams.delete("state");
-
-    return u1.toString() === u2.toString();
-  });
-
-  await browser.close();
+  return { browser, page, loginUrl: url.toString(), cognitoPageUrl };
 }
 
-describe("Testing against express app with default session", () => {
-  let app: Server;
-  let seedInfo: ISeedPodResponse;
+// Testing the OIDC Authorization Code flow in an express-based web application.
+describe.each([[true], [false]])(
+  "Testing against express app with keepAlive %s",
+  (keepAlive) => {
+    let app: Server;
+    let seedInfo: ISeedPodResponse;
+    let testFixture: LoginFixture;
 
-  beforeEach(async () => {
-    // Enable refresh in clientId document
-    seedInfo = await seedPod(ENV, true);
-    await new Promise<void>((res) => {
-      app = createApp(res, { keepAlive: true });
+    beforeEach(async () => {
+      // Enable refresh in clientId document
+      seedInfo = await seedPod(ENV, true);
+      await new Promise<void>((res) => {
+        app = createApp(res, { keepAlive });
+      });
+      testFixture = await loginUser(seedInfo);
+    }, 30_000);
+
+    afterEach(async () => {
+      await tearDownPod(seedInfo);
+      await new Promise<void>((res) => {
+        app.close(() => res());
+      });
+    }, 30_000);
+
+    describe("using the legacy in-memory storage", () => {
+      it("should be able to log in and perform an authenticated fetch", async () => {
+        const { page, browser } = testFixture;
+        try {
+          // Fetching a protected resource once logged in
+          const resourceUrl = new URL(
+            `http://localhost:${CONSTANTS.CLIENT_AUTHN_TEST_PORT}/fetch`,
+          );
+          resourceUrl.searchParams.append(
+            "resource",
+            seedInfo.clientResourceUrl,
+          );
+          await page.goto(resourceUrl.toString());
+          await expect(page.content()).resolves.toBe(
+            `<html><head></head><body>${seedInfo.clientResourceContent}</body></html>`,
+          );
+        } finally {
+          await browser.close();
+        }
+      }, 120_000);
+
+      it("should be able to perform RP-initiated logout", async () => {
+        const { page, browser, loginUrl, cognitoPageUrl } = testFixture;
+        try {
+          // Performing idp logout and being redirected to the postLogoutUrl after doing so
+          await testFixture.page.goto(
+            `http://localhost:${CONSTANTS.CLIENT_AUTHN_TEST_PORT}/idplogout`,
+          );
+          await page.waitForURL(
+            `http://localhost:${CONSTANTS.CLIENT_AUTHN_TEST_PORT}/postLogoutUrl`,
+          );
+          await expect(page.content()).resolves.toBe(
+            `<html><head></head><body>successfully at post logout</body></html>`,
+          );
+
+          // Should not be able to retrieve the protected resource after logout
+          // Fetching a protected resource once logged in
+          const resourceUrl = new URL(
+            `http://localhost:${CONSTANTS.CLIENT_AUTHN_TEST_PORT}/fetch`,
+          );
+          resourceUrl.searchParams.append(
+            "resource",
+            seedInfo.clientResourceUrl,
+          );
+          await page.goto(resourceUrl.toString());
+          await expect(page.content()).resolves.toMatch("Unauthorized");
+
+          // Testing what happens if we try to log back in again after logging out
+          await page.goto(loginUrl);
+
+          // It should go back to the cognito page when we try to log back in
+          // rather than skipping straight to the consent page
+          await page.waitForURL((navigationUrl) => {
+            const u1 = new URL(navigationUrl);
+            u1.searchParams.delete("state");
+
+            const u2 = new URL(cognitoPageUrl);
+            u2.searchParams.delete("state");
+
+            return u1.toString() === u2.toString();
+          });
+        } finally {
+          await browser.close();
+        }
+      }, 120_000);
     });
-  }, 30_000);
 
-  afterEach(async () => {
-    await tearDownPod(seedInfo);
-    await new Promise<void>((res) => {
-      app.close(() => res());
+    describe("storing token in an external storage", () => {
+      it("should be able to log in and perform an authenticated fetch", async () => {
+        const { page, browser } = testFixture;
+        try {
+          // Fetching a protected resource once logged in, rebuilding the session from saved tokens
+          const resourceUrl = new URL(
+            `http://localhost:${CONSTANTS.CLIENT_AUTHN_TEST_PORT}/fetchSessionFromTokens`,
+          );
+          resourceUrl.searchParams.append(
+            "resource",
+            seedInfo.clientResourceUrl,
+          );
+          await page.goto(resourceUrl.toString());
+          await expect(page.content()).resolves.toBe(
+            `<html><head></head><body>${seedInfo.clientResourceContent}</body></html>`,
+          );
+        } finally {
+          await browser.close();
+        }
+      }, 120_000);
+
+      it("Should be able to manage the tokens explicitly", async () => {
+        const { page, browser } = testFixture;
+        try {
+          // Fetching the token set returned after login
+          const tokensUrl = new URL(
+            `http://localhost:${CONSTANTS.CLIENT_AUTHN_TEST_PORT}/tokens`,
+          );
+
+          // Use page.evaluate to fetch JSON response
+          await page.goto(tokensUrl.toString());
+          const tokenSet: SessionTokenSet = await page.evaluate(() => {
+            try {
+              return JSON.parse(document.body.textContent || "{}");
+            } catch (e) {
+              return null;
+            }
+          });
+
+          expect(tokenSet).toBeDefined();
+          expect(tokenSet.accessToken).toBeDefined();
+          expect(tokenSet.idToken).toBeDefined();
+          expect(tokenSet.expiresAt).toBeDefined();
+          expect(tokenSet.dpopKey).toBeDefined();
+          expect(tokenSet.webId).toBeDefined();
+        } finally {
+          await browser.close();
+        }
+      }, 120_000);
+
+      it("should be able to perform RP-initiated logout", async () => {
+        const { page, browser, loginUrl, cognitoPageUrl } = testFixture;
+        try {
+          // Performing idp logout and being redirected to the postLogoutUrl after doing so
+          await testFixture.page.goto(
+            `http://localhost:${CONSTANTS.CLIENT_AUTHN_TEST_PORT}/tokenlogout`,
+          );
+          await page.waitForURL(
+            `http://localhost:${CONSTANTS.CLIENT_AUTHN_TEST_PORT}/postLogoutUrl`,
+          );
+          await expect(page.content()).resolves.toBe(
+            `<html><head></head><body>successfully at post logout</body></html>`,
+          );
+
+          // Should not be able to retrieve the protected resource after logout
+          // Fetching a protected resource once logged in
+          const resourceUrl = new URL(
+            `http://localhost:${CONSTANTS.CLIENT_AUTHN_TEST_PORT}/fetch`,
+          );
+          resourceUrl.searchParams.append(
+            "resource",
+            seedInfo.clientResourceUrl,
+          );
+          await page.goto(resourceUrl.toString());
+          await expect(page.content()).resolves.toMatch("Unauthorized");
+
+          // Testing what happens if we try to log back in again after logging out
+          await page.goto(loginUrl);
+
+          // It should go back to the cognito page when we try to log back in
+          // rather than skipping straight to the consent page
+          await page.waitForURL((navigationUrl) => {
+            const u1 = new URL(navigationUrl);
+            u1.searchParams.delete("state");
+
+            const u2 = new URL(cognitoPageUrl);
+            u2.searchParams.delete("state");
+
+            return u1.toString() === u2.toString();
+          });
+        } finally {
+          await browser.close();
+        }
+      }, 120_000);
     });
-  }, 30_000);
-
-  it("Should be able to properly login and out with idp logout", async () => {
-    await performTest(seedInfo);
-  }, 120_000);
-});
-
-describe("Testing against express app with session keep alive off", () => {
-  let app: Server;
-  let seedInfo: ISeedPodResponse;
-
-  beforeEach(async () => {
-    // Enable refresh in clientId document
-    seedInfo = await seedPod(ENV, true);
-    await new Promise<void>((res) => {
-      app = createApp(res, { keepAlive: false });
-    });
-  }, 30_000);
-
-  afterEach(async () => {
-    await tearDownPod(seedInfo);
-    await new Promise<void>((res) => {
-      app.close(() => res());
-    });
-  }, 30_000);
-
-  it("Should be able to properly login and out with idp logout", async () => {
-    await performTest(seedInfo);
-  }, 120_000);
-});
+  },
+);

--- a/e2e/node/server/e2e-app-test.spec.ts
+++ b/e2e/node/server/e2e-app-test.spec.ts
@@ -132,7 +132,7 @@ describe.each([[true], [false]])(
         try {
           // Fetching a protected resource once logged in
           const resourceUrl = new URL(
-            `http://localhost:${CONSTANTS.CLIENT_AUTHN_TEST_PORT}/fetch`,
+            `http://localhost:${CONSTANTS.CLIENT_AUTHN_TEST_PORT}/legacy/fetch`,
           );
           resourceUrl.searchParams.append(
             "resource",
@@ -152,7 +152,7 @@ describe.each([[true], [false]])(
         try {
           // Performing idp logout and being redirected to the postLogoutUrl after doing so
           await testFixture.page.goto(
-            `http://localhost:${CONSTANTS.CLIENT_AUTHN_TEST_PORT}/idplogout`,
+            `http://localhost:${CONSTANTS.CLIENT_AUTHN_TEST_PORT}/legacy/logout/idp`,
           );
           await page.waitForURL(
             `http://localhost:${CONSTANTS.CLIENT_AUTHN_TEST_PORT}/postLogoutUrl`,
@@ -164,7 +164,7 @@ describe.each([[true], [false]])(
           // Should not be able to retrieve the protected resource after logout
           // Fetching a protected resource once logged in
           const resourceUrl = new URL(
-            `http://localhost:${CONSTANTS.CLIENT_AUTHN_TEST_PORT}/fetch`,
+            `http://localhost:${CONSTANTS.CLIENT_AUTHN_TEST_PORT}/legacy/fetch`,
           );
           resourceUrl.searchParams.append(
             "resource",
@@ -199,7 +199,7 @@ describe.each([[true], [false]])(
         try {
           // Fetching a protected resource once logged in, rebuilding the session from saved tokens
           const resourceUrl = new URL(
-            `http://localhost:${CONSTANTS.CLIENT_AUTHN_TEST_PORT}/fetchSessionFromTokens`,
+            `http://localhost:${CONSTANTS.CLIENT_AUTHN_TEST_PORT}/tokens/fetch`,
           );
           resourceUrl.searchParams.append(
             "resource",
@@ -248,7 +248,7 @@ describe.each([[true], [false]])(
         try {
           // Performing idp logout and being redirected to the postLogoutUrl after doing so
           await testFixture.page.goto(
-            `http://localhost:${CONSTANTS.CLIENT_AUTHN_TEST_PORT}/tokenlogout`,
+            `http://localhost:${CONSTANTS.CLIENT_AUTHN_TEST_PORT}/tokens/logout`,
           );
           await page.waitForURL(
             `http://localhost:${CONSTANTS.CLIENT_AUTHN_TEST_PORT}/postLogoutUrl`,
@@ -260,7 +260,7 @@ describe.each([[true], [false]])(
           // Should not be able to retrieve the protected resource after logout
           // Fetching a protected resource once logged in
           const resourceUrl = new URL(
-            `http://localhost:${CONSTANTS.CLIENT_AUTHN_TEST_PORT}/fetch`,
+            `http://localhost:${CONSTANTS.CLIENT_AUTHN_TEST_PORT}/tokens/fetch`,
           );
           resourceUrl.searchParams.append(
             "resource",

--- a/e2e/node/server/express.ts
+++ b/e2e/node/server/express.ts
@@ -186,7 +186,7 @@ export function createApp(
       res.status(400).send(`Logout processing failed: [${error}]`).end();
     }
   });
-  
+
   app.get("/tokenlogout", async (req, res) => {
     const tokenSet = sessionTokenSets.get(req.session!.sessionId);
     if (!tokenSet) {
@@ -200,7 +200,7 @@ export function createApp(
         (url) => {
           res.redirect(url);
         },
-        `http://localhost:${CONSTANTS.CLIENT_AUTHN_TEST_PORT}/postLogoutUrl`
+        `http://localhost:${CONSTANTS.CLIENT_AUTHN_TEST_PORT}/postLogoutUrl`,
       );
       // Remove tokens after logout
       sessionTokenSets.delete(req.session!.sessionId);

--- a/e2e/node/server/express.ts
+++ b/e2e/node/server/express.ts
@@ -92,7 +92,7 @@ export function createApp(
     res.status(400).send("could not log in").end();
   });
 
-  app.get("/fetch", async (req, res) => {
+  app.get("/legacy/fetch", async (req, res) => {
     const { resource } = req.query;
 
     if (typeof resource !== "string") {
@@ -110,7 +110,7 @@ export function createApp(
       .end();
   });
 
-  app.get("/fetchSessionFromTokens", async (req, res) => {
+  app.get("/tokens/fetch", async (req, res) => {
     const { resource } = req.query;
 
     if (typeof resource !== "string") {
@@ -141,7 +141,7 @@ export function createApp(
     res.json(tokenSet);
   });
 
-  app.get("/refresh", async (req, res) => {
+  app.get("/tokens/refresh", async (req, res) => {
     const previousTokens = sessionTokenSets.get(req.session!.sessionId);
     if (previousTokens === undefined) {
       res.status(401).send("No session found");
@@ -152,7 +152,7 @@ export function createApp(
     res.json(refreshedTokens);
   });
 
-  app.get("/logout", async (req, res) => {
+  app.get("/legacy/logout/app", async (req, res) => {
     const session = await getSessionFromStorage(req.session!.sessionId);
     if (!session) return;
 
@@ -169,7 +169,7 @@ export function createApp(
     res.status(200).send("successfully at post logout").end();
   });
 
-  app.get("/idplogout", async (req, res) => {
+  app.get("/legacy/logout/idp", async (req, res) => {
     const session = await getSessionFromStorage(req.session!.sessionId);
     if (!session) return;
 
@@ -187,7 +187,7 @@ export function createApp(
     }
   });
 
-  app.get("/tokenlogout", async (req, res) => {
+  app.get("/tokens/logout", async (req, res) => {
     const tokenSet = sessionTokenSets.get(req.session!.sessionId);
     if (!tokenSet) {
       res.status(401).send("No session tokens found").end();

--- a/e2e/node/server/express.ts
+++ b/e2e/node/server/express.ts
@@ -29,6 +29,7 @@ import {
   getSessionFromStorage,
   EVENTS,
   refreshTokens,
+  logout,
 } from "@inrupt/solid-client-authn-node";
 // Extensions are required for JSON-LD imports.
 // eslint-disable-next-line import/extensions
@@ -183,6 +184,28 @@ export function createApp(
       sessionTokenSets.delete(req.session!.sessionId);
     } catch (error) {
       res.status(400).send(`Logout processing failed: [${error}]`).end();
+    }
+  });
+  
+  app.get("/tokenlogout", async (req, res) => {
+    const tokenSet = sessionTokenSets.get(req.session!.sessionId);
+    if (!tokenSet) {
+      res.status(401).send("No session tokens found").end();
+      return;
+    }
+
+    try {
+      await logout(
+        tokenSet,
+        (url) => {
+          res.redirect(url);
+        },
+        `http://localhost:${CONSTANTS.CLIENT_AUTHN_TEST_PORT}/postLogoutUrl`
+      );
+      // Remove tokens after logout
+      sessionTokenSets.delete(req.session!.sessionId);
+    } catch (error) {
+      res.status(400).send(`Token-based logout failed: [${error}]`).end();
     }
   });
 

--- a/packages/node/src/Session.ts
+++ b/packages/node/src/Session.ts
@@ -88,12 +88,17 @@ export interface ISessionOptions {
 
 /**
  * If no external storage is provided, this storage gets used.
+ * @hidden This is for internal use only.
  */
 export const defaultStorage = new InMemoryStorage();
 
 const storageUtility = new StorageUtilityNode(defaultStorage, defaultStorage);
 
-const issuerConfigFetcher = new IssuerConfigFetcher(storageUtility);
+/**
+ * Default cache for OpenID Providers configurations.
+ * @hidden this is for internal use only.
+ */
+export const issuerConfigFetcher = new IssuerConfigFetcher(storageUtility);
 
 /**
  * A {@link Session} object represents a user's session on an application. The session holds state, as it stores information enabling access to private resources after login for instance.

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -28,7 +28,7 @@ export {
   refreshSession,
 } from "./multiSession";
 
-export { refreshTokens } from "./multisession.fromTokens";
+export { refreshTokens, logout } from "./multisession.fromTokens";
 
 // Re-export of types defined in the core module and produced/consumed by our API
 export {

--- a/packages/node/src/multiSession.fromTokens.spec.ts
+++ b/packages/node/src/multiSession.fromTokens.spec.ts
@@ -267,7 +267,7 @@ describe("logout", () => {
   it("throws an error if the identity provider does not support RP-initiated logout", async () => {
     // Mock the issuerConfigFetcher _without_ an end_session_endpoint, causing a failure.
     const mockFetchConfig = jest.spyOn(issuerConfigFetcher, "fetchConfig");
-    mockFetchConfig.mockResolvedValue(mockIssuer("https://my.idp/logout"));
+    mockFetchConfig.mockResolvedValue(mockIssuer(undefined)); // No end_session_endpoint
 
     // Create a valid ID token
     const idToken = await createMockIdToken("https://my.idp", "client-id");

--- a/packages/node/src/multiSession.fromTokens.spec.ts
+++ b/packages/node/src/multiSession.fromTokens.spec.ts
@@ -30,7 +30,6 @@ jest.mock("jose", () => {
   return {
     ...actualJose,
     createRemoteJWKSet: jest.fn(),
-    // jwtVerify: jest.fn(),
   };
 });
 
@@ -175,20 +174,6 @@ describe("logout", () => {
 
     // Setup the mocked jwtVerify to succeed by default
     const mockJose = jest.requireMock("jose") as jest.Mocked<typeof Jose>;
-    // mockJose.jwtVerify.mockImplementation(async (jwt, _keySource, options) => {
-    //   // Default successful verification
-    //   return {
-    //     payload: {
-    //       iss: options?.issuer,
-    //       sub: "test-user",
-    //       aud: "client-id",
-    //       exp: Math.floor(Date.now() / 1000) + 3600,
-    //       iat: Math.floor(Date.now() / 1000),
-    //     },
-    //     protectedHeader: { alg: "ES256" },
-    //   };
-    // });
-
     // Setup createRemoteJWKSet to return a key lookup function
     mockJose.createRemoteJWKSet.mockReturnValue(async () => mockPublicKey);
   });

--- a/packages/node/src/multiSession.fromTokens.spec.ts
+++ b/packages/node/src/multiSession.fromTokens.spec.ts
@@ -19,10 +19,20 @@
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-import { jest, it, describe, expect } from "@jest/globals";
-import type { SessionTokenSet } from "core";
-import { refreshTokens } from "./multisession.fromTokens";
-import { Session } from "./Session";
+import { jest, it, describe, expect, beforeEach } from "@jest/globals";
+import type { IIssuerConfig, SessionTokenSet } from "core";
+import * as Jose from "jose";
+import { refreshTokens, logout } from "./multisession.fromTokens";
+import { Session, issuerConfigFetcher } from "./Session";
+
+jest.mock("jose", () => {
+  const actualJose = jest.requireActual("jose") as typeof Jose;
+  return {
+    ...actualJose,
+    createRemoteJWKSet: jest.fn(),
+    // jwtVerify: jest.fn(),
+  };
+});
 
 describe("refreshTokens", () => {
   it("returns refreshed tokens when refresh is successful", async () => {
@@ -111,5 +121,201 @@ describe("refreshTokens", () => {
 
     // Restore the original method
     Session.fromTokens = originalFromTokens;
+  });
+});
+
+describe("logout", () => {
+  const mockIssuer = (endSessionEndpoint?: string): IIssuerConfig => {
+    return {
+      issuer: "https://some.issuer",
+      authorizationEndpoint: "https://some.issuer/autorization",
+      tokenEndpoint: "https://some.issuer/token",
+      jwksUri: "https://some.issuer/keys",
+      claimsSupported: ["code", "openid"],
+      subjectTypesSupported: ["public"],
+      registrationEndpoint: "https://some.issuer/registration",
+      grantTypesSupported: ["authorization_code"],
+      scopesSupported: ["openid"],
+      endSessionEndpoint,
+    };
+  };
+
+  // Singleton keys generated for tests
+  let mockPublicKey: Jose.KeyLike;
+  let mockPrivateKey: Jose.KeyLike;
+
+  // Generate a valid ID token
+  const createMockIdToken = async (
+    issuer: string,
+    audience: string,
+    useValidKey = true,
+  ): Promise<string> => {
+    const signingKey = useValidKey
+      ? mockPrivateKey
+      : (await Jose.generateKeyPair("ES256")).privateKey;
+
+    return new Jose.SignJWT({ sub: "test-user" })
+      .setProtectedHeader({ alg: "ES256" })
+      .setIssuedAt()
+      .setIssuer(issuer)
+      .setAudience(audience)
+      .setExpirationTime("2h")
+      .sign(signingKey);
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    // Generate keys for each test
+    if (!mockPublicKey || !mockPrivateKey) {
+      const keyPair = await Jose.generateKeyPair("ES256");
+      mockPublicKey = keyPair.publicKey;
+      mockPrivateKey = keyPair.privateKey;
+    }
+
+    // Setup the mocked jwtVerify to succeed by default
+    const mockJose = jest.requireMock("jose") as jest.Mocked<typeof Jose>;
+    // mockJose.jwtVerify.mockImplementation(async (jwt, _keySource, options) => {
+    //   // Default successful verification
+    //   return {
+    //     payload: {
+    //       iss: options?.issuer,
+    //       sub: "test-user",
+    //       aud: "client-id",
+    //       exp: Math.floor(Date.now() / 1000) + 3600,
+    //       iat: Math.floor(Date.now() / 1000),
+    //     },
+    //     protectedHeader: { alg: "ES256" },
+    //   };
+    // });
+
+    // Setup createRemoteJWKSet to return a key lookup function
+    mockJose.createRemoteJWKSet.mockReturnValue(async () => mockPublicKey);
+  });
+
+  it("throws an error if idToken is not provided", async () => {
+    const tokenSet: SessionTokenSet = {
+      accessToken: "access-token",
+      refreshToken: "refresh-token",
+      clientId: "client-id",
+      issuer: "https://my.idp",
+      // No ID token provided
+    };
+
+    const redirectHandler = jest.fn();
+    await expect(logout(tokenSet, redirectHandler)).rejects.toThrow(
+      "Logging out of the Identity Provider requires a valid ID token.",
+    );
+    expect(redirectHandler).not.toHaveBeenCalled();
+  });
+
+  it("fetches config from the issuer and verifies the token", async () => {
+    // Mock the issuerConfigFetcher with an end_session_endpoint
+    const mockFetchConfig = jest.spyOn(issuerConfigFetcher, "fetchConfig");
+    mockFetchConfig.mockResolvedValue(mockIssuer("https://my.idp/logout"));
+
+    // Create a valid ID token
+    const idToken = await createMockIdToken("https://my.idp", "client-id");
+
+    // Setup token set with ID token
+    const tokenSet: SessionTokenSet = {
+      accessToken: "access-token",
+      refreshToken: "refresh-token",
+      idToken,
+      clientId: "client-id",
+      issuer: "https://my.idp",
+    };
+
+    const redirectHandler = jest.fn<(url: string) => void>();
+
+    await logout(tokenSet, redirectHandler);
+
+    expect(redirectHandler).toHaveBeenCalledTimes(1);
+    const [redirectHandlerCall] = redirectHandler.mock.calls;
+    const logoutUrl = new URL(redirectHandlerCall[0]);
+    expect(logoutUrl.searchParams.get("id_token_hint")).toBe(idToken);
+    expect(logoutUrl.host).toBe("my.idp");
+    expect(logoutUrl.pathname).toBe("/logout");
+  });
+
+  it("throws an error if token verification fails", async () => {
+    // Mock the issuerConfigFetcher with an end_session_endpoint
+    const mockFetchConfig = jest.spyOn(issuerConfigFetcher, "fetchConfig");
+    mockFetchConfig.mockResolvedValue(mockIssuer("https://my.idp/logout"));
+
+    // Create an ID token with wrong key - will cause verification failure
+    const idToken = await createMockIdToken(
+      "https://my.idp",
+      "client-id",
+      false,
+    );
+
+    // Setup token set with invalid ID token
+    const tokenSet: SessionTokenSet = {
+      accessToken: "access-token",
+      refreshToken: "refresh-token",
+      idToken,
+      clientId: "client-id",
+      issuer: "https://my.idp",
+    };
+
+    const redirectHandler = jest.fn();
+    await expect(logout(tokenSet, redirectHandler)).rejects.toThrow();
+    expect(redirectHandler).not.toHaveBeenCalled();
+  });
+
+  it("throws an error if the identity provider does not support RP-initiated logout", async () => {
+    // Mock the issuerConfigFetcher _without_ an end_session_endpoint, causing a failure.
+    const mockFetchConfig = jest.spyOn(issuerConfigFetcher, "fetchConfig");
+    mockFetchConfig.mockResolvedValue(mockIssuer("https://my.idp/logout"));
+
+    // Create a valid ID token
+    const idToken = await createMockIdToken("https://my.idp", "client-id");
+
+    // Setup token set with ID token
+    const tokenSet: SessionTokenSet = {
+      accessToken: "access-token",
+      refreshToken: "refresh-token",
+      idToken,
+      clientId: "client-id",
+      issuer: "https://my.idp",
+    };
+    const redirectHandler = jest.fn();
+    await expect(logout(tokenSet, redirectHandler)).rejects.toThrow(
+      "The Identity Provider does not support RP-initiated logout.",
+    );
+    expect(redirectHandler).not.toHaveBeenCalled();
+  });
+
+  it("constructs correct logout URL with post_logout_redirect_uri if provided", async () => {
+    // Mock the issuerConfigFetcher with an end_session_endpoint
+    const mockFetchConfig = jest.spyOn(issuerConfigFetcher, "fetchConfig");
+    mockFetchConfig.mockResolvedValue(mockIssuer("https://my.idp/logout"));
+
+    // Create a valid ID token
+    const idToken = await createMockIdToken("https://my.idp", "client-id");
+
+    // Setup token set with ID token
+    const tokenSet: SessionTokenSet = {
+      accessToken: "access-token",
+      refreshToken: "refresh-token",
+      idToken,
+      clientId: "client-id",
+      issuer: "https://my.idp",
+    };
+
+    const redirectHandler = jest.fn<(url: string) => void>();
+
+    // Provide post logout URL
+    const postLogoutUrl = "https://my-app.com/logged-out";
+
+    await logout(tokenSet, redirectHandler, postLogoutUrl);
+
+    expect(redirectHandler).toHaveBeenCalledTimes(1);
+    const [redirectHandlerCall] = redirectHandler.mock.calls;
+    const logoutUrl = new URL(redirectHandlerCall[0]);
+    expect(logoutUrl.searchParams.get("post_logout_redirect_uri")).toBe(
+      postLogoutUrl,
+    );
   });
 });

--- a/packages/node/src/multisession.fromTokens.ts
+++ b/packages/node/src/multisession.fromTokens.ts
@@ -60,24 +60,28 @@ export async function refreshTokens(tokenSet: SessionTokenSet) {
 }
 
 /**
- * Performs an RP-initiated logout at the identity provider using the provided token set.
+ * Performs an RP-initiated logout at the OpenID Provider associated to a user session using the provided token set.
+ * After this has completed, the user will be logged out of their OpenID Provider. This terminates their current browsing
+ * session on any active Solid application.
  *
- * @param tokenSet The set of tokens containing the ID token for logout
- * @param redirectHandler Function to handle the logout URL (typically redirecting the user)
- * @param postLogoutUrl An optional URL to redirect to after logout has completed
+ * @param tokenSet The set of tokens associated to the session being logged out. This must contain a valid ID token.
+ * @param redirectHandler Function to redirect the user to the logout URL
+ * @param postLogoutUrl An optional URL to be redirected to by the OpenID Provider after logout has been completed
  * @returns A Promise that resolves once the logout process is initiated
- * @since 2.4.0
+ * @since unreleased
  * @example
  * ```typescript
- * // Logout with redirect
- * await logout(tokenSet, (url) => window.location.href = url);
- *
- * // Logout with redirect and post-logout redirect URL
- * await logout(
- *   tokenSet,
- *   (url) => window.location.href = url,
- *   "https://my-app.com/logged-out"
- * );
+ * // Express.js logout endpoint
+ * app.get("/logout", async (req, res) => {
+ *   const tokenSet = ...;
+ *   await logout(
+ *     tokenSet,
+ *     // Provide an express.js-specific redirect handler
+ *     (url) => {
+ *       res.redirect(url);
+ *     }
+ *   );
+ * });
  * ```
  */
 export async function logout(

--- a/packages/node/src/multisession.fromTokens.ts
+++ b/packages/node/src/multisession.fromTokens.ts
@@ -100,6 +100,7 @@ export async function logout(
   const opConfig = await issuerConfigFetcher.fetchConfig(tokenSet.issuer);
 
   // Verify that the ID token is valid before proceeding
+  // TODO the JWK could be cached for efficiency.
   await jwtVerify(idToken, createRemoteJWKSet(new URL(opConfig.jwksUri)), {
     issuer: tokenSet.issuer,
   });


### PR DESCRIPTION
# New feature description

This adds a `logout` function to the mutlisession module so that server-side applications managing the tokens in an external storage can easily log the user out of their OpenID Provider.

# Checklist

- [X] All acceptance criteria are met.
- [ ] Relevant documentation, if any, has been written/updated.
- [X] The changelog has been updated, if applicable.
- [X] New functions/types have been exported in `index.ts`, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).