### PR TITLE
Upgrade TypeScript to v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         # We test against different OSes, because the build toolchain has OS-specific dependencies.
-        os: ["ubuntu-latest", "windows-latest", "macos-latest"]
+        os: ["ubuntu-latest", "windows-latest"]
         node-version: ["22.x", "24.x"]
     steps:
       - uses: actions/checkout@v7

--- a/e2e/browser/solid-client-authn-browser/test-app/next-env.d.ts
+++ b/e2e/browser/solid-client-authn-browser/test-app/next-env.d.ts
@@ -1,6 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
 import "./.next/types/routes.d.ts";
+import "./.next/types/root-params.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -29,7 +29,6 @@ import { join } from "node:path";
 
 // Jest 30 loads .ts config files as ESM via Node's native TypeScript support,
 // so `require` is not available. Use createRequire for require.resolve calls.
-// @ts-expect-error: import.meta.url is valid at runtime (ESM), but tsconfig targets CJS.
 const esmRequire = createRequire(import.meta.url);
 
 type ArrayElement<MyArray> = MyArray extends Array<infer T> ? T : never;

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "ts-node": "^10.9.2",
         "typedoc": "^0.28.20",
         "typedoc-plugin-markdown": "^3.17.1",
-        "typescript": "^5.9.3"
+        "typescript": "^6.0.3"
       },
       "engines": {
         "node": "^22.0.0 || ^24.0.0"
@@ -21058,7 +21058,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "ts-node": "^10.9.2",
     "typedoc": "^0.28.20",
     "typedoc-plugin-markdown": "^3.17.1",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   },
   "optionalDependencies": {
     "@nx/nx-win32-x64-msvc": "^23.1.0",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -13,9 +13,9 @@
   },
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "require": "./dist/index.js",
-      "import": "./dist/index.mjs",
-      "types": "./dist/index.d.ts"
+      "import": "./dist/index.mjs"
     }
   },
   "scripts": {

--- a/packages/browser/src/ClientAuthentication.ts
+++ b/packages/browser/src/ClientAuthentication.ts
@@ -35,7 +35,7 @@ import {
   removeOpenIdParams,
 } from "@inrupt/solid-client-authn-core";
 import { normalizeCallbackUrl } from "@inrupt/oidc-client-ext";
-import type { EventEmitter } from "events";
+import type { EventEmitter } from "node:events";
 
 /**
  * Checks if a client's registration has expired.

--- a/packages/browser/src/login/oidc/IssuerConfigFetcher.spec.ts
+++ b/packages/browser/src/login/oidc/IssuerConfigFetcher.spec.ts
@@ -18,7 +18,14 @@
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-import { jest, it, describe, expect } from "@jest/globals";
+import {
+  jest,
+  it,
+  describe,
+  expect,
+  beforeEach,
+  afterEach,
+} from "@jest/globals";
 import { mockStorageUtility } from "@inrupt/solid-client-authn-core";
 import IssuerConfigFetcher from "./IssuerConfigFetcher";
 

--- a/packages/browser/src/login/oidc/incomingRedirectHandler/AuthCodeRedirectHandler.ts
+++ b/packages/browser/src/login/oidc/incomingRedirectHandler/AuthCodeRedirectHandler.ts
@@ -40,7 +40,7 @@ import {
   saveSessionInfoToStorage,
 } from "@inrupt/solid-client-authn-core";
 import { getTokens } from "@inrupt/oidc-client-ext";
-import type { EventEmitter } from "events";
+import type { EventEmitter } from "node:events";
 
 /**
  * @hidden

--- a/packages/browser/src/login/oidc/incomingRedirectHandler/ErrorOidcHandler.ts
+++ b/packages/browser/src/login/oidc/incomingRedirectHandler/ErrorOidcHandler.ts
@@ -28,7 +28,7 @@ import type {
   ISessionInfo,
 } from "@inrupt/solid-client-authn-core";
 import { EVENTS } from "@inrupt/solid-client-authn-core";
-import type { EventEmitter } from "events";
+import type { EventEmitter } from "node:events";
 
 import { getUnauthenticatedSession } from "../../../sessionInfo/SessionInfoManager";
 

--- a/packages/browser/src/login/oidc/refresh/TokenRefresher.ts
+++ b/packages/browser/src/login/oidc/refresh/TokenRefresher.ts
@@ -37,7 +37,7 @@ import {
   EVENTS,
 } from "@inrupt/solid-client-authn-core";
 import { refresh } from "@inrupt/oidc-client-ext";
-import type { EventEmitter } from "events";
+import type { EventEmitter } from "node:events";
 
 // Some identifiers are not in camelcase on purpose, as they are named using the
 // official names from the OIDC/OAuth2 specifications.

--- a/packages/browser/tsconfig.json
+++ b/packages/browser/tsconfig.json
@@ -5,9 +5,6 @@
     "lib": ["es2022", "dom"],
     "rootDir": "./src",
     "outDir": "./dist",
-    // TypeScript 6 no longer walks up to the monorepo-root node_modules/@types,
-    // so @types/node must be listed explicitly for the build to resolve Node
-    // built-ins (e.g. "node:events", the NodeJS namespace).
     "types": ["node"]
   },
 

--- a/packages/browser/tsconfig.json
+++ b/packages/browser/tsconfig.json
@@ -3,7 +3,12 @@
 
   "compilerOptions": {
     "lib": ["es2022", "dom"],
-    "outDir": "./dist"
+    "rootDir": "./src",
+    "outDir": "./dist",
+    // TypeScript 6 no longer walks up to the monorepo-root node_modules/@types,
+    // so @types/node must be listed explicitly for the build to resolve Node
+    // built-ins (e.g. "node:events", the NodeJS namespace).
+    "types": ["node"]
   },
 
   "include": ["src/**/*"],

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,14 +7,14 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "require": "./dist/index.js",
-      "import": "./dist/index.mjs",
-      "types": "./dist/index.d.ts"
+      "import": "./dist/index.mjs"
     },
     "./mocks": {
+      "types": "./dist/mocks.d.ts",
       "require": "./dist/mocks.js",
-      "import": "./dist/mocks.mjs",
-      "types": "./dist/mocks.d.ts"
+      "import": "./dist/mocks.mjs"
     }
   },
   "typesVersions": {

--- a/packages/core/src/SessionEventListener.ts
+++ b/packages/core/src/SessionEventListener.ts
@@ -18,7 +18,7 @@
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-import type { EventEmitter } from "events";
+import type { EventEmitter } from "node:events";
 import type { EVENTS } from "./constant";
 import type { KeyPair } from "./authenticatedFetch/dpopUtils";
 

--- a/packages/core/src/authenticatedFetch/fetchFactory.ts
+++ b/packages/core/src/authenticatedFetch/fetchFactory.ts
@@ -18,7 +18,7 @@
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-import type { EventEmitter } from "events";
+import type { EventEmitter } from "node:events";
 import { REFRESH_BEFORE_EXPIRATION_SECONDS, EVENTS } from "../constant";
 import type { ITokenRefresher } from "../login/oidc/refresh/ITokenRefresher";
 import type { KeyPair } from "./dpopUtils";

--- a/packages/core/src/login/ILoginOptions.ts
+++ b/packages/core/src/login/ILoginOptions.ts
@@ -23,7 +23,7 @@
  * @packageDocumentation
  */
 
-import type { EventEmitter } from "events";
+import type { EventEmitter } from "node:events";
 import type ILoginInputOptions from "../ILoginInputOptions";
 
 /**

--- a/packages/core/src/login/oidc/IIncomingRedirectHandler.ts
+++ b/packages/core/src/login/oidc/IIncomingRedirectHandler.ts
@@ -23,7 +23,7 @@
  * @packageDocumentation
  */
 
-import type { EventEmitter } from "events";
+import type { EventEmitter } from "node:events";
 import type IHandleable from "../../util/handlerPattern/IHandleable";
 import type { ISessionInfo } from "../../sessionInfo/ISessionInfo";
 import type { IRpLogoutOptions } from "../../logout/ILogoutHandler";

--- a/packages/core/src/login/oidc/IOidcOptions.ts
+++ b/packages/core/src/login/oidc/IOidcOptions.ts
@@ -26,7 +26,7 @@
 /**
  * Defines how OIDC login should proceed
  */
-import type { EventEmitter } from "events";
+import type { EventEmitter } from "node:events";
 import type { IIssuerConfig } from "./IIssuerConfig";
 import type { IClient } from "./IClient";
 import { DEFAULT_SCOPES } from "../../constant";

--- a/packages/core/src/login/oidc/__mocks__/IncomingRedirectHandler.ts
+++ b/packages/core/src/login/oidc/__mocks__/IncomingRedirectHandler.ts
@@ -18,7 +18,7 @@
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-import type { EventEmitter } from "events";
+import type { EventEmitter } from "node:events";
 import { jest } from "@jest/globals";
 
 import type IIncomingRedirectHandler from "../IIncomingRedirectHandler";

--- a/packages/core/src/login/oidc/refresh/ITokenRefresher.ts
+++ b/packages/core/src/login/oidc/refresh/ITokenRefresher.ts
@@ -18,7 +18,7 @@
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-import type { EventEmitter } from "events";
+import type { EventEmitter } from "node:events";
 import type { KeyPair } from "../../../authenticatedFetch/dpopUtils";
 
 /**

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -5,9 +5,6 @@
     "lib": ["es2022", "dom"],
     "rootDir": "./src",
     "outDir": "./dist",
-    // TypeScript 6 no longer walks up to the monorepo-root node_modules/@types,
-    // so @types/node must be listed explicitly for the build to resolve Node
-    // built-ins (e.g. "node:events", the NodeJS namespace).
     "types": ["node"]
   },
 

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -3,7 +3,12 @@
 
   "compilerOptions": {
     "lib": ["es2022", "dom"],
-    "outDir": "./dist"
+    "rootDir": "./src",
+    "outDir": "./dist",
+    // TypeScript 6 no longer walks up to the monorepo-root node_modules/@types,
+    // so @types/node must be listed explicitly for the build to resolve Node
+    // built-ins (e.g. "node:events", the NodeJS namespace).
+    "types": ["node"]
   },
 
   "include": ["src/**/*"],

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -11,9 +11,9 @@
   },
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "require": "./dist/index.js",
-      "import": "./dist/index.mjs",
-      "types": "./dist/index.d.ts"
+      "import": "./dist/index.mjs"
     }
   },
   "scripts": {

--- a/packages/node/src/ClientAuthentication.ts
+++ b/packages/node/src/ClientAuthentication.ts
@@ -34,7 +34,7 @@ import type {
   ISessionInternalInfo,
   AuthorizationRequestState,
 } from "@inrupt/solid-client-authn-core";
-import type { EventEmitter } from "events";
+import type { EventEmitter } from "node:events";
 
 /**
  * @hidden

--- a/packages/node/src/Session.spec.ts
+++ b/packages/node/src/Session.spec.ts
@@ -23,7 +23,7 @@ import type { ISessionInfo } from "@inrupt/solid-client-authn-core";
 import { EVENTS } from "@inrupt/solid-client-authn-core";
 // eslint-disable-next-line import/no-unresolved
 import { mockStorage } from "@inrupt/solid-client-authn-core/mocks";
-import type EventEmitter from "events";
+import type EventEmitter from "node:events";
 import type { SessionTokenSet } from "core";
 import { mockClientAuthentication } from "./__mocks__/ClientAuthentication";
 import type ClientAuthentication from "./ClientAuthentication";

--- a/packages/node/src/Session.ts
+++ b/packages/node/src/Session.ts
@@ -39,7 +39,7 @@ import {
   getWebidFromTokenPayload,
 } from "@inrupt/solid-client-authn-core";
 import { v4 } from "uuid";
-import EventEmitter from "events";
+import EventEmitter from "node:events";
 import { exportJWK } from "jose";
 import type ClientAuthentication from "./ClientAuthentication";
 import { getClientAuthenticationWithDependencies } from "./dependencies";

--- a/packages/node/src/login/oidc/AggregateIncomingRedirectHandler.ts
+++ b/packages/node/src/login/oidc/AggregateIncomingRedirectHandler.ts
@@ -32,7 +32,7 @@ import type {
   SessionConfig,
 } from "@inrupt/solid-client-authn-core";
 import { AggregateHandler } from "@inrupt/solid-client-authn-core";
-import type { EventEmitter } from "events";
+import type { EventEmitter } from "node:events";
 
 /**
  * @hidden

--- a/packages/node/src/login/oidc/incomingRedirectHandler/AuthCodeRedirectHandler.ts
+++ b/packages/node/src/login/oidc/incomingRedirectHandler/AuthCodeRedirectHandler.ts
@@ -49,7 +49,7 @@ import {
 
 import { URL } from "url";
 import { Issuer } from "openid-client";
-import type { EventEmitter } from "events";
+import type { EventEmitter } from "node:events";
 import { configToIssuerMetadata } from "../IssuerConfigFetcher";
 import { asDPoPInput } from "../../../util/dpopInput";
 

--- a/packages/node/src/login/oidc/oidcHandlers/RefreshTokenOidcHandler.ts
+++ b/packages/node/src/login/oidc/oidcHandlers/RefreshTokenOidcHandler.ts
@@ -47,7 +47,7 @@ import {
 } from "@inrupt/solid-client-authn-core";
 import type { JWK, CryptoKey as JoseCryptoKey } from "jose";
 import { importJWK } from "jose";
-import type { EventEmitter } from "events";
+import type { EventEmitter } from "node:events";
 
 function validateOptions(
   oidcLoginOptions: IOidcOptions,

--- a/packages/node/src/login/oidc/refresh/TokenRefresher.ts
+++ b/packages/node/src/login/oidc/refresh/TokenRefresher.ts
@@ -40,7 +40,7 @@ import {
 } from "@inrupt/solid-client-authn-core";
 import type { IssuerMetadata, TokenSet } from "openid-client";
 import { Issuer } from "openid-client";
-import type { EventEmitter } from "events";
+import type { EventEmitter } from "node:events";
 import { configToIssuerMetadata } from "../IssuerConfigFetcher";
 import { negotiateClientSigningAlg } from "../ClientRegistrar";
 import { asDPoPInput } from "../../../util/dpopInput";

--- a/packages/node/tsconfig.json
+++ b/packages/node/tsconfig.json
@@ -3,7 +3,12 @@
 
   "compilerOptions": {
     "lib": ["es2022"],
-    "outDir": "./dist"
+    "rootDir": "./src",
+    "outDir": "./dist",
+    // TypeScript 6 no longer walks up to the monorepo-root node_modules/@types,
+    // so @types/node must be listed explicitly for the build to resolve Node
+    // built-ins (e.g. "node:events", the NodeJS namespace).
+    "types": ["node"]
   },
 
   "include": ["src/**/*"],

--- a/packages/node/tsconfig.json
+++ b/packages/node/tsconfig.json
@@ -5,9 +5,6 @@
     "lib": ["es2022"],
     "rootDir": "./src",
     "outDir": "./dist",
-    // TypeScript 6 no longer walks up to the monorepo-root node_modules/@types,
-    // so @types/node must be listed explicitly for the build to resolve Node
-    // built-ins (e.g. "node:events", the NodeJS namespace).
     "types": ["node"]
   },
 

--- a/packages/oidc-browser/tsconfig.json
+++ b/packages/oidc-browser/tsconfig.json
@@ -3,7 +3,12 @@
 
   "compilerOptions": {
     "lib": ["es2022", "dom"],
-    "outDir": "./dist"
+    "rootDir": "./src",
+    "outDir": "./dist",
+    // TypeScript 6 no longer walks up to the monorepo-root node_modules/@types,
+    // so @types/node must be listed explicitly for the build to resolve Node
+    // built-ins (e.g. "node:events", the NodeJS namespace).
+    "types": ["node"]
   },
 
   "typedocOptions": {
@@ -13,5 +18,5 @@
   },
 
   "include": ["src/**/*"],
-  "exclude": ["*.spec.ts"]
+  "exclude": ["src/**/*.spec.ts", "**/__mocks__/*"]
 }

--- a/packages/oidc-browser/tsconfig.json
+++ b/packages/oidc-browser/tsconfig.json
@@ -5,9 +5,6 @@
     "lib": ["es2022", "dom"],
     "rootDir": "./src",
     "outDir": "./dist",
-    // TypeScript 6 no longer walks up to the monorepo-root node_modules/@types,
-    // so @types/node must be listed explicitly for the build to resolve Node
-    // built-ins (e.g. "node:events", the NodeJS namespace).
     "types": ["node"]
   },
 

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -15,8 +15,7 @@
     "target": "es2022",
     "sourceMap": true,
     "lib": ["es2022", "dom"],
-    // "bundler" resolution replaces the node10 resolution deprecated in
-    // TypeScript 6. It matches how our Rollup build resolves modules and lets
+    // "bundler" resolution matches how the Rollup build resolves modules, and
     // "module": "preserve" leave module syntax untouched for the bundler to
     // handle. See https://aka.ms/ts6.
     "moduleResolution": "bundler",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -16,6 +16,12 @@
     "sourceMap": true,
     "lib": ["es2022", "dom"],
     "moduleResolution": "node",
+    // TypeScript 6 deprecates the "node" (node10) module resolution and errors
+    // unless it is explicitly acknowledged. Switching to "bundler"/"node16"
+    // resolution changes how the internal @inrupt/solid-client-authn-* packages
+    // resolve their type-only exports and breaks the build/tests, so that is
+    // deferred to the TypeScript 7 migration. See https://aka.ms/ts6.
+    "ignoreDeprecations": "6.0",
     "resolveJsonModule": true,
     "outDir": "./dist",
     // This is required to transform native ESM from our dependencies using ts-jest.

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -7,7 +7,7 @@
     "./jest.config.ts"
   ],
   "compilerOptions": {
-    "module": "commonjs",
+    "module": "preserve",
     "strict": true,
     "declaration": true,
     "noImplicitAny": true,
@@ -15,13 +15,11 @@
     "target": "es2022",
     "sourceMap": true,
     "lib": ["es2022", "dom"],
-    "moduleResolution": "node",
-    // TypeScript 6 deprecates the "node" (node10) module resolution and errors
-    // unless it is explicitly acknowledged. Switching to "bundler"/"node16"
-    // resolution changes how the internal @inrupt/solid-client-authn-* packages
-    // resolve their type-only exports and breaks the build/tests, so that is
-    // deferred to the TypeScript 7 migration. See https://aka.ms/ts6.
-    "ignoreDeprecations": "6.0",
+    // "bundler" resolution replaces the node10 resolution deprecated in
+    // TypeScript 6. It matches how our Rollup build resolves modules and lets
+    // "module": "preserve" leave module syntax untouched for the bundler to
+    // handle. See https://aka.ms/ts6.
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "outDir": "./dist",
     // This is required to transform native ESM from our dependencies using ts-jest.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,8 +2,6 @@
   "extends": "./tsconfig.build.json",
 
   "compilerOptions": {
-    // "baseUrl" was deprecated in TypeScript 6; "paths" values are now resolved
-    // relative to this config file's directory instead.
     "paths": {
       "*": ["./packages/*/src"]
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,9 +2,10 @@
   "extends": "./tsconfig.build.json",
 
   "compilerOptions": {
-    "baseUrl": "./packages",
+    // "baseUrl" was deprecated in TypeScript 6; "paths" values are now resolved
+    // relative to this config file's directory instead.
     "paths": {
-      "*": ["*/src"]
+      "*": ["./packages/*/src"]
     }
   }
 }


### PR DESCRIPTION
This bumps the Typescript major version from 5 to 6. TypeScript 6 no longer walks up to the monorepo root node_modules/@types, so @types/node must be listed explicitly for the build to resolve Node built-ins (e.g. "node:events", the NodeJS namespace).

"baseUrl" was deprecated in TypeScript 6; "paths" values are now resolved relative to the root config file's directory instead.