### PR TITLE
Reintroduce custom fetch to buildAuthenticatedFetch as an option

### DIFF
--- a/packages/core/src/authenticatedFetch/fetchFactory.ts
+++ b/packages/core/src/authenticatedFetch/fetchFactory.ts
@@ -95,8 +95,9 @@ async function makeAuthenticatedRequest(
   url: RequestInfo | URL,
   defaultRequestInit?: RequestInit,
   dpopKey?: KeyPair,
+  unauthFetch = fetch,
 ) {
-  return fetch(
+  return unauthFetch(
     url,
     await buildAuthenticatedHeaders(
       url.toString(),
@@ -147,6 +148,7 @@ const computeRefreshDelay = (expiresIn?: number): number => {
  * @param accessToken an access token, either a Bearer token or a DPoP one.
  * @param options The option object may contain two objects: the DPoP key token
  * is bound to if applicable, and options to customize token renewal behavior.
+ * @param {typeof fetch} [options.fetch=fetch] A custom fetch function (defaults to the global fetch).
  *
  * @returns A fetch function that adds an appropriate Authorization header with
  * the provided token, and adds a DPoP header if applicable.
@@ -158,6 +160,7 @@ export function buildAuthenticatedFetch(
     refreshOptions?: RefreshOptions;
     expiresIn?: number;
     eventEmitter?: EventEmitter;
+    fetch?: typeof fetch; // optional custom fetch
   },
 ): typeof fetch {
   let currentAccessToken = accessToken;
@@ -258,6 +261,7 @@ export function buildAuthenticatedFetch(
       url,
       requestInit,
       options?.dpopKey,
+      options?.fetch,
     );
 
     const failedButNotExpectedAuthError =
@@ -280,6 +284,7 @@ export function buildAuthenticatedFetch(
         response.url,
         requestInit,
         options.dpopKey,
+        options.fetch,
       );
     }
     return response;


### PR DESCRIPTION
# Feature description

This PR addresses #3810.

Add the optional `fetch` parameter back to `buildAuthenticatedFetch` options (second parameter), defaulting to global `fetch`. This is a non-breaking change.

**Usage:**

```js
const authFetch = await buildAuthenticatedFetch(accessToken, {
  fetch: customFetch, // optional
  // ...otherOptions
});
```

## Motivation

Custom `fetch` was removed in v2 of `@inrupt/solid-client-authn-core`. But `buildAuthenticatedFetch` is used externally as well, most notably in [automated CSS authentication](https://communitysolidserver.github.io/CommunitySolidServer/latest/usage/client-credentials/). While not strictly necessary for most use cases, a custom `fetch` option gives more flexibility (polyfills, logging, tweaking functionality, etc.) when building authenticated fetches.

# Checklist

- [ ] All acceptance criteria are met. _not found_  
- [x] Relevant documentation has been written/updated. _JSDoc of the affected method_  
- [ ] The changelog has been updated, if applicable. _the CHANGELOG doesn't seem to track changes to `core`; will add upon request_  
- [ ] New functions/types have been exported in `index.ts`, if applicable. _not applicable_  
- [x] Commits in this PR are minimal and have descriptive commit messages

Fixes #3810 