### PR TITLE
Make export named functions to cleanup API docs

### DIFF
--- a/packages/browser/src/defaultSession.ts
+++ b/packages/browser/src/defaultSession.ts
@@ -19,7 +19,6 @@
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-import { ISessionEventListener } from "@inrupt/solid-client-authn-core";
 import { Session } from "./Session";
 
 let defaultSession: Session | undefined;


### PR DESCRIPTION
They are reported as variables otherwise.