### PR TITLE
Fix race condition in browser-based test

### DIFF
--- a/e2e/browser/solid-client-authn-browser/test-app/components/authenticatedFetch/index.tsx
+++ b/e2e/browser/solid-client-authn-browser/test-app/components/authenticatedFetch/index.tsx
@@ -28,7 +28,7 @@ const DataDisplay = ({ data }: { data?: string }) => {
     return <pre data-testid="fetchResponseTextbox">{data}</pre>;
   }
   return undefined;
-}
+};
 
 export default function AuthenticatedFetch({
   onError,

--- a/e2e/browser/solid-client-authn-browser/test-app/components/authenticatedFetch/index.tsx
+++ b/e2e/browser/solid-client-authn-browser/test-app/components/authenticatedFetch/index.tsx
@@ -23,6 +23,13 @@ import { useState } from "react";
 import type { ISessionInfo } from "@inrupt/solid-client-authn-browser";
 import { fetch as authenticatedFetch } from "@inrupt/solid-client-authn-browser";
 
+const DataDisplay = ({ data }: { data?: string }) => {
+  if (data !== undefined) {
+    return <pre data-testid="fetchResponseTextbox">{data}</pre>;
+  }
+  return undefined;
+}
+
 export default function AuthenticatedFetch({
   onError,
   sessionInfo,
@@ -31,10 +38,12 @@ export default function AuthenticatedFetch({
   onError: (err: string) => void;
 }) {
   const [resource, setResource] = useState<string>();
-  const [data, setData] = useState<string>("not fetched");
+  const [data, setData] = useState<string | undefined>("not fetched");
 
   const handleFetch = () => {
     if (resource !== undefined) {
+      // Remove the fetchResponseTextbox test-id from the DOM while fetching.
+      setData(undefined);
       authenticatedFetch(resource)
         .then((response) => response.text())
         .then(setData)
@@ -69,7 +78,7 @@ export default function AuthenticatedFetch({
           Fetch
         </button>
       </div>
-      <pre data-testid="fetchResponseTextbox">{data}</pre>
+      <DataDisplay data={data} />
     </>
   );
 }

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -26,11 +26,11 @@ export {
   getSessionIdFromStorageAll,
   clearSessionFromStorageAll,
   refreshSession,
-  refreshTokens,
 } from "./multiSession";
 
-// Re-export of types defined in the core module and produced/consumed by our API
+export { refreshTokens } from "./multisession.fromTokens";
 
+// Re-export of types defined in the core module and produced/consumed by our API
 export {
   ILoginInputOptions,
   ILogoutOptions,

--- a/packages/node/src/multiSession.fromTokens.spec.ts
+++ b/packages/node/src/multiSession.fromTokens.spec.ts
@@ -1,0 +1,115 @@
+//
+// Copyright Inrupt Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+// Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+import { jest, it, describe, expect } from "@jest/globals";
+import type { SessionTokenSet } from "core";
+import { refreshTokens } from "./multisession.fromTokens";
+import { Session } from "./Session";
+
+describe("refreshTokens", () => {
+  it("returns refreshed tokens when refresh is successful", async () => {
+    const newTokens = {
+      accessToken: "new-access-token",
+      refreshToken: "new-refresh-token",
+      idToken: "new-id-token",
+      clientId: "client-id",
+      issuer: "https://my.idp",
+      webId: "https://my.webid",
+      expiresAt: Date.now() / 1000 + 3600,
+    };
+    // Mock Session.fromTokens static method
+    const mockSession = {
+      info: {
+        isLoggedIn: true,
+        sessionId: "test-session-id",
+        webId: "https://my.webid",
+      },
+      login: jest.fn<Session["login"]>().mockResolvedValue(),
+      events: {
+        on: jest
+          .fn<
+            (
+              event: "newTokens",
+              callback: (tokens: SessionTokenSet) => void,
+            ) => void
+          >()
+          .mockImplementation((_, callback) => {
+            // Simulate token refresh by calling the callback with new tokens
+            callback(newTokens);
+          }),
+      },
+    };
+
+    // Mock the static method
+    const originalFromTokens = Session.fromTokens;
+    Session.fromTokens = jest
+      .fn<typeof Session.fromTokens>()
+      .mockResolvedValue(mockSession as unknown as Session);
+    const tokenSet = {
+      accessToken: "old-access-token",
+      refreshToken: "old-refresh-token",
+      clientId: "client-id",
+      issuer: "https://my.idp",
+    };
+
+    const refreshedTokens = await refreshTokens(tokenSet);
+
+    // Verify we got the refreshed tokens
+    expect(refreshedTokens).toEqual(newTokens);
+    // Restore the original method
+    Session.fromTokens = originalFromTokens;
+  });
+
+  it("throws an error when refresh fails", async () => {
+    // Mock Session.fromTokens static method with a session that fails to log in
+    const mockSession = {
+      info: {
+        isLoggedIn: false, // Session failed to log in
+        sessionId: "test-session-id",
+      },
+      login: jest.fn<Session["login"]>().mockResolvedValue(),
+      events: {
+        on: jest.fn(),
+      },
+    };
+
+    // Mock the static method
+    const originalFromTokens = Session.fromTokens;
+    Session.fromTokens = jest
+      .fn<typeof Session.fromTokens>()
+      .mockResolvedValue(mockSession as unknown as Session);
+
+    const tokenSet = {
+      accessToken: "old-access-token",
+      refreshToken: "old-refresh-token",
+      clientId: "client-id",
+      issuer: "https://my.idp",
+    };
+
+    // The function should reject with an error
+    await expect(refreshTokens(tokenSet)).rejects.toThrow(
+      "Could not refresh the session.",
+    );
+
+    // Restore the original method
+    Session.fromTokens = originalFromTokens;
+  });
+});

--- a/packages/node/src/multiSession.spec.ts
+++ b/packages/node/src/multiSession.spec.ts
@@ -26,7 +26,6 @@ import {
   mockStorage,
   mockStorageUtility,
 } from "@inrupt/solid-client-authn-core";
-import type { SessionTokenSet } from "core";
 import {
   mockClientAuthentication,
   mockCustomClientAuthentication,
@@ -37,11 +36,9 @@ import {
   getSessionFromStorage,
   getSessionIdFromStorageAll,
   refreshSession,
-  refreshTokens,
 } from "./multiSession";
 import { mockSessionInfoManager } from "./sessionInfo/__mocks__/SessionInfoManager";
 import type * as Dependencies from "./dependencies";
-import { Session } from "./Session";
 
 jest.mock("./dependencies");
 
@@ -328,95 +325,5 @@ describe("refreshSession", () => {
       }),
     );
     expect(mySession?.info.expirationDate).toBeGreaterThan(Date.now());
-  });
-});
-
-describe("refreshTokens", () => {
-  it("returns refreshed tokens when refresh is successful", async () => {
-    const newTokens = {
-      accessToken: "new-access-token",
-      refreshToken: "new-refresh-token",
-      idToken: "new-id-token",
-      clientId: "client-id",
-      issuer: "https://my.idp",
-      webId: "https://my.webid",
-      expiresAt: Date.now() / 1000 + 3600,
-    };
-    // Mock Session.fromTokens static method
-    const mockSession = {
-      info: {
-        isLoggedIn: true,
-        sessionId: "test-session-id",
-        webId: "https://my.webid",
-      },
-      login: jest.fn<Session["login"]>().mockResolvedValue(),
-      events: {
-        on: jest
-          .fn<
-            (
-              event: "newTokens",
-              callback: (tokens: SessionTokenSet) => void,
-            ) => void
-          >()
-          .mockImplementation((_, callback) => {
-            // Simulate token refresh by calling the callback with new tokens
-            callback(newTokens);
-          }),
-      },
-    };
-
-    // Mock the static method
-    const originalFromTokens = Session.fromTokens;
-    Session.fromTokens = jest
-      .fn<typeof Session.fromTokens>()
-      .mockResolvedValue(mockSession as unknown as Session);
-    const tokenSet = {
-      accessToken: "old-access-token",
-      refreshToken: "old-refresh-token",
-      clientId: "client-id",
-      issuer: "https://my.idp",
-    };
-
-    const refreshedTokens = await refreshTokens(tokenSet);
-
-    // Verify we got the refreshed tokens
-    expect(refreshedTokens).toEqual(newTokens);
-    // Restore the original method
-    Session.fromTokens = originalFromTokens;
-  });
-
-  it("throws an error when refresh fails", async () => {
-    // Mock Session.fromTokens static method with a session that fails to log in
-    const mockSession = {
-      info: {
-        isLoggedIn: false, // Session failed to log in
-        sessionId: "test-session-id",
-      },
-      login: jest.fn<Session["login"]>().mockResolvedValue(),
-      events: {
-        on: jest.fn(),
-      },
-    };
-
-    // Mock the static method
-    const originalFromTokens = Session.fromTokens;
-    Session.fromTokens = jest
-      .fn<typeof Session.fromTokens>()
-      .mockResolvedValue(mockSession as unknown as Session);
-
-    const tokenSet = {
-      accessToken: "old-access-token",
-      refreshToken: "old-refresh-token",
-      clientId: "client-id",
-      issuer: "https://my.idp",
-    };
-
-    // The function should reject with an error
-    await expect(refreshTokens(tokenSet)).rejects.toThrow(
-      "Could not refresh the session.",
-    );
-
-    // Restore the original method
-    Session.fromTokens = originalFromTokens;
   });
 });

--- a/packages/node/src/multiSession.ts
+++ b/packages/node/src/multiSession.ts
@@ -19,10 +19,7 @@
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-import type {
-  SessionTokenSet,
-  IStorage,
-} from "@inrupt/solid-client-authn-core";
+import type { IStorage } from "@inrupt/solid-client-authn-core";
 import { EVENTS } from "@inrupt/solid-client-authn-core";
 import type ClientAuthentication from "./ClientAuthentication";
 import { getClientAuthenticationWithDependencies } from "./dependencies";
@@ -94,42 +91,6 @@ export async function refreshSession(
       tokenType: sessionInfo.tokenType,
     });
   }
-}
-
-/**
- * Refresh the Access Token and ID Token using the Refresh Token.
- * The tokens may not be expired in order to be refreshed.
- *
- * @param tokenSet the tokens to refresh
- * @returns a new set of tokens
- * @since 2.4.0
- * @example
- * ```
- * const refreshedTokens = await refreshTokens(previousTokenSet);
- * const session = await Session.fromTokens(refreshedTokens, sessionId);
- * ```
- */
-export async function refreshTokens(tokenSet: SessionTokenSet) {
-  const session = await Session.fromTokens(tokenSet);
-  // Replace with Promise.withResolvers when minimal node is 22.
-  let tokenResolve: (tokens: SessionTokenSet) => void;
-  let tokenReject: (reason?: Error) => void = () => {};
-  const tokenPromise = new Promise<SessionTokenSet>((resolve, reject) => {
-    tokenResolve = resolve;
-    tokenReject = reject;
-  });
-  session.events.on("newTokens", (tokens) => {
-    tokenResolve(tokens);
-  });
-  await session.login({
-    oidcIssuer: tokenSet.issuer,
-    clientId: tokenSet.clientId,
-    refreshToken: tokenSet.refreshToken,
-  });
-  if (!session.info.isLoggedIn) {
-    tokenReject(new Error("Could not refresh the session."));
-  }
-  return tokenPromise;
 }
 
 async function internalGetSessionFromStorage(

--- a/packages/node/src/multisession.fromTokens.ts
+++ b/packages/node/src/multisession.fromTokens.ts
@@ -1,0 +1,59 @@
+//
+// Copyright Inrupt Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+// Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+import type { SessionTokenSet } from "@inrupt/solid-client-authn-core";
+import { Session } from "./Session";
+
+/**
+ * Refresh the Access Token and ID Token using the Refresh Token.
+ * The tokens may not be expired in order to be refreshed.
+ *
+ * @param tokenSet the tokens to refresh
+ * @returns a new set of tokens
+ * @since 2.4.0
+ * @example
+ * ```
+ * const refreshedTokens = await refreshTokens(previousTokenSet);
+ * const session = await Session.fromTokens(refreshedTokens, sessionId);
+ * ```
+ */
+export async function refreshTokens(tokenSet: SessionTokenSet) {
+  const session = await Session.fromTokens(tokenSet);
+  // Replace with Promise.withResolvers when minimal node is 22.
+  let tokenResolve: (tokens: SessionTokenSet) => void;
+  let tokenReject: (reason?: Error) => void = () => {};
+  const tokenPromise = new Promise<SessionTokenSet>((resolve, reject) => {
+    tokenResolve = resolve;
+    tokenReject = reject;
+  });
+  session.events.on("newTokens", (tokens) => {
+    tokenResolve(tokens);
+  });
+  await session.login({
+    oidcIssuer: tokenSet.issuer,
+    clientId: tokenSet.clientId,
+    refreshToken: tokenSet.refreshToken,
+  });
+  if (!session.info.isLoggedIn) {
+    tokenReject(new Error("Could not refresh the session."));
+  }
+  return tokenPromise;
+}


### PR DESCRIPTION
In some cases, a stale value was read from the application UI wile it was being re-rendered. This change makes it so that the test-id being rendered is removed from the DOM while the data is being fetched so that the test script waits for the latest value to be displayed.