### PR TITLE
fix(core): include the RFC 9449 ath claim in DPoP proofs (closes #3184)

### DIFF
--- a/packages/core/src/authenticatedFetch/dpopUtils.spec.ts
+++ b/packages/core/src/authenticatedFetch/dpopUtils.spec.ts
@@ -20,7 +20,7 @@
 
 import { it, describe, expect } from "@jest/globals";
 import type { CryptoKey } from "jose";
-import { generateKeyPair, exportJWK, jwtVerify } from "jose";
+import { generateKeyPair, exportJWK, jwtVerify, base64url } from "jose";
 import { createDpopHeader, generateDpopKeyPair } from "./dpopUtils";
 
 let publicKey: CryptoKey | undefined;
@@ -92,6 +92,37 @@ describe("createDpopHeader", () => {
     expect(protectedHeader.alg).toBe("ES256");
     expect(protectedHeader.typ).toBe("dpop+jwt");
     expect(protectedHeader.jwk).toEqual((await mockKeyPair()).publicKey);
+  });
+
+  it("omits the 'ath' claim when no access token is provided (backwards compatible)", async () => {
+    const header = await createDpopHeader(
+      "https://some.resource",
+      "GET",
+      await mockKeyPair(),
+    );
+    const { payload } = await jwtVerify(header, (await mockJwk()).publicKey);
+    expect(payload.ath).toBeUndefined();
+  });
+
+  it("binds the proof to the access token via the RFC 9449 'ath' claim when provided", async () => {
+    const accessToken = "some.access.token";
+    const header = await createDpopHeader(
+      "https://some.resource",
+      "GET",
+      await mockKeyPair(),
+      accessToken,
+    );
+    const { payload } = await jwtVerify(header, (await mockJwk()).publicKey);
+    // RFC 9449 §4.2: ath = base64url(SHA-256(ASCII(access token))).
+    const expectedAth = base64url.encode(
+      new Uint8Array(
+        await crypto.subtle.digest(
+          "SHA-256",
+          new TextEncoder().encode(accessToken),
+        ),
+      ),
+    );
+    expect(payload.ath).toBe(expectedAth);
   });
 });
 

--- a/packages/core/src/authenticatedFetch/dpopUtils.ts
+++ b/packages/core/src/authenticatedFetch/dpopUtils.ts
@@ -19,7 +19,7 @@
 //
 
 import type { JWK, CryptoKey } from "jose";
-import { SignJWT, generateKeyPair, exportJWK } from "jose";
+import { SignJWT, generateKeyPair, exportJWK, base64url } from "jose";
 import { v4 } from "uuid";
 import { PREFERRED_SIGNING_ALG } from "../constant";
 
@@ -41,23 +41,47 @@ export type KeyPair = {
 };
 
 /**
- * Creates a DPoP header according to https://tools.ietf.org/html/draft-fett-oauth-dpop-04,
+ * Computes the RFC 9449 `ath` claim: the base64url-encoded SHA-256 hash of the
+ * ASCII encoding of the access token's value (RFC 9449 §4.2). Uses the WHATWG
+ * Web Crypto API (`crypto.subtle`) — the same cross-platform primitive `jose`
+ * relies on, available in browsers and the Node versions `jose` v6 supports.
+ *
+ * @hidden
+ */
+async function accessTokenHash(accessToken: string): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(accessToken),
+  );
+  return base64url.encode(new Uint8Array(digest));
+}
+
+/**
+ * Creates a DPoP header according to {@link https://www.rfc-editor.org/rfc/rfc9449 RFC 9449},
  * based on the target URL and method, using the provided key.
  *
  * @param audience Target URL.
  * @param method HTTP method allowed.
  * @param dpopKey Key used to sign the token.
+ * @param accessToken When provided, the proof is bound to this access token via the
+ * RFC 9449 `ath` claim. This is REQUIRED (RFC 9449 §7) whenever the DPoP proof
+ * accompanies an access token to a protected resource — without it, a correctly
+ * enforcing resource server rejects the request with 401.
  * @returns A JWT that can be used as a DPoP Authorization header.
  */
 export async function createDpopHeader(
   audience: string,
   method: string,
   dpopKey: KeyPair,
+  accessToken?: string,
 ): Promise<string> {
   return new SignJWT({
     htu: normalizeHTU(audience),
     htm: method.toUpperCase(),
     jti: v4(),
+    ...(accessToken !== undefined
+      ? { ath: await accessTokenHash(accessToken) }
+      : {}),
   })
     .setProtectedHeader({
       alg: PREFERRED_SIGNING_ALG[0],

--- a/packages/core/src/authenticatedFetch/fetchFactory.ts
+++ b/packages/core/src/authenticatedFetch/fetchFactory.ts
@@ -60,9 +60,17 @@ async function buildDpopFetchOptions(
   const headers = new Headers(defaultOptions?.headers);
   // Any pre-existing Authorization header should be overriden.
   headers.set("Authorization", `DPoP ${authToken}`);
+  // Bind the proof to this access token via the RFC 9449 `ath` claim (§7): a proof
+  // accompanying an access token to a protected resource MUST carry `ath`, or a
+  // correctly enforcing resource server rejects it with 401.
   headers.set(
     "DPoP",
-    await createDpopHeader(targetUrl, defaultOptions?.method ?? "get", dpopKey),
+    await createDpopHeader(
+      targetUrl,
+      defaultOptions?.method ?? "get",
+      dpopKey,
+      authToken,
+    ),
   );
   return {
     ...defaultOptions,


### PR DESCRIPTION
## Problem

`createDpopHeader` (`packages/core/src/authenticatedFetch/dpopUtils.ts`) builds DPoP proofs with only `htu`/`htm`/`jti`/`iat` and never emits `ath` — it still cites the pre-standard `draft-fett-oauth-dpop-04`. RFC 9449 §7 requires that a DPoP proof accompanying an access token to a protected resource MUST carry an `ath` claim (§4.2: `base64url(SHA-256(access_token))`). Resource servers that enforce this reject ath-less proofs with **401**, so apps built on `@inrupt/solid-client-authn-browser` (e.g. Penny, sleepy.bike) authenticate but then cannot read or write pod resources. (A known artefact of the pre-RFC DPoP era across the Solid ecosystem.) Fixes #3184.

## Change

- `createDpopHeader` gains an optional `accessToken`; when present it adds `ath = base64url(SHA-256(token))` to the proof payload. Omitting it preserves the previous payload, so the public signature stays **backward-compatible** — the token-endpoint call sites (`oidc-browser`) correctly continue to omit `ath`.
- `buildDpopFetchOptions` passes the `authToken` it already holds, so resource requests now carry `ath`.
- Uses `jose`'s `base64url` + the Web Crypto `crypto.subtle` API that `jose` v6 itself runs on; no new dependency and no platform-specific code path.

## Tests

- `ath` present and equal to `base64url(SHA-256(token))` for a known token.
- Backwards-compatible: omitting `accessToken` yields no `ath`.

## Notes for maintainers

- Keeping `accessToken` optional preserves the public `createDpopHeader` signature; if you'd prefer it required for resource requests, that's your call (possibly a major version).
- The `ath` digest uses `crypto.subtle` — the same Web Crypto primitive `jose` v6 itself runs on, available in browsers and every Node version `jose` v6 supports (the package engine is Node 22+). This matches how `core` already does crypto via `jose`, so no platform split is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)